### PR TITLE
chore: speed up CI especially for OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,6 @@ before_install:
     tar xf cmake-3.11.2-Linux-x86_64.tar.gz -C cmake --strip-components=1
     export PATH=${TRAVIS_BUILD_DIR}/cmake/bin:${PATH}
   else
-    brew install cmake boost
     brew upgrade cmake boost
   fi
 - cmake --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,63 +9,81 @@ matrix:
     env: COMPILER="g++-7"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         packages:
         - g++-7
+        - boost1.68
   - os: linux
     language: cpp
     compiler: gcc
     env: COMPILER="g++-6"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         packages:
         - g++-6
+        - boost1.68
   - os: linux
     language: cpp
     compiler: gcc
     env: COMPILER="g++-5"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         packages:
         - g++-5
+        - boost1.68
   - os: linux
     language: cpp
     compiler: clang
     env: COMPILER="clang++-7"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         - llvm-toolchain-trusty-7
         packages:
         - clang-7
+        - boost1.68
   - os: linux
     language: cpp
     compiler: clang
     env: COMPILER="clang++-6.0"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         - llvm-toolchain-trusty-6.0
         packages:
         - clang-6.0
+        - boost1.68
   - os: linux
     language: cpp
     compiler: clang
     env: COMPILER="clang++-5.0"
     addons:
       apt:
+        update: true
         sources:
+        - sourceline: 'ppa:mhier/libboost-latest'
         - ubuntu-toolchain-r-test
         - llvm-toolchain-trusty-5.0
         packages:
         - clang-5.0
+        - boost1.68
   - os: osx
     language: cpp
     compiler: clang
@@ -86,7 +104,7 @@ script:
 - cd build
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+    cmake -DCMAKE_CXX_COMPILER=$COMPILER -FIND_BOOST=ON ..
   else
     cmake -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1/ ..
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,14 +79,19 @@ before_install:
     tar xf cmake-3.11.2-Linux-x86_64.tar.gz -C cmake --strip-components=1
     export PATH=${TRAVIS_BUILD_DIR}/cmake/bin:${PATH}
   else
-    brew install cmake
-    brew upgrade cmake
+    brew install cmake boost
+    brew upgrade cmake boost
   fi
 - cmake --version
 
 script:
 - mkdir build
 - cd build
-- cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+- |
+  if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+    cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
+  else
+    cmake -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=/usr/local/Cellar/boost/1.69.0/ ..
+  fi
 - make
 - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ script:
 - cd build
 - |
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-    cmake -DCMAKE_CXX_COMPILER=$COMPILER -FIND_BOOST=ON ..
+    cmake -DCMAKE_CXX_COMPILER=$COMPILER -DFIND_BOOST=ON ..
   else
     cmake -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1/ ..
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,6 @@ before_install:
     travis_retry wget "https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.tar.gz"
     tar xf cmake-3.11.2-Linux-x86_64.tar.gz -C cmake --strip-components=1
     export PATH=${TRAVIS_BUILD_DIR}/cmake/bin:${PATH}
-  else
-    brew upgrade cmake boost
   fi
 - cmake --version
 
@@ -90,7 +88,7 @@ script:
   if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     cmake -DCMAKE_CXX_COMPILER=$COMPILER ..
   else
-    cmake -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=/usr/local/Cellar/boost/1.69.0/ ..
+    cmake -DCMAKE_CXX_COMPILER=$COMPILER -DBOOST_ROOT=/usr/local/Cellar/boost/1.67.0_1/ ..
   fi
 - make
 - ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 if(BOOST_ROOT)
     # if BOOST_ROOT is manually defined, use the library.
-    find_package(Boost 1.67.0 REQUIRED)
+    find_package(Boost 1.67.0 REQUIRED COMPONENTS unit_test_framework)
     include_directories(${Boost_INCLUDE_DIRS})
 else()
     if(EXISTS "${PROJECT_SOURCE_DIR}/extlib/boost_1_69_0/boost/version.hpp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,8 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/extlib/toml/toml.hpp")
                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 endif()
 
-if(BOOST_ROOT)
+option(FIND_BOOST "find boost library" OFF)
+if(BOOST_ROOT OR FIND_BOOST)
     # if BOOST_ROOT is manually defined, use the library.
     find_package(Boost 1.67.0 REQUIRED COMPONENTS unit_test_framework)
     include_directories(${Boost_INCLUDE_DIRS})

