### PR TITLE
Organize observers

### DIFF
--- a/input/sh3_AICG2+.toml
+++ b/input/sh3_AICG2+.toml
@@ -1,9 +1,9 @@
 # vim:set foldmethod=marker
 [files]
-output.prefix = "sh3_unlim_" # output file prefix
-output.path   = "./"         # output path
-output.format = "xyz"        # output format
-output.progress_bar = true   # write progress bar into console. by default, true
+output.prefix = "sh3_unlim" # output file prefix
+output.path   = "./"        # output path
+output.format = "xyz"       # output format
+output.progress_bar = true  # write progress bar into console. by default, true
 
 [units]
 length = "angstrom" # "angstorm" or "Å" or "nm"

--- a/mjolnir/core/DCDObserver.hpp
+++ b/mjolnir/core/DCDObserver.hpp
@@ -95,12 +95,10 @@ class DCDObserver final : public ObserverBase<traitsT>
       : base_type(), prefix_(filename_prefix),
         pos_name_(filename_prefix + std::string("_position.dcd")),
         vel_name_(filename_prefix + std::string("_velocity.dcd")),
-        ene_name_(filename_prefix + std::string(".ene"))
     {
         // clear files and throw an error if the files cannot be opened.
         this->clear_file(this->pos_name_);
         this->clear_file(this->vel_name_);
-        this->clear_file(this->ene_name_);
     }
     ~DCDObserver() override = default;
 
@@ -114,11 +112,11 @@ class DCDObserver final : public ObserverBase<traitsT>
         this->buffer_x_.resize(sys.size());
         this->buffer_y_.resize(sys.size());
         this->buffer_z_.resize(sys.size());
-
-        std::ofstream ofs(this->ene_name_, std::ios::app);
-        ofs << "# timestep  " << ff.list_energy_name() << " kinetic_energy\n";
         return;
     }
+
+    void output(const std::size_t step,
+                const system_type& sys, const forcefield_type& ff) override;
 
     void finalize(const std::size_t,
                   const system_type&, const forcefield_type&) override
@@ -149,9 +147,6 @@ class DCDObserver final : public ObserverBase<traitsT>
         }
         return;
     }
-
-    void output(const std::size_t step,
-                const system_type& sys, const forcefield_type& ff) override;
 
     std::string const& prefix() const noexcept override {return prefix_;}
 
@@ -246,22 +241,11 @@ class DCDObserver final : public ObserverBase<traitsT>
         return;
     }
 
-    real_type calc_kinetic_energy(const system_type& sys) const
-    {
-        real_type k = 0.0;
-        for(std::size_t i=0; i<sys.size(); ++i)
-        {
-            k += math::length_sq(sys[i].velocity) * sys[i].mass;
-        }
-        return k * 0.5;
-    }
-
   private:
 
     std::string prefix_;
     std::string pos_name_;
     std::string vel_name_;
-    std::string ene_name_;
     std::size_t number_of_frames_;
     std::vector<float> buffer_x_;
     std::vector<float> buffer_y_;
@@ -340,18 +324,6 @@ inline void DCDObserver<traitsT>::output(
                       block_size);
             detail::write_as_bytes(ofs, block_size);
         }
-    }
-
-    // ------------------------------------------------------------------------
-    // write energy
-    {
-        std::ofstream ofs(this->ene_name_, std::ios::app);
-        // if the width exceeds, operator<<(std::ostream, std::string) ignores
-        // ostream::width and outputs whole string.
-        ofs << std::setw(11) << std::left << std::to_string(step) << ' ';
-        ofs << ff.dump_energy(sys) << ' ';
-        ofs << std::setw(14) << std::right << this->calc_kinetic_energy(sys) << '\n';
-        ofs.close();
     }
     return ;
 }

--- a/mjolnir/core/DCDObserver.hpp
+++ b/mjolnir/core/DCDObserver.hpp
@@ -94,7 +94,7 @@ class DCDObserver final : public ObserverBase<traitsT>
     explicit DCDObserver(const std::string& filename_prefix)
       : base_type(), prefix_(filename_prefix),
         pos_name_(filename_prefix + std::string("_position.dcd")),
