### PR TITLE
ContactInteraction

### DIFF
--- a/mjolnir/interaction/local/BondAngleInteraction.hpp
+++ b/mjolnir/interaction/local/BondAngleInteraction.hpp
@@ -32,8 +32,6 @@ class BondAngleInteraction final : public LocalInteractionBase<traitsT>
     using iterator             = typename container_type::iterator;
     using const_iterator       = typename container_type::const_iterator;
 
-    using math_constant        = math::constants<real_type>;
-
   public:
 
     BondAngleInteraction(const connection_kind_type kind,
@@ -109,8 +107,8 @@ BondAngleInteraction<traitsT, potentialT>::calc_force(system_type& sys) const no
         const real_type coef  = -(idxp.second.derivative(theta));
 
         const real_type sin_theta    = std::sin(theta);
-        const real_type coef_inv_sin = (sin_theta > math_constant::tolerance) ?
-                             coef / sin_theta : coef / math_constant::tolerance;
+        const real_type coef_inv_sin = (sin_theta > math::tolerance<real_type>()) ?
+                             coef / sin_theta : coef / math::tolerance<real_type>();
 
         const coordinate_type Fi =
             (coef_inv_sin * inv_len_r_ij) * (cos_theta * r_ij_reg - r_kj_reg);

--- a/mjolnir/interaction/local/ContactInteraction.hpp
+++ b/mjolnir/interaction/local/ContactInteraction.hpp
@@ -60,7 +60,7 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
         MJOLNIR_LOG_INFO("potential = ", potential_type::name(),
                          ", number of bonds = ", potentials.size());
 
-        this->cutoff_ = std::max_element(potentials_.begin(), potentials_.end(),
+        this->cutoff_ = std::max_element(potentials.begin(), potentials.end(),
             [](const potential_index_pair& lhs, const potential_index_pair& rhs)
             {
                 return lhs.second.cutoff() < rhs.second.cutoff();
@@ -76,7 +76,7 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
             item.second.update(sys);
         }
 
-        this->cutoff_ = std::max_element(potentials_.begin(), potentials_.end(),
+        this->cutoff_ = std::max_element(potentials.begin(), potentials.end(),
             [](const potential_index_pair& lhs, const potential_index_pair& rhs)
             {
                 return lhs.second.cutoff() < rhs.second.cutoff();

--- a/mjolnir/interaction/local/ContactInteraction.hpp
+++ b/mjolnir/interaction/local/ContactInteraction.hpp
@@ -1,0 +1,196 @@
+#ifndef MJOLNIR_INTERACTION_CONTACT_INTERACTION_HPP
+#define MJOLNIR_INTERACTION_CONTACT_INTERACTION_HPP
+#include <mjolnir/core/LocalInteractionBase.hpp>
+#include <mjolnir/math/math.hpp>
+#include <mjolnir/util/string.hpp>
+#include <mjolnir/util/logger.hpp>
+#include <cmath>
+#include <iostream>
+
+namespace mjolnir
+{
+
+// ContactInteraction is basically the same as BondLengthInteraction. The only
+// difference is that it has a kind of "Neighbor List" to skip broken contacts.
+// BondLengthInteraction considers that all the interactions are kept within
+// the cutoff range (if a potential has a cutoff). Contrary, ContactInteraction
+// considers any of the interactions occasionally become distant than the cutoff
+// range. It becomes faster when a number of the contacts are not formed
+// throughout the simulation time.
+template<typename traitsT, typename potentialT>
+class ContactInteraction final : public LocalInteractionBase<traitsT>
+{
+  public:
+    using traits_type          = traitsT;
+    using potential_type       = potentialT;
+    using base_type            = LocalInteractionBase<traits_type>;
+    using real_type            = typename base_type::real_type;
+    using coordinate_type      = typename base_type::coordinate_type;
+    using system_type          = typename base_type::system_type;
+    using topology_type        = typename base_type::topology_type;
+    using connection_kind_type = typename base_type::connection_kind_type;
+
+    using indices_type         = std::array<std::size_t, 2>;
+    using potential_index_pair = std::pair<indices_type, potentialT>;
+    using container_type       = std::vector<potential_index_pair>;
+    using iterator             = typename container_type::iterator;
+    using const_iterator       = typename container_type::const_iterator;
+
+  public:
+
+    ContactInteraction(const connection_kind_type kind,
+                       const container_type&      pot,
+                       const real_type            margin = 0.5)
+        : kind_(kind), potentials(pot), margin_(margin)
+    {}
+    ContactInteraction(const connection_kind_type kind,
+                       container_type&&           pot,
+                       const real_type            margin = 0.5)
+        : kind_(kind), potentials(std::move(pot)), margin_(margin)
+    {}
+    ~ContactInteraction() override = default;
+
+    void      calc_force (system_type&)       const noexcept override;
+    real_type calc_energy(const system_type&) const noexcept override;
+
+    void initialize(const system_type& sys) override
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+        MJOLNIR_LOG_INFO("potential = ", potential_type::name(),
+                         ", number of bonds = ", potentials.size());
+
+        this->cutoff_ = std::max_element(potentials_.begin(), potentials_.end(),
+            [](const potential_index_pair& lhs, const potential_index_pair& rhs)
+            {
+                return lhs.second.cutoff() < rhs.second.cutoff();
+            })->second.cutoff();
+        this->make_list(sys);
+        return;
+    }
+
+    void update(const system_type& sys) override
+    {
+        for(auto& item : potentials)
+        {
+            item.second.update(sys);
+        }
+
+        this->cutoff_ = std::max_element(potentials_.begin(), potentials_.end(),
+            [](const potential_index_pair& lhs, const potential_index_pair& rhs)
+            {
+                return lhs.second.cutoff() < rhs.second.cutoff();
+            })->second.cutoff();
+        this->make_list(sys);
+        return;
+    }
+
+    void update_margin(const real_type dmargin, const system_type& sys) override
+    {
+        this->current_margin_ -= dmargin;
+        if(this->current_margin_ < 0)
+        {
+            this->make_list(sys);
+        }
+        return;
+    }
+
+    std::string name() const override
+    {return "Contact:"_s + potential_type::name();}
+
+    void write_topology(topology_type&) const override;
+
+  private:
+
+    void make_list(const system_type& sys)
+    {
+        this->active_contacts_.clear();
+        this->active_contacts_.reserve(potentials.size());
+
+        const real_type threshold = this->cutoff_ * (real_type(1) + this->margin_);
+        const real_type threshold_sq = threshold * threshold;
+
+        for(std::size_t i=0; i < this->potentials.size(); ++i)
+        {
+            const auto pos0 = sys.position(this->potentials[i].first[0]);
+            const auto pos1 = sys.position(this->potentials[i].first[1]);
+            const auto dpos = sys.adjust_direction(pos1 - pos0);
+            const auto len2 = math::length_sq(dpos);
+            if(len2 < threshold_sq)
+            {
+                this->active_contacts_.push_back(i);
+            }
+        }
+        this->current_margin_ = this->cutoff_ * this->margin_;
+        return;
+    }
+
+  private:
+    connection_kind_type kind_;
+    container_type potentials;
+
+    // neighbor list stuff
+    real_type cutoff_;
+    real_type margin_;
+    real_type current_margin_;
+    std::vector<std::size_t> active_contacts_;
+};
+
+template<typename traitsT, typename potentialT>
+void ContactInteraction<traitsT, potentialT>::calc_force(
+        system_type& sys) const noexcept
+{
+    for(const std::size_t active_contact : active_contacts_)
+    {
+        const auto& idxp = this->potentials[active_contact];
+
+        const std::size_t idx0 = idxp.first[0];
+        const std::size_t idx1 = idxp.first[1];
+
+        const auto dpos =
+            sys.adjust_direction(sys.position(idx1) - sys.position(idx0));
+
+        const real_type len2 = math::length_sq(dpos); // l^2
+        const real_type rlen = math::rsqrt(len2);     // 1/l
+        const real_type force = -1 * idxp.second.derivative(len2 * rlen);
+        // here, L^2 * (1 / L) = L.
+
+        const coordinate_type f = dpos * (force * rlen);
+        sys.force(idx0) -= f;
+        sys.force(idx1) += f;
+    }
+    return;
+}
+
+template<typename traitsT, typename potentialT>
+typename ContactInteraction<traitsT, potentialT>::real_type
+ContactInteraction<traitsT, potentialT>::calc_energy(
+        const system_type& sys) const noexcept
+{
+    real_type E = 0.0;
+    for(const std::size_t active_contact : active_contacts_)
+    {
+        const auto& idxp = this->potentials[active_contact];
+        E += idxp.second.potential(math::length(sys.adjust_direction(
+                sys.position(idxp.first[1]) - sys.position(idxp.first[0]))));
+    }
+    return E;
+}
+
+template<typename traitsT, typename potentialT>
+void ContactInteraction<traitsT, potentialT>::write_topology(
+        topology_type& topol) const
+{
+    if(this->kind_.empty() || this->kind_ == "none") {return;}
+
+    for(const auto& idxp : this->potentials)
+    {
+        const auto i = idxp.first[0];
+        const auto j = idxp.first[1];
+        topol.add_connection(i, j, this->kind_);
+    }
+    return;
+}
+
+} // mjolnir
+#endif /* MJOLNIR_BOND_LENGTH_INTERACTION */

--- a/mjolnir/math/constants.hpp
+++ b/mjolnir/math/constants.hpp
@@ -10,16 +10,12 @@ template<typename realT>
 struct constants
 {
     using real_type = realT;
-    static constexpr real_type tolerance = static_cast<real_type>(1e-8);
-
     static constexpr real_type pi          = static_cast<real_type>(3.14159265358979323846264338);
     static constexpr real_type half_pi     = static_cast<real_type>(1.57079632679489661923132169);
     static constexpr real_type two_pi      = static_cast<real_type>(6.28318530717958647692528677);
     static constexpr real_type one_over_pi = static_cast<real_type>(0.31830988618379067153776753);
 };
 
-template<typename realT>
-constexpr typename constants<realT>::real_type constants<realT>::tolerance;
 template<typename realT>
 constexpr typename constants<realT>::real_type constants<realT>::pi;
 template<typename realT>
@@ -28,6 +24,28 @@ template<typename realT>
 constexpr typename constants<realT>::real_type constants<realT>::two_pi;
 template<typename realT>
 constexpr typename constants<realT>::real_type constants<realT>::one_over_pi;
+
+template<typename realT>
+struct tolerance_aux;
+
+template<>
+struct tolerance_aux<double>
+{
+    using real_type = double;
+    static constexpr real_type value() noexcept {return 1e-8;}
+};
+template<>
+struct tolerance_aux<float>
+{
+    using real_type = float;
+    static constexpr real_type value() noexcept {return 1e-4;}
+};
+
+template<typename realT>
+constexpr realT tolerance() noexcept
+{
+    return tolerance_aux<realT>::value();
+}
 
 } // math
 } // mjolnir

--- a/mjolnir/potential/local/ClementiDihedralPotential.hpp
+++ b/mjolnir/potential/local/ClementiDihedralPotential.hpp
@@ -1,5 +1,6 @@
 #ifndef MJOLNIR_POTENTIAL_LOCAL_CLEMENTI_DIHEDRAL_POTENTIAL_HPP
 #define MJOLNIR_POTENTIAL_LOCAL_CLEMENTI_DIHEDRAL_POTENTIAL_HPP
+#include <limits>
 #include <cmath>
 
 namespace mjolnir
@@ -48,6 +49,9 @@ class ClementiDihedralPotential
     real_type k1() const noexcept {return k1_;}
     real_type k3() const noexcept {return k3_;}
     real_type v0() const noexcept {return v0_;}
+
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
 
   private:
 

--- a/mjolnir/potential/local/FlexibleLocalAnglePotential.hpp
+++ b/mjolnir/potential/local/FlexibleLocalAnglePotential.hpp
@@ -2,6 +2,7 @@
 #define MJOLNIR_POTENTIAL_LOCAL_FLEXIBLE_LOCAL_ANGLE_POTENTIAL_HPP
 #include <array>
 #include <algorithm>
+#include <limits>
 #include <cassert>
 #include <cmath>
 
@@ -104,6 +105,9 @@ class FlexibleLocalAnglePotential
     real_type                        k()   const noexcept {return k_;}
     std::array<real_type, 10> const& y()   const noexcept {return ys_;}
     std::array<real_type, 10> const& d2y() const noexcept {return d2ys_;}
+
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
 
   private:
 

--- a/mjolnir/potential/local/FlexibleLocalDihedralPotential.hpp
+++ b/mjolnir/potential/local/FlexibleLocalDihedralPotential.hpp
@@ -81,6 +81,9 @@ class FlexibleLocalDihedralPotential
     real_type                       k()    const noexcept {return k_;}
     std::array<real_type, 7> const& coef() const noexcept {return term_;}
 
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
+
   private:
     real_type min_energy;
     real_type k_;

--- a/mjolnir/potential/local/GaussianPotential.hpp
+++ b/mjolnir/potential/local/GaussianPotential.hpp
@@ -1,5 +1,6 @@
 #ifndef MJOLNIR_POTENTIAL_LOCAL_GAUSSIAN_POTENTIAL_HPP
 #define MJOLNIR_POTENTIAL_LOCAL_GAUSSIAN_POTENTIAL_HPP
+#include <mjolnir/math/constants.hpp>
 #include <cmath>
 
 namespace mjolnir
@@ -18,7 +19,9 @@ class GaussianPotential
   public:
     GaussianPotential(const real_type k, const real_type sigma,
                       const real_type v0) noexcept
-        : k_(k), sigma_(sigma), inv_sigma2_(-1./(2*sigma*sigma)), v0_(v0)
+        : k_(k), sigma_(sigma), inv_sigma2_(-1./(2*sigma*sigma)), v0_(v0),
+          cutoff_(v0_ + sigma_ *
+                  std::sqrt(2 * std::log(k_ / math::tolerance<real_type>())))
     {}
     ~GaussianPotential() = default;
 
@@ -39,15 +42,18 @@ class GaussianPotential
 
     static const char* name() noexcept {return "Gaussian";}
 
-    real_type k()     const noexcept {return k_;}
-    real_type sigma() const noexcept {return sigma_;}
-    real_type v0()    const noexcept {return v0_;}
+    real_type k()      const noexcept {return k_;}
+    real_type sigma()  const noexcept {return sigma_;}
+    real_type v0()     const noexcept {return v0_;}
+
+    real_type cutoff() const noexcept {return cutoff_;}
 
   private:
 
     real_type k_, sigma_;
     real_type inv_sigma2_;
     real_type v0_;
+    real_type cutoff_;
 };
 
 } // mjolnir

--- a/mjolnir/potential/local/GoContactPotential.hpp
+++ b/mjolnir/potential/local/GoContactPotential.hpp
@@ -58,8 +58,10 @@ class GoContactPotential
 
     static const char* name() noexcept {return "GoContact";}
 
-    real_type k()  const noexcept {return epsilon_;}
-    real_type v0() const noexcept {return v0_;}
+    real_type k()      const noexcept {return epsilon_;}
+    real_type v0()     const noexcept {return v0_;}
+
+    real_type cutoff() const noexcept {return this->v0_ * cutoff_ratio;}
 
   private:
 

--- a/mjolnir/potential/local/HarmonicPotential.hpp
+++ b/mjolnir/potential/local/HarmonicPotential.hpp
@@ -1,5 +1,6 @@
 #ifndef MJOLNIR_POTENTIAL_LOCAL_HARMONIC_POTENTIAL_HPP
 #define MJOLNIR_POTENTIAL_LOCAL_HARMONIC_POTENTIAL_HPP
+#include <limits>
 
 namespace mjolnir
 {
@@ -37,6 +38,9 @@ class HarmonicPotential
 
     real_type k()  const noexcept {return k_;}
     real_type v0() const noexcept {return v0_;}
+
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
 
   private:
 

--- a/mjolnir/potential/local/PeriodicGaussianPotential.hpp
+++ b/mjolnir/potential/local/PeriodicGaussianPotential.hpp
@@ -1,6 +1,7 @@
 #ifndef MJOLNIR_POTENTIAL_LOCAL_ANGULAR_GAUSSIAN_POTENTIAL_HPP
 #define MJOLNIR_POTENTIAL_LOCAL_ANGULAR_GAUSSIAN_POTENTIAL_HPP
 #include <mjolnir/math/math.hpp>
+#include <limits>
 
 namespace mjolnir
 {
@@ -50,6 +51,9 @@ class PeriodicGaussianPotential
     real_type k()     const noexcept {return k_;}
     real_type sigma() const noexcept {return sigma_;}
     real_type v0()    const noexcept {return v0_;}
+
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
 
   private:
 

--- a/mjolnir/potential/local/SumLocalPotential.hpp
+++ b/mjolnir/potential/local/SumLocalPotential.hpp
@@ -1,6 +1,7 @@
 #ifndef MJOLNIR_POTENTIAL_LOCAL_SUM_LOCAL_POTENTIAL_HPP
 #define MJOLNIR_POTENTIAL_LOCAL_SUM_LOCAL_POTENTIAL_HPP
 #include <tuple>
+#include <limits>
 
 namespace mjolnir
 {
@@ -141,6 +142,9 @@ class SumLocalPotential
     {
         return detail::collect_name_impl<0, size, Potentials...>::invoke();
     }
+
+    real_type cutoff() const noexcept // no cutoff exists.
+    {return std::numeric_limits<real_type>::infinity();}
 
   private:
     potentials_type potentials_;

--- a/test/mjolnir/CMakeLists.txt
+++ b/test/mjolnir/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TEST_NAMES
     test_bond_length_interaction
     test_bond_angle_interaction
     test_dihedral_angle_interaction
+    test_contact_interaction
     test_global_pair_interaction
     test_position_restraint_interaction
 

--- a/test/mjolnir/test_contact_interaction.cpp
+++ b/test/mjolnir/test_contact_interaction.cpp
@@ -1,0 +1,107 @@
+#define BOOST_TEST_MODULE "test_contact_interaction"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <test/util/traits.hpp>
+#include <mjolnir/interaction/local/ContactInteraction.hpp>
+#include <mjolnir/potential/local/GoContactPotential.hpp>
+#include <mjolnir/util/make_unique.hpp>
+
+BOOST_AUTO_TEST_CASE(Contact_calc_force)
+{
+    mjolnir::LoggerManager::set_default_logger("test_Contact_calc_force");
+
+    typedef mjolnir::test::traits<double> traits;
+    constexpr static traits::real_type tol = 1e-8;
+
+    typedef traits::real_type real_type;
+    typedef traits::coordinate_type            coord_type;
+    typedef traits::boundary_type              boundary_type;
+    typedef mjolnir::System<traits>            system_type;
+    typedef mjolnir::GoContactPotential<real_type>   potential_type;
+    typedef mjolnir::ContactInteraction<traits, potential_type> interaction_type;
+
+    auto normalize = [](const coord_type& v){return v / mjolnir::math::length(v);};
+
+    const real_type k(100.);
+    const real_type native(2.0);
+
+    potential_type   potential(k, native);
+    interaction_type interaction("none", {{ {{0,1}}, potential}});
+
+    system_type sys(2, boundary_type{});
+
+    sys.at(0).mass = 1.0;
+    sys.at(1).mass = 1.0;
+    sys.at(0).rmass = 1.0;
+    sys.at(1).rmass = 1.0;
+
+    sys.at(0).position = coord_type(0,0,0);
+    sys.at(1).position = coord_type(0,0,0);
+    sys.at(0).velocity = coord_type(0,0,0);
+    sys.at(1).velocity = coord_type(0,0,0);
+    sys.at(0).force    = coord_type(0,0,0);
+    sys.at(1).force    = coord_type(0,0,0);
+
+    sys.at(0).name  = "X";
+    sys.at(1).name  = "X";
+    sys.at(0).group = "NONE";
+    sys.at(1).group = "NONE";
+
+    const real_type dr = 1e-3;
+    real_type dist = 1e0;
+    sys[1].position[0] = dist;
+
+    interaction.initialize(sys);
+
+    for(int i = 0; i < 2000; ++i)
+    {
+        sys[0].position = coord_type(0,0,0);
+        sys[1].position = coord_type(0,0,0);
+        sys[0].force    = coord_type(0,0,0);
+        sys[1].force    = coord_type(0,0,0);
+        sys[1].position[0] = dist;
+
+        interaction.update_margin(dr, sys);
+
+        const real_type deriv = potential.derivative(dist);
+        const real_type coef  = std::abs(deriv);
+
+        interaction.calc_force(sys);
+
+        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
+        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
+        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
+        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
+
+        // direction
+        if(dist < native) // repulsive
+        {
+            const real_type dir1 = mjolnir::math::dot_product(
+                normalize(sys[0].force), normalize(sys[0].position - sys[1].position));
+            const real_type dir2 = mjolnir::math::dot_product(
+                normalize(sys[1].force), normalize(sys[1].position - sys[0].position));
+
+            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
+            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
+        }
+        else
+        {
+            const real_type dir1 = mjolnir::math::dot_product(
+                normalize(sys[0].force), normalize(sys[1].position - sys[0].position));
+            const real_type dir2 = mjolnir::math::dot_product(
+                normalize(sys[1].force), normalize(sys[0].position - sys[1].position));
+
+            BOOST_TEST(dir1 == 1e0, boost::test_tools::tolerance(tol));
+            BOOST_TEST(dir2 == 1e0, boost::test_tools::tolerance(tol));
+        }
+        BOOST_TEST(mjolnir::math::length(sys[0].force + sys[1].force) == 0.0,
+                   boost::test_tools::tolerance(tol));
+
+        dist += dr;
+    }
+}


### PR DESCRIPTION
Add `ContactInteraction`.

It is basically the same as `BondLengthInteraction`, but it has a kind of neighbor-list and skips contacts that the particles are more distant than the cutoff range.