--- a/test/mjolnir/test_axis_aligned_plane_shape.cpp
+++ b/test/mjolnir/test_axis_aligned_plane_shape.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_axis_aligned_plane_shape"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <test/util/traits.hpp>
 #include <mjolnir/core/System.hpp>
 #include <mjolnir/core/AxisAlignedPlane.hpp>

--- a/test/mjolnir/test_bond_angle_interaction.cpp
+++ b/test/mjolnir/test_bond_angle_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_bond_angle_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <test/util/traits.hpp>
 #include <mjolnir/interaction/BondAngleInteraction.hpp>
 #include <mjolnir/math/constants.hpp>

--- a/test/mjolnir/test_bond_length_interaction.cpp
+++ b/test/mjolnir/test_bond_length_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_bond_length_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <test/util/traits.hpp>
 #include <mjolnir/interaction/BondLengthInteraction.hpp>
 #include <mjolnir/potential/local/HarmonicPotential.hpp>

--- a/test/mjolnir/test_clementi_dihedral_potential.cpp
+++ b/test/mjolnir/test_clementi_dihedral_potential.cpp
@@ -1,5 +1,10 @@
 #define BOOST_TEST_MODULE "test_clementi_dihedral_potential"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 
 #include <mjolnir/potential/local/ClementiDihedralPotential.hpp>
 #include <mjolnir/math/constants.hpp>

--- a/test/mjolnir/test_debye_huckel_potential.cpp
+++ b/test/mjolnir/test_debye_huckel_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_debye_huckel_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <test/util/traits.hpp>
 #include <mjolnir/potential/global/DebyeHuckelPotential.hpp>
 #include <mjolnir/util/make_unique.hpp>

--- a/test/mjolnir/test_dihedral_angle_interaction.cpp
+++ b/test/mjolnir/test_dihedral_angle_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_dihedral_angle_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <test/util/traits.hpp>
 #include <mjolnir/interaction/DihedralAngleInteraction.hpp>
 #include <mjolnir/math/constants.hpp>

--- a/test/mjolnir/test_excluded_volume_potential.cpp
+++ b/test/mjolnir/test_excluded_volume_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_excluded_volume_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/global/ExcludedVolumePotential.hpp>
 
 BOOST_AUTO_TEST_CASE(EXV_double)

--- a/test/mjolnir/test_excluded_volume_wall_potential.cpp
+++ b/test/mjolnir/test_excluded_volume_wall_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_excluded_volume_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/external/ExcludedVolumeWallPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(ExcludedVolumeWallPotential_double)

--- a/test/mjolnir/test_flp_angle_potential.cpp
+++ b/test/mjolnir/test_flp_angle_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_flexible_local_angle_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/FlexibleLocalAnglePotential.hpp>
 #include <mjolnir/math/constants.hpp>
 

--- a/test/mjolnir/test_flp_dihedral_potential.cpp
+++ b/test/mjolnir/test_flp_dihedral_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_flexible_local_dihedral_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/FlexibleLocalDihedralPotential.hpp>
 #include <mjolnir/math/constants.hpp>
 

--- a/test/mjolnir/test_gaussian_potential.cpp
+++ b/test/mjolnir/test_gaussian_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_gaussian_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/GaussianPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(Gaussian_double)

--- a/test/mjolnir/test_go_contact_potential.cpp
+++ b/test/mjolnir/test_go_contact_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_gocontact_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/GoContactPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(GoContact_double)

--- a/test/mjolnir/test_harmonic_potential.cpp
+++ b/test/mjolnir/test_harmonic_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_harmonic_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/HarmonicPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(Harmonic_double)

--- a/test/mjolnir/test_implicit_membrane_potential.cpp
+++ b/test/mjolnir/test_implicit_membrane_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_implicit_membrane_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/external/ImplicitMembranePotential.hpp>
 
 BOOST_AUTO_TEST_CASE(ImplicitMembranePotential_double)

--- a/test/mjolnir/test_lennard_jones_potential.cpp
+++ b/test/mjolnir/test_lennard_jones_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_lennard_jones_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/global/LennardJonesPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(LennardJones_double)

--- a/test/mjolnir/test_lennard_jones_wall_potential.cpp
+++ b/test/mjolnir/test_lennard_jones_wall_potential.cpp
@@ -1,6 +1,12 @@
 #define BOOST_TEST_MODULE "test_lennard_jones_wall_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
+
 #include <mjolnir/potential/external/LennardJonesWallPotential.hpp>
 
 BOOST_AUTO_TEST_CASE(LennardJonesWallPotential_double)

