### PR TITLE
feat: add SimulatorBase::run()

### DIFF
--- a/mjolnir/core/MolecularDynamicsSimulator.hpp
+++ b/mjolnir/core/MolecularDynamicsSimulator.hpp
@@ -32,6 +32,7 @@ class MolecularDynamicsSimulator final : public SimulatorBase
 
     void initialize() override;
     bool step()       override;
+    void run()        override;
     void finalize()   override;
 
     real_type calc_energy() const {return this->ff_.calc_energy(this->system_);}
@@ -81,6 +82,17 @@ inline bool MolecularDynamicsSimulator<traitsT, integratorT>::step()
     this->time_ = this->step_count_ * integrator_.delta_t();
 
     return step_count_ < total_step_;
+}
+
+template<typename traitsT, typename integratorT>
+inline void MolecularDynamicsSimulator<traitsT, integratorT>::run()
+{
+    for(std::size_t i=0; i<total_step_; ++i)
+    {
+        this->step();
+    }
+    assert(this->step_count_ == total_step_);
+    return;
 }
 
 template<typename traitsT, typename integratorT>

--- a/mjolnir/core/SimulatedAnnealingSimulator.hpp
+++ b/mjolnir/core/SimulatedAnnealingSimulator.hpp
@@ -64,6 +64,7 @@ class SimulatedAnnealingSimulator final : public SimulatorBase
 
     void initialize() override;
     bool step()       override;
+    void run()        override;
     void finalize()   override;
 
     real_type calc_energy() const {return this->ff_.calc_energy(this->system_);}
@@ -136,6 +137,20 @@ inline bool SimulatedAnnealingSimulator<traitsT, integratorT, scheduleT>::step()
     this->integrator_.update(system_);
 
     return step_count_ < total_step_;
+}
+
+template<typename traitsT, typename integratorT, template<typename> class scheduleT>
+inline void SimulatedAnnealingSimulator<traitsT, integratorT, scheduleT>::run()
+{
+    MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+    MJOLNIR_LOG_FUNCTION_DEBUG();
+
+    for(std::size_t i=0; i<total_step_; ++i)
+    {
+        this->step();
+    }
+    assert(this->step_count_ == total_step_);
+    return;
 }
 
 template<typename traitsT, typename integratorT,

--- a/mjolnir/core/SimulatorBase.hpp
+++ b/mjolnir/core/SimulatorBase.hpp
@@ -11,6 +11,7 @@ class SimulatorBase
 
     virtual void initialize() = 0;
     virtual bool step()       = 0;
+    virtual void run()        = 0;
     virtual void finalize()   = 0;
 };
 

--- a/mjolnir/core/SteepestDescentSimulator.hpp
+++ b/mjolnir/core/SteepestDescentSimulator.hpp
@@ -32,6 +32,7 @@ class SteepestDescentSimulator final : public SimulatorBase
 
     void initialize() override;
     bool step()       override;
+    void run()        override;
     void finalize()   override;
 
     real_type calc_energy() const {return this->ff_.calc_energy(this->system_);}
@@ -103,6 +104,13 @@ inline bool SteepestDescentSimulator<traitsT>::step()
 
     ++step_count_;
     return this->step_count_ < this->step_limit_;
+}
+
+template<typename traitsT>
+inline void SteepestDescentSimulator<traitsT>::run()
+{
+    while(this->step()){/* do nothing */;}
+    return;
 }
 
 template<typename traitsT>

--- a/src/mjolnir.cpp
+++ b/src/mjolnir.cpp
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
     const auto start = std::chrono::system_clock::now();
     std::cerr << "start running simulation" << std::endl;
 
-    while(simulator->step()){/* do nothing */;}
+    simulator->run();
 
     simulator->finalize();
 


### PR DESCRIPTION
calling `simulator->step()` until it returns `false` is a nice idea to conceal the differences between simulators, but calling this explicitly from `main` is not perfect.

This PR adds `simulator->run()` that currently just call `step()` until the simulation finishes. But, essentially, it will provide more point to hook. It will be useful to have such an interface for other kind of simulation protocols.