-        vel_name_(filename_prefix + std::string("_velocity.dcd")),
+        vel_name_(filename_prefix + std::string("_velocity.dcd"))
     {
         // clear files and throw an error if the files cannot be opened.
         this->clear_file(this->pos_name_);

--- a/mjolnir/core/DCDObserver.hpp
+++ b/mjolnir/core/DCDObserver.hpp
@@ -3,7 +3,6 @@
 #include <mjolnir/core/ObserverBase.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/System.hpp>
-#include <mjolnir/util/progress_bar.hpp>
 #include <iostream>
 #include <fstream>
 #include <iomanip>
@@ -89,13 +88,11 @@ class DCDObserver final : public ObserverBase<traitsT>
     using coordinate_type   = typename base_type::coordinate_type;
     using system_type       = typename base_type::system_type;
     using forcefield_type   = typename base_type::forcefield_type;
-    using progress_bar_type = progress_bar<50>;
 
   public:
 
-    DCDObserver(const std::string& filename_prefix, bool output_progress = false)
-      : base_type(), output_progress_(output_progress), progress_bar_(1),
-        prefix_(filename_prefix),
+    DCDObserver(const std::string& filename_prefix)
+      : base_type(), prefix_(filename_prefix),
         pos_name_(filename_prefix + std::string("_position.dcd")),
         vel_name_(filename_prefix + std::string("_velocity.dcd")),
         ene_name_(filename_prefix + std::string(".ene"))
@@ -110,8 +107,6 @@ class DCDObserver final : public ObserverBase<traitsT>
     void initialize(const std::size_t total_step,
                     const system_type& sys, const forcefield_type& ff) override
     {
-        this->progress_bar_.reset(total_step); // set total_step
-
         this->write_header(this->pos_name_, total_step, sys, ff);
         this->write_header(this->vel_name_, total_step, sys, ff);
 
@@ -263,7 +258,6 @@ class DCDObserver final : public ObserverBase<traitsT>
 
   private:
 
-    bool output_progress_;
     std::string prefix_;
     std::string pos_name_;
     std::string vel_name_;
@@ -272,7 +266,6 @@ class DCDObserver final : public ObserverBase<traitsT>
     std::vector<float> buffer_x_;
     std::vector<float> buffer_y_;
     std::vector<float> buffer_z_;
-    progress_bar_type progress_bar_;
 };
 
 template<typename traitsT>
@@ -359,14 +352,6 @@ inline void DCDObserver<traitsT>::output(
         ofs << ff.dump_energy(sys) << ' ';
         ofs << std::setw(14) << std::right << this->calc_kinetic_energy(sys) << '\n';
         ofs.close();
-
-        // XXX consider introducing template argument to remove this if-branching
-        //     at the compile time
-        if(this->output_progress_)
-        {
-            std::cerr << progress_bar_.format(step);
-            if(step == progress_bar_.total()){std::cerr << std::endl;}
-        }
     }
     return ;
 }

--- a/mjolnir/core/DCDObserver.hpp
+++ b/mjolnir/core/DCDObserver.hpp
@@ -91,7 +91,7 @@ class DCDObserver final : public ObserverBase<traitsT>
 
   public:
 
-    DCDObserver(const std::string& filename_prefix)
+    explicit DCDObserver(const std::string& filename_prefix)
       : base_type(), prefix_(filename_prefix),
         pos_name_(filename_prefix + std::string("_position.dcd")),
         vel_name_(filename_prefix + std::string("_velocity.dcd")),

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -21,7 +21,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
 
   public:
 
-    EnergyObserver(const std::string& filename_prefix)
+    explicit EnergyObserver(const std::string& filename_prefix)
       : prefix_(filename_prefix), file_name_(filename_prefix + ".ene")
     {
         // clear files and throw an error if the files cannot be opened.

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -1,0 +1,90 @@
+#ifndef MJOLNIR_CORE_ENERGY_OBSERVER_HPP
+#define MJOLNIR_CORE_ENERGY_OBSERVER_HPP
+#include <mjolnir/core/ObserverBase.hpp>
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+
+namespace mjolnir
+{
+
+template<typename traitsT>
+class EnergyObserver final : public ObserverBase<traitsT>
+{
+  public:
+    using base_type         = ObserverBase<traitsT>;
+    using traits_type       = typename base_type::traits_type;
+    using real_type         = typename base_type::real_type;
+    using coordinate_type   = typename base_type::coordinate_type;
+    using system_type       = typename base_type::system_type;
+    using forcefield_type   = typename base_type::forcefield_type;
+
+  public:
+
+    EnergyObserver(const std::string& filename_prefix)
+      : prefix_(filename_prefix), file_name_(filename_prefix + ".ene")
+    {
+        // clear files and throw an error if the files cannot be opened.
+        this->clear_file(this->file_name_);
+    }
+    ~EnergyObserver() override = default;
+
+    void initialize(const std::size_t total_step,
+                    const system_type&, const forcefield_type& ff) override
+    {
+        std::ofstream ofs(this->file_name_, std::ios::app);
+        ofs << "# timestep  " << ff.list_energy_name() << " kinetic_energy\n";
+        return;
+    }
+
+    void output(const std::size_t step,
+                const system_type& sys, const forcefield_type& ff) override
+    {
+        std::ofstream ofs(this->file_name_, std::ios::app);
+
+        // if the width exceeds, operator<<(std::ostream, std::string) ignores
+        // ostream::width and outputs whole string.
+        ofs << std::setw(11) << std::left << std::to_string(step) << ' ';
+        ofs << ff.dump_energy(sys) << ' ';
+        ofs << std::setw(14) << std::right << this->calc_kinetic_energy(sys) << '\n';
+        return;
+    }
+
+    void finalize(const std::size_t,
+                  const system_type&, const forcefield_type&) override
+    {/* do nothing. */}
+
+    std::string const& prefix() const noexcept override {return this->prefix_;}
+
+  private:
+
+    void clear_file(const std::string& fname) const
+    {
+        std::ofstream ofs(fname);
+        if(not ofs.good())
+        {
+            throw_exception<std::runtime_error>(
+                "[error] mjolnir::EnergyObserver: file open error: ", fname);
+        }
+        return;
+    }
+
+    real_type calc_kinetic_energy(const system_type& sys) const
+    {
+        real_type k = 0.0;
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            k += math::length_sq(sys[i].velocity) * sys[i].mass;
+        }
+        return k * 0.5;
+    }
+
+  private:
+
+    std::string prefix_;
+    std::string file_name_;
+};
+
+
+} // mjolnir
+#endif//MJOLNIR_CORE_ENERGY_OBSERVER_HPP

