### PR TITLE
feat: make func name in logger long again

### DIFF
--- a/mjolnir/util/logger.hpp
+++ b/mjolnir/util/logger.hpp
@@ -339,6 +339,11 @@ class basic_scope
       : start_(std::chrono::system_clock::now()), logger_(trc),
         name_(name), location_(loc)
     {
+#if !defined(MJOLNIR_DEBUG)
+        // remove template typenames (e.g. [with T = int]) from the name
+        // because it often become too long to read
+        name_.erase(std::find(name_.begin(), name_.end(), '['), name_.end());
+#endif
         logger_.log(logger_type::Level::None, this->name_, " {");
         logger_.log(logger_type::Level::None, "--> ", this->location_, ':');
         logger_.indent();

--- a/mjolnir/util/macro.hpp
+++ b/mjolnir/util/macro.hpp
@@ -6,20 +6,11 @@
 #define MJOLNIR_STRINGIZE(x)     MJOLNIR_STRINGIZE_AUX(x)
 
 // MJOLNIR_FUNC_NAME, expanded into function name.
-//
-// __PRETTY_FUNCTION__ is too informative. since it shows the template argument,
-// the function name become too long.
-
-#if defined(MJOLNIR_DEBUG)
-// debug mode. print more verbose function name.
-#  if defined(__GNUC__)
-#    define MJOLNIR_FUNC_NAME __PRETTY_FUNCTION__
-#  elif defined(_MSC_VER)
-#    define MJOLNIR_FUNC_NAME __FUNCSIG__
-#  else
-#    define MJOLNIR_FUNC_NAME __func__
-#  endif
-#else // release mode. simplify function names.
+#if defined(__GNUC__)
+#  define MJOLNIR_FUNC_NAME __PRETTY_FUNCTION__
+#elif defined(_MSC_VER)
+#  define MJOLNIR_FUNC_NAME __FUNCSIG__
+#else
 #  define MJOLNIR_FUNC_NAME __func__
 #endif
 // #endif


### PR DESCRIPTION
It seems to be good enough to use `__PRETTY_FUNCTION__` and remove the template names from the name. By applying these changes, the logger can obtain namespace, class name, return value type and argument types. It is longer than `__func__`, which only contains function name, but I think here is the optimal point between the length of the name and the information contained.