### PR TITLE
Refactor: remove reconstruction

### DIFF
--- a/mjolnir/core/AxisAlignedPlane.hpp
+++ b/mjolnir/core/AxisAlignedPlane.hpp
@@ -185,14 +185,6 @@ class AxisAlignedPlane
         return;
     }
 
-    //! update exclusion list and cutoff length.
-    template<typename Potential>
-    void reconstruct(const system_type& sys, const Potential& pot)
-    {
-        this->initialize(sys, pot);
-        return;
-    }
-
     // neighbor-list stuff
     void make  (const system_type& sys);
     void update(const real_type dm, const system_type& sys);

--- a/mjolnir/core/NaivePairCalculation.hpp
+++ b/mjolnir/core/NaivePairCalculation.hpp
@@ -37,13 +37,6 @@ class NaivePairCalculation
     void initialize (const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
-    template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>

--- a/mjolnir/core/PeriodicGridCellList.hpp
+++ b/mjolnir/core/PeriodicGridCellList.hpp
@@ -65,13 +65,6 @@ class PeriodicGridCellList
     void initialize(const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
-    template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>

--- a/mjolnir/core/Plane.hpp
+++ b/mjolnir/core/Plane.hpp
@@ -61,14 +61,6 @@ class Plane
         return;
     }
 
-    //! update exclusion list and cutoff length.
-    template<typename Potential>
-    void reconstruct(const system_type& sys, const Potential& pot)
-    {
-        this->initialize(sys, pot);
-        return;
-    }
-
     void make  (const system_type& sys);
     void update(const real_type dm, const system_type& sys);
 

--- a/mjolnir/core/UnlimitedGridCellList.hpp
+++ b/mjolnir/core/UnlimitedGridCellList.hpp
@@ -66,13 +66,6 @@ class UnlimitedGridCellList
     void initialize(const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
-    template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>

--- a/mjolnir/core/VerletList.hpp
+++ b/mjolnir/core/VerletList.hpp
@@ -50,13 +50,6 @@ class VerletList
     }
 
     template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
-    template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot);
 
     template<typename PotentialT>

--- a/mjolnir/interaction/external/ExternalDistanceInteraction.hpp
+++ b/mjolnir/interaction/external/ExternalDistanceInteraction.hpp
@@ -51,7 +51,7 @@ class ExternalDistanceInteraction final
     void update(const system_type& sys) override
     {
         this->potential_.update(sys); // update system parameters
-        this->shape_.reconstruct(sys, this->potential_);
+        this->shape_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/interaction/global/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairExcludedVolumeInteraction.hpp
@@ -57,7 +57,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/interaction/global/GlobalPairInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairInteraction.hpp
@@ -51,7 +51,7 @@ class GlobalPairInteraction final : public GlobalInteractionBase<traitsT>
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/interaction/global/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairLennardJonesInteraction.hpp
@@ -57,7 +57,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/interaction/global/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairUniformLennardJonesInteraction.hpp
@@ -57,7 +57,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/ExternalDistanceInteraction.hpp
+++ b/mjolnir/omp/ExternalDistanceInteraction.hpp
@@ -83,7 +83,7 @@ class ExternalDistanceInteraction<
     void update(const system_type& sys) override
     {
         this->potential_.update(sys); // update system parameters
-        this->shape_.reconstruct(sys, this->potential_);
+        this->shape_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/GlobalPairDebyeHuckelInteraction.hpp
+++ b/mjolnir/omp/GlobalPairDebyeHuckelInteraction.hpp
@@ -55,7 +55,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -54,7 +54,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -55,7 +55,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -55,7 +55,7 @@ class GlobalPairInteraction<
         MJOLNIR_LOG_INFO("potential is ", this->name());
         this->potential_.update(sys);
         // potential update may change the cutoff length!
-        this->partition_.reconstruct(sys, this->potential_);
+        this->partition_.initialize(sys, this->potential_);
     }
 
     void update_margin(const real_type dmargin, const system_type& sys) override

--- a/mjolnir/omp/PeriodicGridCellList.hpp
+++ b/mjolnir/omp/PeriodicGridCellList.hpp
@@ -157,13 +157,6 @@ class PeriodicGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, parameterT>
     }
 
     template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
-    template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot)
     {
         neighbors_.clear();

--- a/mjolnir/omp/UnlimitedGridCellList.hpp
+++ b/mjolnir/omp/UnlimitedGridCellList.hpp
@@ -122,13 +122,6 @@ class UnlimitedGridCellList<
         return;
     }
 
-    template<typename PotentialT>
-    void reconstruct(const system_type& sys, const PotentialT& pot)
-    {
-        this->initialize(sys, pot); // do the same thing as `initialize`
-        return;
-    }
-
     //XXX do NOT call this from parallel region
     template<typename PotentialT>
     void make  (const system_type& sys, const PotentialT& pot)


### PR DESCRIPTION
Currently, most of the implementation of `reconstruction` just call `initialize`. It replaces `reconstruct` by re-`initialize`.