--- a/mjolnir/core/MolecularDynamicsSimulator.hpp
+++ b/mjolnir/core/MolecularDynamicsSimulator.hpp
@@ -1,7 +1,7 @@
 #ifndef MJOLNIR_MOLECULAR_DYNAMICS_SIMULATOR
 #define MJOLNIR_MOLECULAR_DYNAMICS_SIMULATOR
 #include <mjolnir/core/SimulatorBase.hpp>
-#include <mjolnir/core/ObserverBase.hpp>
+#include <mjolnir/core/ObserverContainer.hpp>
 #include <mjolnir/core/System.hpp>
 #include <mjolnir/core/ForceField.hpp>
 
@@ -12,14 +12,13 @@ template<typename traitsT, typename integratorT>
 class MolecularDynamicsSimulator final : public SimulatorBase
 {
   public:
-    using traits_type        = traitsT;
-    using real_type          = typename traits_type::real_type;
-    using coordinate_type    = typename traits_type::coordinate_type;
-    using integrator_type    = integratorT;
-    using system_type        = System<traits_type>;
-    using forcefield_type    = ForceField<traits_type>;
-    using observer_base_type = ObserverBase<traits_type>;
-    using observer_type      = std::unique_ptr<observer_base_type>;
+    using traits_type     = traitsT;
+    using real_type       = typename traits_type::real_type;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using integrator_type = integratorT;
+    using system_type     = System<traits_type>;
+    using forcefield_type = ForceField<traits_type>;
+    using observer_type   = ObserverContainer<traits_type>;
 
     MolecularDynamicsSimulator(
             const std::size_t tstep, const std::size_t save_step,
@@ -27,7 +26,7 @@ class MolecularDynamicsSimulator final : public SimulatorBase
             integrator_type&& integr, observer_type&& obs)
     : total_step_(tstep), step_count_(0), save_step_(save_step), time_(0.),
       system_(std::move(sys)), ff_(std::move(ff)),
-      integrator_(std::move(integr)), observer_(std::move(obs))
+      integrator_(std::move(integr)), observers_(std::move(obs))
     {}
     ~MolecularDynamicsSimulator() override = default;
 
@@ -47,14 +46,14 @@ class MolecularDynamicsSimulator final : public SimulatorBase
     real_type  time() const noexcept {return time_;}
 
   protected:
-    std::size_t       total_step_;
-    std::size_t       step_count_;
-    std::size_t       save_step_;
-    real_type         time_;
-    system_type       system_;
-    forcefield_type   ff_;
-    integrator_type   integrator_;
-    observer_type     observer_;
+    std::size_t     total_step_;
+    std::size_t     step_count_;
+    std::size_t     save_step_;
+    real_type       time_;
+    system_type     system_;
+    forcefield_type ff_;
+    integrator_type integrator_;
+    observer_type   observers_;
 };
 
 template<typename traitsT, typename integratorT>
@@ -63,7 +62,7 @@ inline void MolecularDynamicsSimulator<traitsT, integratorT>::initialize()
     this->ff_.initialize(this->system_);
     this->integrator_.initialize(this->system_, this->ff_);
 
-    observer_->initialize(this->total_step_, this->system_, this->ff_);
+    observers_.initialize(this->total_step_, this->system_, this->ff_);
     return;
 }
 
