### PR TITLE
fix: format matrix/vector correctly in logger

### DIFF
--- a/mjolnir/math/Matrix.hpp
+++ b/mjolnir/math/Matrix.hpp
@@ -145,7 +145,7 @@ operator<<(std::basic_ostream<charT, traitsT>& os, const Matrix<T, R, C>& mat)
     for(std::size_t i=0; i<R; ++i)
     {
         os << '(';
-        for(std::size_t j=0; j<R; ++j)
+        for(std::size_t j=0; j<C; ++j)
         {
             if(j!=0) {os << ',';}
             os << mat(i, j);

--- a/mjolnir/math/Vector.hpp
+++ b/mjolnir/math/Vector.hpp
@@ -13,6 +13,21 @@ namespace math
 template<typename realT, std::size_t N>
 using Vector = Matrix<realT, N, 1>;
 
+template<typename charT, typename traitsT,
+         typename T, std::size_t R>
+std::basic_ostream<charT, traitsT>&
+operator<<(std::basic_ostream<charT, traitsT>& os, const Matrix<T, R, 1>& mat)
+{
+    os << '(';
+    for(std::size_t i=0; i<R; ++i)
+    {
+        if(i!=0) {os << ',';}
+        os << mat(i, 0);
+    }
+    os << ')';
+    return os;
+}
+
 // use mjolnir::math::X() to access elements of vector.
 
 template<typename realT>


### PR DESCRIPTION
Since `operator<<` was broken for a while, the positions/velocities were
formatted weirdly in the log file.