--- a/test/mjolnir/test_math.cpp
+++ b/test/mjolnir/test_math.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_math_functions"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <boost/mpl/list.hpp>
 #include <mjolnir/math/math.hpp>
 

--- a/test/mjolnir/test_matrix.cpp
+++ b/test/mjolnir/test_matrix.cpp
@@ -1,7 +1,12 @@
 #define BOOST_TEST_MODULE "test_matrix"
 
-#include <boost/mpl/list.hpp>
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <boost/mpl/list.hpp>
 #include <mjolnir/math/Matrix.hpp>
 #include <random>
 #include <cstdint>

--- a/test/mjolnir/test_periodic_gaussian_potential.cpp
+++ b/test/mjolnir/test_periodic_gaussian_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_periodic_gaussian_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/potential/local/PeriodicGaussianPotential.hpp>
 #include <mjolnir/math/constants.hpp>
 

--- a/test/mjolnir/test_range.cpp
+++ b/test/mjolnir/test_range.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_range"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/util/range.hpp>
 
 BOOST_AUTO_TEST_CASE(test_range)

--- a/test/mjolnir/test_read_bond_angle_interaction.cpp
+++ b/test/mjolnir/test_read_bond_angle_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_bond_angle_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_interaction.hpp>
 #include <test/util/traits.hpp>
 

--- a/test/mjolnir/test_read_bond_length_interaction.cpp
+++ b/test/mjolnir/test_read_bond_length_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_bond_length_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_interaction.hpp>
 #include <test/util/traits.hpp>
 

--- a/test/mjolnir/test_read_clementi_dihedral_potential.cpp
+++ b/test/mjolnir/test_read_clementi_dihedral_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_clementi_dihedral_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_clementi_dihedral_double)

--- a/test/mjolnir/test_read_debye_huckel_potential.cpp
+++ b/test/mjolnir/test_read_debye_huckel_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_debye_huckel_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_global_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_debye_huckel_double)

--- a/test/mjolnir/test_read_dihedral_angle_interaction.cpp
+++ b/test/mjolnir/test_read_dihedral_angle_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_dihedral_angle_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_interaction.hpp>
 #include <test/util/traits.hpp>
 

--- a/test/mjolnir/test_read_excluded_volume_potential.cpp
+++ b/test/mjolnir/test_read_excluded_volume_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_excluded_volume_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_global_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_excluded_volume_double)

--- a/test/mjolnir/test_read_excluded_volume_wall_potential.cpp
+++ b/test/mjolnir/test_read_excluded_volume_wall_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_excluded_volume_wall_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_external_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_excluded_volume_wall_double)

--- a/test/mjolnir/test_read_external_forcefield.cpp
+++ b/test/mjolnir/test_read_external_forcefield.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_external_forcefield"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/input/read_external_forcefield.hpp>
 

--- a/test/mjolnir/test_read_flexible_local_angle_potential.cpp
+++ b/test/mjolnir/test_read_flexible_local_angle_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_flexible_local_angle_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_flexible_local_angle_double)

--- a/test/mjolnir/test_read_flexible_local_dihedral_potential.cpp
+++ b/test/mjolnir/test_read_flexible_local_dihedral_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_flexible_local_dihedral_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_flexible_local_dihedral_double)

--- a/test/mjolnir/test_read_forcefield.cpp
+++ b/test/mjolnir/test_read_forcefield.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_forcefield"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/input/read_forcefield.hpp>
 
 BOOST_AUTO_TEST_CASE(read_empty_forcefield)

--- a/test/mjolnir/test_read_gaussian_potential.cpp
+++ b/test/mjolnir/test_read_gaussian_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_gaussian_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_gaussian_double)

--- a/test/mjolnir/test_read_global_forcefield.cpp
+++ b/test/mjolnir/test_read_global_forcefield.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_global_forcefield"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/input/read_global_forcefield.hpp>
 

--- a/test/mjolnir/test_read_global_pair_interaction.cpp
+++ b/test/mjolnir/test_read_global_pair_interaction.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_global_pair_interaction"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_global_interaction.hpp>
 
 BOOST_AUTO_TEST_CASE(read_global_pair_exv)

--- a/test/mjolnir/test_read_go_contact_potential.cpp
+++ b/test/mjolnir/test_read_go_contact_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_go_contact_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_go_contact_double)

--- a/test/mjolnir/test_read_harmonic_potential.cpp
+++ b/test/mjolnir/test_read_harmonic_potential.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_harmonic_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_harmonic_double)