@@ -72,7 +71,7 @@ inline bool MolecularDynamicsSimulator<traitsT, integratorT>::step()
 {
     if(step_count_ % save_step_ == 0)
     {
-        observer_->output(this->step_count_, this->system_, this->ff_);
+        observers_.output(this->step_count_, this->system_, this->ff_);
     }
 
     integrator_.step(this->time_, system_, ff_);
@@ -85,8 +84,8 @@ inline bool MolecularDynamicsSimulator<traitsT, integratorT>::step()
 template<typename traitsT, typename integratorT>
 inline void MolecularDynamicsSimulator<traitsT, integratorT>::finalize()
 {
-    observer_->output(this->step_count_, this->system_, this->ff_);
-    observer_->finalize(this->total_step_, this->system_, this->ff_);
+    observers_.output(this->step_count_, this->system_, this->ff_);
+    observers_.finalize(this->total_step_, this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/ObserverContainer.hpp
+++ b/mjolnir/core/ObserverContainer.hpp
@@ -29,7 +29,12 @@ class ObserverContainer
     ObserverContainer(bool output_progress = false)
         : output_progress_(output_progress)
     {}
-    virtual ~ObserverContainer() = default;
+    ~ObserverContainer() = default;
+
+    ObserverContainer(const ObserverContainer&) = default;
+    ObserverContainer(ObserverContainer&&)      = default;
+    ObserverContainer& operator=(const ObserverContainer&) = default;
+    ObserverContainer& operator=(ObserverContainer&&)      = default;
 
     void initialize(const std::size_t total_step,
                     const system_type& sys, const forcefield_type& ff)

--- a/mjolnir/core/ObserverContainer.hpp
+++ b/mjolnir/core/ObserverContainer.hpp
@@ -67,7 +67,7 @@ class ObserverContainer
     {
         for(const auto& obs : this->observers_)
         {
-            obs->initialize(total_step, sys, ff);
+            obs->finalize(total_step, sys, ff);
         }
 
         if(this->output_progress_)

--- a/mjolnir/core/ObserverContainer.hpp
+++ b/mjolnir/core/ObserverContainer.hpp
@@ -26,7 +26,7 @@ class ObserverContainer
 
   public:
 
-    ObserverContainer(bool output_progress = false)
+    explicit ObserverContainer(bool output_progress = false)
         : output_progress_(output_progress)
     {}
     ~ObserverContainer() = default;

--- a/mjolnir/core/ObserverContainer.hpp
+++ b/mjolnir/core/ObserverContainer.hpp
@@ -1,0 +1,96 @@
+#ifndef MJOLNIR_CORE_OBSERVER_CONTAINER_HPP
+#define MJOLNIR_CORE_OBSERVER_CONTAINER_HPP
+#include <mjolnir/util/progress_bar.hpp>
+#include <mjolnir/core/ObserverBase.hpp>
+#include <vector>
+
+// This class manages several different XXXObservers to output
+// positions, energies, topologies, and others.
+//
+// Also, this class outputs progress bar into stdout if the flag is on.
+
+namespace mjolnir
+{
+
+template<typename traitsT>
+class ObserverContainer
+{
+  public:
+    using observer_base_type = ObserverBase<traitsT>;
+    using observer_base_ptr  = std::unique_ptr<observer_base_type>;
+    using real_type          = typename observer_base_type::real_type;
+    using coordinate_type    = typename observer_base_type::coordinate_type;
+    using system_type        = typename observer_base_type::system_type;
+    using forcefield_type    = typename observer_base_type::forcefield_type;
+    using progress_bar_type  = progress_bar</*width of bar = */50>;
+
+  public:
+
+    ObserverContainer(bool output_progress = false)
+        : output_progress_(output_progress)
+    {}
+    virtual ~ObserverContainer() = default;
+
+    void initialize(const std::size_t total_step,
+                    const system_type& sys, const forcefield_type& ff)
+    {
+        for(const auto& obs : observers_)
+        {
+            obs->initialize(total_step, sys, ff);
+        }
+
+        this->progress_bar_.reset(total_step); // set total_step as 100%.
+    }
+    void output(const std::size_t step,
+                const system_type& sys, const forcefield_type& ff)
+    {
+        for(const auto& obs : this->observers_)
+        {
+            obs->output(step, sys, ff);
+        }   
+
+        // this branching might be wiped out by introducing another parameter
+        // to SimulatorTraits, but I don't think the cost of the implementation
+        // is larger than the benefit on the runtime efficiency.
+        if(this->output_progress_)
+        {
+            std::cerr << this->progress_bar_.format(step);
+        }
+    }
+    void finalize(const std::size_t total_step,
+                  const system_type& sys, const forcefield_type& ff)
+    {
+        for(const auto& obs : this->observers_)
+        {
+            obs->initialize(total_step, sys, ff);
+        }
+
+        if(this->output_progress_)
+        {
+            // In order to re-write progress bar in each step, it does not print
+            // end-line after the progress bar. But if finalize is called, we
+            // can `finalize` the progress bar.
+            std::cerr << std::endl;
+        }
+    }
+
+    // assign one another XXXObserver
+    void push_back(observer_base_ptr&& obs)
+    {
+        this->observers_.push_back(std::move(obs));
+    }
+
+    // mainly for testing purpose.
+    std::vector<observer_base_ptr> const& observers() const noexcept
+    {
+        return this->observers_;
+    }
+
+  private:
+    std::vector<observer_base_ptr> observers_;
+    progress_bar_type              progress_bar_;
+    bool                           output_progress_;
+};
+
+} // mjolnir
+#endif// MJOLNIR_CORE_OBSERVER_HPP

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -1,7 +1,6 @@
 #ifndef MJOLNIR_CORE_XYZ_OBSERVER_HPP
 #define MJOLNIR_CORE_XYZ_OBSERVER_HPP
 #include <mjolnir/core/ObserverBase.hpp>
-#include <mjolnir/util/progress_bar.hpp>
 #include <iostream>
 #include <fstream>
 #include <iomanip>
@@ -19,13 +18,11 @@ class XYZObserver final : public ObserverBase<traitsT>
     using coordinate_type   = typename base_type::coordinate_type;
     using system_type       = typename base_type::system_type;
     using forcefield_type   = typename base_type::forcefield_type;
-    using progress_bar_type = progress_bar<50>;
 
   public:
 
-    XYZObserver(const std::string& filename_prefix, bool output_progress = false)
-      : base_type(), output_progress_(output_progress), progress_bar_(1),
-        prefix_(filename_prefix),
+    XYZObserver(const std::string& filename_prefix)
+      : base_type(), prefix_(filename_prefix),
         xyz_name_(filename_prefix + std::string("_position.xyz")),
         vel_name_(filename_prefix + std::string("_velocity.xyz")),
         ene_name_(filename_prefix + std::string(".ene"))
@@ -40,8 +37,6 @@ class XYZObserver final : public ObserverBase<traitsT>
     void initialize(const std::size_t total_step,
                     const system_type& sys, const forcefield_type& ff) override
     {
-        this->progress_bar_.reset(total_step); // set total_step
-
         std::ofstream ofs(this->ene_name_, std::ios::app);
         ofs << "# timestep  " << ff.list_energy_name() << " kinetic_energy\n";
         return;
@@ -81,12 +76,10 @@ class XYZObserver final : public ObserverBase<traitsT>
 
   private:
 
-    bool output_progress_;
     std::string prefix_;
     std::string xyz_name_;
     std::string vel_name_;
     std::string ene_name_;
-    progress_bar_type progress_bar_;
 };
 
 template<typename traitsT>
@@ -120,14 +113,6 @@ inline void XYZObserver<traitsT>::output(
     ofs << ff.dump_energy(sys) << ' ';
     ofs << std::setw(14) << std::right << this->calc_kinetic_energy(sys) << '\n';
     ofs.close();
-
-    // XXX consider introducing template argument to remove this if-branching
-    //     at the compile time
-    if(this->output_progress_)
-    {
-        std::cerr << progress_bar_.format(step);
-        if(step == progress_bar_.total()){std::cerr << std::endl;}
-    }
     return ;
 }
 

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -25,29 +25,59 @@ class XYZObserver final : public ObserverBase<traitsT>
       : base_type(), prefix_(filename_prefix),
         xyz_name_(filename_prefix + std::string("_position.xyz")),
         vel_name_(filename_prefix + std::string("_velocity.xyz")),
-        ene_name_(filename_prefix + std::string(".ene"))
     {
         // clear files and throw an error if the files cannot be opened.
         this->clear_file(this->xyz_name_);
         this->clear_file(this->vel_name_);
-        this->clear_file(this->ene_name_);
     }
     ~XYZObserver() override = default;
 
     void initialize(const std::size_t total_step,
                     const system_type& sys, const forcefield_type& ff) override
     {
-        std::ofstream ofs(this->ene_name_, std::ios::app);
-        ofs << "# timestep  " << ff.list_energy_name() << " kinetic_energy\n";
-        return;
+        // do nothing.
     }
 
     void output(const std::size_t step,
-                const system_type& sys, const forcefield_type& ff) override;
+                const system_type& sys, const forcefield_type& ff) override
+    {
+        // -------------------------------------------------------------------
+        // output positions
+        {
+            std::ofstream ofs(xyz_name_, std::ios::app);
+            ofs << sys.size() << "\nstep = " << step << '\n';
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto& p = sys.position(i);
+                ofs << sys.name(i) << ' ' << std::fixed << std::setprecision(8)
+                    << math::X(p)  << ' ' << math::Y(p) << ' ' << math::Z(p)
+                    << '\n';
+            }
+            ofs.close();
+        }
+
+        // -------------------------------------------------------------------
+        // output velocities
+        {
+            std::ofstream ofs(vel_name_, std::ios::app);
+            ofs << sys.size() << "\nstep = " << step << '\n';
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto& v = sys.velocity(i);
+                ofs << sys.name(i) << ' ' << std::fixed << std::setprecision(8)
+                    << math::X(v)  << ' ' << math::Y(v) << ' ' << math::Z(v)
+                    << '\n';
+            }
+            ofs.close();
+        }
+        return ;
+    }
 
     void finalize(const std::size_t total_step,
                   const system_type& sys, const forcefield_type& ff) override
-    {/* do nothing. */}
+    {
+        // do nothing.
+    }
 
     std::string const& prefix() const noexcept override {return prefix_;}
 
@@ -64,57 +94,12 @@ class XYZObserver final : public ObserverBase<traitsT>
         return;
     }
 
