### PR TITLE
refactor: read [simulator] before calling readers

### DIFF
--- a/mjolnir/input/read_input_file.hpp
+++ b/mjolnir/input/read_input_file.hpp
@@ -34,7 +34,8 @@ read_boundary(const toml::table& root, const toml::value& simulator)
     else
     {
         throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_boundary: invalid boundary", boundary, "here", {
+            "mjolnir::read_boundary: invalid boundary",
+            toml::find(simulator, "boundary_type"), "here", {
             "- \"Unlimited\"     : no boundary condition. infinite space",
             "- \"PeriodicCuboid\": periodic boundary with cuboidal shape"
             }));
@@ -61,7 +62,8 @@ read_precision(const toml::table& root, const toml::value& simulator)
     else
     {
         throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_precision: invalid precision", prec, "here", {
+            "mjolnir::read_precision: invalid precision",
+            toml::find(simulator, "precition"), "here", {
             "expected value is one of the following.",
             "- \"double\": 64 bit floating-point",
             "- \"float\" : 32 bit floating-point"


### PR DESCRIPTION
The important flags, such as `precision` and `boundary_type`, are defined in the `[simulator]` table.
Those flags must be read before reading other settings. Reading [simulator] before others makes  initialization a bit faster, especially in the case if [simulator] is splitted from the main file.