--- a/test/mjolnir/test_read_implicit_membrane_potential.cpp
+++ b/test/mjolnir/test_read_implicit_membrane_potential.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_implicit_membrane_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/input/read_external_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_implicit_membrane_double)

--- a/test/mjolnir/test_read_input_path.cpp
+++ b/test/mjolnir/test_read_input_path.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_input_path"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/input/read_files_table.hpp>
 
 BOOST_AUTO_TEST_CASE(read_input_path)

--- a/test/mjolnir/test_read_integrator.cpp
+++ b/test/mjolnir/test_read_integrator.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_integrator"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/input/read_integrator.hpp>

--- a/test/mjolnir/test_read_lennard_jones_potential.cpp
+++ b/test/mjolnir/test_read_lennard_jones_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_lennard_jones_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_global_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_lennard_jones_double)

--- a/test/mjolnir/test_read_lennard_jones_wall_potential.cpp
+++ b/test/mjolnir/test_read_lennard_jones_wall_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_lennard_jones_wall_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_external_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_lennard_jones_wall_double)

--- a/test/mjolnir/test_read_local_forcefield.cpp
+++ b/test/mjolnir/test_read_local_forcefield.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_local_forcefield"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/input/read_local_forcefield.hpp>
 

--- a/test/mjolnir/test_read_observer.cpp
+++ b/test/mjolnir/test_read_observer.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_observer"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/input/read_observer.hpp>

--- a/test/mjolnir/test_read_periodic_gaussian_potential.cpp
+++ b/test/mjolnir/test_read_periodic_gaussian_potential.cpp
@@ -1,6 +1,11 @@
 #define BOOST_TEST_MODULE "test_read_periodic_gaussian_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
 #include <mjolnir/input/read_local_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_periodic_gaussian_double)

--- a/test/mjolnir/test_read_simulator.cpp
+++ b/test/mjolnir/test_read_simulator.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_simulator"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <test/util/make_empty_input.hpp>
 #include <mjolnir/input/read_simulator.hpp>
 

--- a/test/mjolnir/test_read_system.cpp
+++ b/test/mjolnir/test_read_system.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_system"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/System.hpp>

--- a/test/mjolnir/test_read_uniform_lennard_jones_potential.cpp
+++ b/test/mjolnir/test_read_uniform_lennard_jones_potential.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_read_uniform_lennard_jones_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/input/read_global_potential.hpp>
 
 BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_double)

--- a/test/mjolnir/test_read_unit.cpp
+++ b/test/mjolnir/test_read_unit.cpp
@@ -1,5 +1,9 @@
 #define BOOST_TEST_MODULE "test_unit_conversion"
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <boost/mpl/list.hpp>
 #include <test/util/make_empty_input.hpp>
 #include <test/util/traits.hpp>

--- a/test/mjolnir/test_static_string.cpp
+++ b/test/mjolnir/test_static_string.cpp
@@ -1,5 +1,9 @@
 #define BOOST_TEST_MODULE "test_static_string"
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/util/static_string.hpp>
 
 BOOST_AUTO_TEST_CASE(test_construction)

--- a/test/mjolnir/test_throw_exception.cpp
+++ b/test/mjolnir/test_throw_exception.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_throw_exception"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/util/throw_exception.hpp>
 #include <stdexcept>
 

--- a/test/mjolnir/test_topology.cpp
+++ b/test/mjolnir/test_topology.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_topology"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/core/Topology.hpp>
 #include <cstdint>
 

--- a/test/mjolnir/test_uniform_lennard_jones_potential.cpp
+++ b/test/mjolnir/test_uniform_lennard_jones_potential.cpp
@@ -1,6 +1,10 @@
 #define BOOST_TEST_MODULE "test_uniform_lennard_jones_potential"
 
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
 #include <mjolnir/potential/global/UniformLennardJonesPotential.hpp>
 #include <mjolnir/util/make_unique.hpp>
 

--- a/test/mjolnir/test_vector.cpp
+++ b/test/mjolnir/test_vector.cpp
@@ -1,7 +1,12 @@
 #define BOOST_TEST_MODULE "test_vector"
 
-#include <boost/mpl/list.hpp>
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
 #include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <boost/mpl/list.hpp>
 #include <mjolnir/math/Vector.hpp>
 
 #include <random>


### PR DESCRIPTION
use boost.test library that is already compiled, instead of header-only version.