-    real_type calc_kinetic_energy(const system_type& sys) const
-    {
-        real_type k = 0.0;
-        for(std::size_t i=0; i<sys.size(); ++i)
-        {
-            k += math::length_sq(sys[i].velocity) * sys[i].mass;
-        }
-        return k * 0.5;
-    }
-
   private:
 
     std::string prefix_;
     std::string xyz_name_;
     std::string vel_name_;
-    std::string ene_name_;
 };
-
-template<typename traitsT>
-inline void XYZObserver<traitsT>::output(
-    const std::size_t step, const system_type& sys, const forcefield_type& ff)
-{
-    std::ofstream ofs(xyz_name_, std::ios::app);
-    ofs << sys.size() << "\nstep = " << step << '\n';
-    for(std::size_t i=0; i<sys.size(); ++i)
-    {
-        const auto& p = sys.position(i);
-        ofs << sys.name(i) << ' ' << std::fixed << std::setprecision(8)
-            << p[0] << ' ' << p[1] << ' ' << p[2] << '\n';
-    }
-    ofs.close();
-
-    ofs.open(vel_name_, std::ios::app);
-    ofs << sys.size() << "\nstep = " << step << '\n';
-    for(std::size_t i=0; i<sys.size(); ++i)
-    {
-        const auto& v = sys.velocity(i);
-        ofs << sys.name(i) << ' ' << std::fixed << std::setprecision(8)
-            << v[0] << ' ' << v[1] << ' ' << v[2] << '\n';
-    }
-    ofs.close();
-
-    ofs.open(ene_name_, std::ios::app);
-    // if the width exceeds, operator<<(std::ostream, std::string) ignores
-    // ostream::width and outputs whole string.
-    ofs << std::setw(11) << std::left << std::to_string(step) << ' ';
-    ofs << ff.dump_energy(sys) << ' ';
-    ofs << std::setw(14) << std::right << this->calc_kinetic_energy(sys) << '\n';
-    ofs.close();
-    return ;
-}
 
 } // mjolnir
 #endif // MJOLNIR_CORE_XYZ_OBSERVER_HPP

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -21,7 +21,7 @@ class XYZObserver final : public ObserverBase<traitsT>
 
   public:
 
