### PR TITLE
Fix aligned allocator

### DIFF
--- a/mjolnir/util/aligned_allocator.hpp
+++ b/mjolnir/util/aligned_allocator.hpp
@@ -123,14 +123,16 @@ class aligned_allocator
     using const_reference = value_type const&;
     using propagate_on_container_move_assignment = std::true_type;
 
+    // use the maximum alignment in {Alignment, alignof(T), alignof(void*)}.
+    static constexpr std::size_t alignment = compiletime::max(
+            Alignment, compiletime::max(alignof(T), alignof(void*))
+        );
+
     template<typename U>
     struct rebind
     {
-        using other = aligned_allocator<U, std::alignment_of<U>::value>;
+        using other = aligned_allocator<U, alignment>;
     };
-
-    static constexpr std::size_t alignment =
-        (Alignment > sizeof(void*)) ? Alignment : sizeof(void*);
 
   public:
 

--- a/mjolnir/util/aligned_allocator.hpp
+++ b/mjolnir/util/aligned_allocator.hpp
@@ -1,5 +1,6 @@
 #ifndef MJOLNIR_UTIL_ALIGNED_ALLOCATOR_HPP
 #define MJOLNIR_UTIL_ALIGNED_ALLOCATOR_HPP
+#include <mjolnir/math/compiletime.hpp> // for constexpr max(a, b)
 #include <type_traits>
 #include <memory>
 #include <limits>


### PR DESCRIPTION
fix `rebind`. Consider the `Alignment` value when rebinding it to other types.
Most of the containers use `rebind`, so this bug makes incompatibility with STL containers.