### PR TITLE
feat: add finalize to observer

### DIFF
--- a/mjolnir/core/MolecularDynamicsSimulator.hpp
+++ b/mjolnir/core/MolecularDynamicsSimulator.hpp
@@ -86,6 +86,7 @@ template<typename traitsT, typename integratorT>
 inline void MolecularDynamicsSimulator<traitsT, integratorT>::finalize()
 {
     observer_->output(this->step_count_, this->system_, this->ff_);
+    observer_->finalize(this->total_step_, this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/ObserverBase.hpp
+++ b/mjolnir/core/ObserverBase.hpp
@@ -25,6 +25,8 @@ class ObserverBase
                             const system_type&, const forcefield_type&) = 0;
     virtual void output    (const std::size_t step,
                             const system_type&, const forcefield_type&) = 0;
+    virtual void finalize  (const std::size_t total_step,
+                            const system_type&, const forcefield_type&) = 0;
 
     // for testing purpose.
     virtual std::string const& prefix() const noexcept = 0;

--- a/mjolnir/core/SimulatedAnnealingSimulator.hpp
+++ b/mjolnir/core/SimulatedAnnealingSimulator.hpp
@@ -142,7 +142,8 @@ template<typename traitsT, typename integratorT,
 inline void
 SimulatedAnnealingSimulator<traitsT, integratorT, scheduleT>::finalize()
 {
-    observer_->output(this->step_count_, this->system_, this->ff_);
+    observer_->output  (this->step_count_, this->system_, this->ff_);
+    observer_->finalize(this->step_count_, this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/SteepestDescentSimulator.hpp
+++ b/mjolnir/core/SteepestDescentSimulator.hpp
@@ -104,7 +104,8 @@ inline bool SteepestDescentSimulator<traitsT>::step()
 template<typename traitsT>
 inline void SteepestDescentSimulator<traitsT>::finalize()
 {
-    this->observer_->output(this->step_count_, this->system_, this->ff_);
+    this->observer_->output  (this->step_count_, this->system_, this->ff_);
+    this->observer_->finalize(this->step_limit_, this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -50,6 +50,10 @@ class XYZObserver final : public ObserverBase<traitsT>
     void output(const std::size_t step,
                 const system_type& sys, const forcefield_type& ff) override;
 
+    void finalize(const std::size_t total_step,
+                  const system_type& sys, const forcefield_type& ff) override
+    {/* do nothing. */}
+
     std::string const& prefix() const noexcept override {return prefix_;}
 
   private:


### PR DESCRIPTION
XYZObserver doesn't need this, but another file format might require some operations when the simulation is completed.