-    XYZObserver(const std::string& filename_prefix)
+    explicit XYZObserver(const std::string& filename_prefix)
       : base_type(), prefix_(filename_prefix),
         xyz_name_(filename_prefix + std::string("_position.xyz")),
         vel_name_(filename_prefix + std::string("_velocity.xyz")),

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -24,7 +24,7 @@ class XYZObserver final : public ObserverBase<traitsT>
     explicit XYZObserver(const std::string& filename_prefix)
       : base_type(), prefix_(filename_prefix),
         xyz_name_(filename_prefix + std::string("_position.xyz")),
-        vel_name_(filename_prefix + std::string("_velocity.xyz")),
+        vel_name_(filename_prefix + std::string("_velocity.xyz"))
     {
         // clear files and throw an error if the files cannot be opened.
         this->clear_file(this->xyz_name_);

--- a/mjolnir/input/read_observer.hpp
+++ b/mjolnir/input/read_observer.hpp
@@ -12,6 +12,46 @@ namespace mjolnir
 {
 
 template<typename traitsT>
+void add_observer(ObserverContainer<traitsT>& observers,
+                  const toml::value& format, const std::string& file_prefix)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    MJOLNIR_LOG_FUNCTION();
+
+    // To show the informative error message, here it uses toml::value that
+    // contains file location. But this function assumes that the `format`
+    // contains `toml::string`.
+    assert(format.is(toml::value_t::String));
+
+    if(format == "xyz")
+    {
+        using observer_type = XYZObserver<traitsT>;
+        MJOLNIR_LOG_NOTICE("output xyz format.");
+        observers.push_back(make_unique<observer_type>(file_prefix));
+        return;
+    }
+    if(format == "dcd")
+    {
+        using observer_type = DCDObserver<traitsT>;
+        MJOLNIR_LOG_NOTICE("output dcd format.");
+        observers.push_back(make_unique<observer_type>(file_prefix));
+        return;
+    }
+    else
+    {
+        throw_exception<std::runtime_error>(toml::format_error("[error] "
+            "mjolnir::read_observer: output format not supported", format,
+            "here", {
+                "expected one of the following.",
+                "- \"xyz\": the simplest ascii format",
+                "- \"dcd\": widely used binary format"
+            }));
+    }
+    return ;
+}
+
+
+template<typename traitsT>
 ObserverContainer<traitsT>
 read_observer(const toml::table& root)
 {
@@ -23,7 +63,6 @@ read_observer(const toml::table& root)
 
     const auto progress_bar_enabled = toml::expect<bool>(output, "progress_bar")
                                                         .unwrap_or(true);
-
     std::string output_path("./");
     if(toml::get<toml::table>(output).count("path") == 1)
     {
@@ -31,40 +70,32 @@ read_observer(const toml::table& root)
         if(output_path.back() != '/') {output_path += '/';}
     }
     const auto output_prefix = toml::find<std::string>(output, "prefix");
-    MJOLNIR_LOG_NOTICE("output files are `", output_path, output_prefix, ".*`");
+    MJOLNIR_LOG_NOTICE("output file prefix is `", output_path, output_prefix, '`');
 
     const std::string file_prefix = output_path + output_prefix;
+
+    // ------------------------------------------------------------------------
 
     ObserverContainer<traitsT> observers(progress_bar_enabled);
 
     // Energy is always written to "prefix.ene".
     observers.push_back(make_unique<EnergyObserver<traitsT>>(file_prefix));
 
-    const auto& format = toml::find<std::string>(output, "format");
-    if(format == "xyz")
+    const auto& format = toml::find(output, "format");
+
+    if(format.is(toml::value_t::String))
     {
-        using observer_type = XYZObserver<traitsT>;
-        MJOLNIR_LOG_NOTICE("output format is xyz.");
-        observers.push_back(make_unique<observer_type>(file_prefix));
-        return observers;
+        add_observer(observers, format, file_prefix);
     }
-    if(format == "dcd")
+    else if(format.is(toml::value_t::Array))
     {
-        using observer_type = DCDObserver<traitsT>;
-        MJOLNIR_LOG_NOTICE("output format is dcd.");
-        observers.push_back(make_unique<observer_type>(file_prefix));
-        return observers;
+        const auto fmts = toml::get<toml::array>(format);
+        for(const auto& fmt : fmts)
+        {
+            add_observer(observers, fmt, file_prefix);
+        }
     }
-    else
-    {
-        throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_observer: output format not supported",
-            toml::find(output, "format"), "here", {
-            "expected one of the following.",
-            "- \"xyz\": the simplest ascii format",
-            "- \"dcd\": widely used DCD format"
-            }));
-    }
+    return observers;
 }
 
 } // mjolnir

--- a/mjolnir/input/read_observer.hpp
+++ b/mjolnir/input/read_observer.hpp
@@ -2,6 +2,7 @@
 #define MJOLNIR_READ_OBSERVER_HPP
 #include <extlib/toml/toml.hpp>
 #include <mjolnir/core/ObserverContainer.hpp>
+#include <mjolnir/core/EnergyObserver.hpp>
 #include <mjolnir/core/XYZObserver.hpp>
 #include <mjolnir/core/DCDObserver.hpp>
 #include <mjolnir/util/logger.hpp>
@@ -35,6 +36,9 @@ read_observer(const toml::table& root)
     const std::string file_prefix = output_path + output_prefix;
 
     ObserverContainer<traitsT> observers(progress_bar_enabled);
+
+    // Energy is always written to "prefix.ene".
+    observers.push_back(make_unique<EnergyObserver<traitsT>>(file_prefix));
 
     const auto& format = toml::find<std::string>(output, "format");
     if(format == "xyz")

--- a/test/mjolnir/test_read_observer.cpp
+++ b/test/mjolnir/test_read_observer.cpp
@@ -18,8 +18,17 @@ BOOST_AUTO_TEST_CASE(read_observer)
         }};
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 1);
-        BOOST_TEST(obs.observers().front()->prefix() == "./test");
+        BOOST_TEST(obs.observers().size() == 2);
+        BOOST_TEST(obs.observers().at(0)->prefix() == "./test");
+        BOOST_TEST(obs.observers().at(1)->prefix() == "./test");
+
+        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
+                             obs.observers().at(0).get());
+        BOOST_TEST(static_cast<bool>(ene));
+
+        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
+                             obs.observers().at(1).get());
+        BOOST_TEST(static_cast<bool>(xyz));
     }
     {
         const toml::table v = toml::table{{"files", toml::table{{"output",
@@ -28,8 +37,17 @@ BOOST_AUTO_TEST_CASE(read_observer)
         }};
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 1);
-        BOOST_TEST(obs.observers().front()->prefix() == "./test");
+        BOOST_TEST(obs.observers().size() == 2);
+        BOOST_TEST(obs.observers().at(0)->prefix() == "./test");
+        BOOST_TEST(obs.observers().at(1)->prefix() == "./test");
+
+        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
+                             obs.observers().at(0).get());
+        BOOST_TEST(static_cast<bool>(ene));
+
+        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
+                             obs.observers().at(1).get());
+        BOOST_TEST(static_cast<bool>(xyz));
     }
 
     // XXX
@@ -45,8 +63,17 @@ BOOST_AUTO_TEST_CASE(read_observer)
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
 
-        BOOST_TEST(obs.observers().size() == 1);
-        BOOST_TEST(obs.observers().front()->prefix() == "./test/test");
+        BOOST_TEST(obs.observers().size() == 2);
+        BOOST_TEST(obs.observers().at(0)->prefix() == "./test/test");
+        BOOST_TEST(obs.observers().at(1)->prefix() == "./test/test");
+
+        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
+                             obs.observers().at(0).get());
+        BOOST_TEST(static_cast<bool>(ene));
+
+        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
+                             obs.observers().at(1).get());
+        BOOST_TEST(static_cast<bool>(xyz));
     }
 }
 
@@ -65,13 +92,15 @@ BOOST_AUTO_TEST_CASE(read_xyz_observer)
 
         const toml::table v{{"files", files}};
 
-        const auto obs_cont = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs_cont.observers().size() == 1);
+        const auto obs = mjolnir::read_observer<traits_type>(v);
+        BOOST_TEST(obs.observers().size() == 2);
 
-        const auto& obs      = obs_cont.observers().front();
-        BOOST_TEST(obs->prefix() == "./test");
+        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
+                             obs.observers().at(0).get());
+        BOOST_TEST(static_cast<bool>(ene));
 
-        const auto xyz = dynamic_cast<observer_type*>(obs.get());
+        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
+                             obs.observers().at(1).get());
         BOOST_TEST(static_cast<bool>(xyz));
     }
 }
@@ -91,13 +120,15 @@ BOOST_AUTO_TEST_CASE(read_dcd_observer)
 
         const toml::table v{{"files", files}};
 
-        const auto obs_cont = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs_cont.observers().size() == 1);
+        const auto obs = mjolnir::read_observer<traits_type>(v);
+        BOOST_TEST(obs.observers().size() == 2);
 
-        const auto& obs = obs_cont.observers().front();
-        BOOST_TEST(obs->prefix() == "./test");
+        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
+                             obs.observers().at(0).get());
+        BOOST_TEST(static_cast<bool>(ene));
 
-        const auto dcd = dynamic_cast<observer_type*>(obs.get());
+        const auto dcd = dynamic_cast<mjolnir::DCDObserver<traits_type>*>(
+                             obs.observers().at(1).get());
         BOOST_TEST(static_cast<bool>(dcd));
     }
 }

--- a/test/mjolnir/test_read_observer.cpp
+++ b/test/mjolnir/test_read_observer.cpp
@@ -18,7 +18,8 @@ BOOST_AUTO_TEST_CASE(read_observer)
         }};
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs->prefix() == "./test");
+        BOOST_TEST(obs.observers().size() == 1);
+        BOOST_TEST(obs.observers().front()->prefix() == "./test");
     }
     {
         const toml::table v = toml::table{{"files", toml::table{{"output",
@@ -27,7 +28,8 @@ BOOST_AUTO_TEST_CASE(read_observer)
         }};
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs->prefix() == "./test");
+        BOOST_TEST(obs.observers().size() == 1);
+        BOOST_TEST(obs.observers().front()->prefix() == "./test");
     }
 
     // XXX
@@ -42,7 +44,9 @@ BOOST_AUTO_TEST_CASE(read_observer)
         }};
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs->prefix() == "./test/test");
+
+        BOOST_TEST(obs.observers().size() == 1);
+        BOOST_TEST(obs.observers().front()->prefix() == "./test/test");
     }
 }
 
@@ -61,7 +65,10 @@ BOOST_AUTO_TEST_CASE(read_xyz_observer)
 
         const toml::table v{{"files", files}};
 
-        const auto obs = mjolnir::read_observer<traits_type>(v);
+        const auto obs_cont = mjolnir::read_observer<traits_type>(v);
+        BOOST_TEST(obs_cont.observers().size() == 1);
+
+        const auto& obs      = obs_cont.observers().front();
         BOOST_TEST(obs->prefix() == "./test");
 
         const auto xyz = dynamic_cast<observer_type*>(obs.get());
@@ -84,7 +91,10 @@ BOOST_AUTO_TEST_CASE(read_dcd_observer)
 
         const toml::table v{{"files", files}};
 
-        const auto obs = mjolnir::read_observer<traits_type>(v);
+        const auto obs_cont = mjolnir::read_observer<traits_type>(v);
+        BOOST_TEST(obs_cont.observers().size() == 1);
+
+        const auto& obs = obs_cont.observers().front();
         BOOST_TEST(obs->prefix() == "./test");
 
         const auto dcd = dynamic_cast<observer_type*>(obs.get());


### PR DESCRIPTION
related to #64 .

WIP: This PR will include the following changes.
- [x] add `ObserverContainer` and replace `std::unique_ptr<ObserverBase>` in `Simulator`s with it
- [x] enable to set multiple observers
- [x] split `EnergyObserver` from current observers