### PR TITLE
#113 :alembic: Enable to define variable

### DIFF
--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -1,6 +1,7 @@
 #ifndef MJOLNIR_INPUT_READ_GLOBAL_POTENTIAL_HPP
 #define MJOLNIR_INPUT_READ_GLOBAL_POTENTIAL_HPP
 #include <extlib/toml/toml.hpp>
+#include <mjolnir/input/utility.hpp>
 #include <mjolnir/potential/global/ExcludedVolumePotential.hpp>
 #include <mjolnir/potential/global/LennardJonesPotential.hpp>
 #include <mjolnir/potential/global/UniformLennardJonesPotential.hpp>
@@ -73,6 +74,9 @@ read_excluded_volume_potential(const toml::value& global)
             " within ", connection.second, " will be ignored");
     }
 
+    const auto& env = global.as_table().count("env") == 1 ?
+                      global.as_table().at("env") : toml::value{};
+
     const real_type eps = toml::find<real_type>(global, "epsilon");
     MJOLNIR_LOG_INFO("epsilon = ", eps);
 
@@ -85,8 +89,8 @@ read_excluded_volume_potential(const toml::value& global)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto idx = toml::find<std::size_t>(param, "index");
-        const auto radius = toml::find<real_type>(param, "radius");
+        const auto idx    = find_parameter<std::size_t>(param, env, "index");
+        const auto radius = find_parameter<real_type  >(param, env, "radius");
 
         params.emplace_back(idx, radius);
         MJOLNIR_LOG_INFO("idx = ", idx, ", radius = ", radius);
@@ -115,6 +119,9 @@ read_lennard_jones_potential(const toml::value& global)
             " within ", connection.second, " will be ignored");
     }
 
+    const auto& env = global.as_table().count("env") == 1 ?
+                      global.as_table().at("env") : toml::value{};
+
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
@@ -124,11 +131,9 @@ read_lennard_jones_potential(const toml::value& global)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto idx     = toml::find<std::size_t>(param, "index");
-        const auto sigma   = toml::expect<real_type>(param, u8"σ").or_other(
-                             toml::expect<real_type>(param, "sigma")).unwrap();
-        const auto epsilon = toml::expect<real_type>(param, u8"ε").or_other(
-                             toml::expect<real_type>(param, "epsilon")).unwrap();
+        const auto idx     = find_parameter<std::size_t>(param, env, "index");
+        const auto sigma   = find_parameter<real_type>(param, env, "sigma",   u8"σ");
+        const auto epsilon = find_parameter<real_type>(param, env, "epsilon", u8"ε");
 
         params.emplace_back(idx, parameter_type{sigma, epsilon});
         MJOLNIR_LOG_INFO("idx = ", idx, ", sigma = ", sigma, ", epsilon = ", epsilon);
@@ -157,6 +162,9 @@ read_uniform_lennard_jones_potential(const toml::value& global)
             " within ", connection.second, " will be ignored");
     }
 
+    const auto& env = global.as_table().count("env") == 1 ?
+                      global.as_table().at("env") : toml::value{};
+
     const auto sigma   = toml::expect<real_type>(global, u8"σ").or_other(
                          toml::expect<real_type>(global, "sigma")).unwrap();
     const auto epsilon = toml::expect<real_type>(global, u8"ε").or_other(
@@ -171,7 +179,7 @@ read_uniform_lennard_jones_potential(const toml::value& global)
     {
         for(const auto& param : toml::find<toml::array>(global, "parameters"))
         {
-            const auto idx = toml::find<std::size_t>(param, "index");
+            const auto idx = find_parameter<std::size_t>(param, env, "index");
             params.emplace_back(idx, parameter_type{});
         }
     }
@@ -198,6 +206,9 @@ read_debye_huckel_potential(const toml::value& global)
             " within ", connection.second, " will be ignored");
     }
 
+    const auto& env = global.as_table().count("env") == 1 ?
+                      global.as_table().at("env") : toml::value{};
+
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
@@ -207,8 +218,8 @@ read_debye_huckel_potential(const toml::value& global)
     params.reserve(ps.size());
     for(const auto& param : ps)
     {
-        const auto idx    = toml::find<std::size_t>(param, "index");
-        const auto charge = toml::find<real_type  >(param, "charge");
+        const auto idx    = find_parameter<std::size_t>(param, env, "index");
+        const auto charge = find_parameter<real_type  >(param, env, "charge");
 
         params.emplace_back(idx, parameter_type{charge});
         MJOLNIR_LOG_INFO("idx = ", idx, ", charge = ", charge);

--- a/mjolnir/input/read_local_potential.hpp
+++ b/mjolnir/input/read_local_potential.hpp
@@ -1,6 +1,8 @@
 #ifndef MJOLNIR_INPUT_READ_LOCAL_POTENTIAL_HPP
 #define MJOLNIR_INPUT_READ_LOCAL_POTENTIAL_HPP
 #include <extlib/toml/toml.hpp>
+#include <mjolnir/input/utility.hpp>
+
 #include <mjolnir/potential/local/HarmonicPotential.hpp>
 #include <mjolnir/potential/local/GoContactPotential.hpp>
 #include <mjolnir/potential/local/ClementiDihedralPotential.hpp>
@@ -22,12 +24,13 @@ namespace mjolnir
 // {indices = [1, 2], k = 10.0, v0 = 1.0} <- a portion of this table, k and v0.
 // ]
 template<typename realT>
-HarmonicPotential<realT> read_harmonic_potential(const toml::value& param)
+HarmonicPotential<realT>
+read_harmonic_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto k  = toml::find<real_type>(param, "k" );
-    const auto v0 = toml::find<real_type>(param, "v0");
+    const auto k  = find_parameter<real_type>(param, env, "k" );
+    const auto v0 = find_parameter<real_type>(param, env, "v0");
 
     MJOLNIR_LOG_INFO("HarmonicPotential = {v0 = ", v0, ", k = ", k, '}');
     return HarmonicPotential<realT>(k, v0);
@@ -35,26 +38,27 @@ HarmonicPotential<realT> read_harmonic_potential(const toml::value& param)
 
 template<typename realT>
 GoContactPotential<realT>
-read_go_contact_potential(const toml::value& param)
+read_go_contact_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto k  = toml::find<real_type>(param, "k");
-    const auto v0 = toml::find<real_type>(param, "v0");
+    const auto k  = find_parameter<real_type>(param, env, "k");
+    const auto v0 = find_parameter<real_type>(param, env, "v0");
 
     MJOLNIR_LOG_INFO("GoContactPotential = {v0 = ", v0, ", k = ", k, '}');
     return GoContactPotential<realT>(k, v0);
 }
 
 template<typename realT>
-GaussianPotential<realT> read_gaussian_potential(const toml::value& param)
+GaussianPotential<realT>
+read_gaussian_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto v0    = toml::find<real_type>(param, "v0");
-    const auto k     = toml::find<real_type>(param, "k");
-    const auto sigma = toml::expect<real_type>(param, u8"σ").or_other(
-                       toml::expect<real_type>(param, "sigma")).unwrap();
+    const auto v0    = find_parameter<real_type>(param, env, "v0");
+    const auto k     = find_parameter<real_type>(param, env, "k");
+    const auto sigma = find_parameter<real_type>(param, env, "sigma", u8"σ");
+
     MJOLNIR_LOG_INFO("GaussianPotential = {v0 = ", v0, ", k = ", k,
                      ", sigma = ", sigma, '}');
     return GaussianPotential<realT>(k, sigma, v0);
@@ -62,14 +66,13 @@ GaussianPotential<realT> read_gaussian_potential(const toml::value& param)
 
 template<typename realT>
 PeriodicGaussianPotential<realT>
-read_periodic_gaussian_potential(const toml::value& param)
+read_periodic_gaussian_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto v0    = toml::find<real_type>(param, "v0");
-    const auto k     = toml::find<real_type>(param, "k");
-    const auto sigma = toml::expect<real_type>(param, u8"σ").or_other(
-                       toml::expect<real_type>(param, "sigma")).unwrap();
+    const auto v0    = find_parameter<real_type>(param, env, "v0");
+    const auto k     = find_parameter<real_type>(param, env, "k");
+    const auto sigma = find_parameter<real_type>(param, env, "sigma", u8"σ");
 
     MJOLNIR_LOG_INFO("PeriodicGaussianPotential = {v0 = ", v0, ", k = ", k,
                      ", sigma = ", sigma, '}');
@@ -78,13 +81,13 @@ read_periodic_gaussian_potential(const toml::value& param)
 
 template<typename realT>
 FlexibleLocalAnglePotential<realT>
-read_flexible_local_angle_potential(const toml::value& param)
+read_flexible_local_angle_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto k     = toml::find<real_type                >(param, "k");
-    const auto term1 = toml::find<std::array<real_type, 10>>(param, "y");
-    const auto term2 = toml::find<std::array<real_type, 10>>(param, "d2y");
+    const auto k     = find_parameter<real_type                >(param, env, "k");
+    const auto term1 = find_parameter<std::array<real_type, 10>>(param, env, "y");
+    const auto term2 = find_parameter<std::array<real_type, 10>>(param, env, "d2y");
 
     MJOLNIR_LOG_INFO("FlexibleLocalAngle = {k = ", k,
                      ", y = ", term1, ", d2y = ", term2, '}');
@@ -93,13 +96,13 @@ read_flexible_local_angle_potential(const toml::value& param)
 
 template<typename realT>
 ClementiDihedralPotential<realT>
-read_clementi_dihedral_potential(const toml::value& param)
+read_clementi_dihedral_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    const auto v0 = toml::find<real_type>(param, "v0");
-    const auto k1 = toml::find<real_type>(param, "k1");
-    const auto k3 = toml::find<real_type>(param, "k3");
+    const auto v0 = find_parameter<real_type>(param, env, "v0");
+    const auto k1 = find_parameter<real_type>(param, env, "k1");
+    const auto k3 = find_parameter<real_type>(param, env, "k3");
 
     MJOLNIR_LOG_INFO("ClementiDihedral = {v0 = ", v0,
                      ", k1 = ", k1, ", k3 = ", k3, '}');
@@ -108,12 +111,12 @@ read_clementi_dihedral_potential(const toml::value& param)
 
 template<typename realT>
 FlexibleLocalDihedralPotential<realT>
-read_flexible_local_dihedral_potential(const toml::value& param)
+read_flexible_local_dihedral_potential(const toml::value& param, const toml::value& env)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     using real_type = realT;
-    auto k    = toml::find<real_type               >(param, "k");
-    auto term = toml::find<std::array<real_type, 7>>(param, "coef");
+    auto k    = find_parameter<real_type               >(param, env, "k");
+    auto term = find_parameter<std::array<real_type, 7>>(param, env, "coef");
 
     MJOLNIR_LOG_INFO("FlexibleLocalDihedral = {k = ", k, ", coef = ", term, '}');
     return FlexibleLocalDihedralPotential<realT>(k, term);
@@ -135,57 +138,64 @@ template<typename potentialT> struct read_local_potential_impl;
 template<typename realT>
 struct read_local_potential_impl<HarmonicPotential<realT>>
 {
-    static HarmonicPotential<realT> invoke(const toml::value& param)
+    static HarmonicPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_harmonic_potential<realT>(param);
+        return read_harmonic_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<GoContactPotential<realT>>
 {
-    static GoContactPotential<realT> invoke(const toml::value& param)
+    static GoContactPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_go_contact_potential<realT>(param);
+        return read_go_contact_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<GaussianPotential<realT>>
 {
-    static GaussianPotential<realT> invoke(const toml::value& param)
+    static GaussianPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_gaussian_potential<realT>(param);
+        return read_gaussian_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<PeriodicGaussianPotential<realT>>
 {
-    static PeriodicGaussianPotential<realT> invoke(const toml::value& param)
+    static PeriodicGaussianPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_periodic_gaussian_potential<realT>(param);
+        return read_periodic_gaussian_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<FlexibleLocalAnglePotential<realT>>
 {
-    static FlexibleLocalAnglePotential<realT> invoke(const toml::value& param)
+    static FlexibleLocalAnglePotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_flexible_local_angle_potential<realT>(param);
+        return read_flexible_local_angle_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<ClementiDihedralPotential<realT>>
 {
-    static ClementiDihedralPotential<realT> invoke(const toml::value& param)
+    static ClementiDihedralPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_clementi_dihedral_potential<realT>(param);
+        return read_clementi_dihedral_potential<realT>(param, env);
     }
 };
 template<typename realT>
 struct read_local_potential_impl<FlexibleLocalDihedralPotential<realT>>
 {
-    static FlexibleLocalDihedralPotential<realT> invoke(const toml::value& param)
+    static FlexibleLocalDihedralPotential<realT>
+    invoke(const toml::value& param, const toml::value& env)
     {
-        return read_flexible_local_dihedral_potential<realT>(param);
+        return read_flexible_local_dihedral_potential<realT>(param, env);
     }
 };
 } // namespace detail
@@ -206,15 +216,18 @@ read_local_potential(const toml::value& local)
     const auto& params = toml::find<toml::array>(local, "parameters");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
+    const auto& env = local.as_table().count("env") == 1 ?
+                      local.as_table().at("env") : toml::value{};
+
     std::vector<indices_potential_pair_t> retval;
     retval.reserve(params.size());
     for(const auto& item : params)
     {
-        const auto indices = toml::find<indices_t>(item, "indices");
+        const auto indices = find_parameter<indices_t>(item, env, "indices");
         MJOLNIR_LOG_INFO_NO_LF("idxs = ", indices, ", ");
 
         retval.emplace_back(indices,
-            detail::read_local_potential_impl<potentialT>::invoke(item));
+            detail::read_local_potential_impl<potentialT>::invoke(item, env));
     }
     return retval;
 }
@@ -238,6 +251,9 @@ read_local_potentials(const toml::value& local)
     const auto& params = toml::find<toml::array>(local, "parameters");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
+    const auto& env = local.as_table().count("env") == 1 ?
+                      local.as_table().at("env") : toml::value{};
+
     std::vector<indices_potential_pair_type> retval;
     retval.reserve(params.size());
     for(const auto& item : params)
@@ -246,15 +262,15 @@ read_local_potentials(const toml::value& local)
         using potential_1_type = potential1T<real_type>;
         using potential_2_type = potential2T<real_type>;
 
-        const auto indices = toml::find<indices_type>(item, "indices");
+        const auto indices = find_parameter<indices_type>(item, env, "indices");
         MJOLNIR_LOG_INFO("idxs = ", indices);
 
-        const auto& pot1 = toml::find(item, potential_1_type::name());
-        const auto& pot2 = toml::find(item, potential_2_type::name());
+        const auto& pot1 = find_parameter<toml::value>(item, env, potential_1_type::name());
+        const auto& pot2 = find_parameter<toml::value>(item, env, potential_2_type::name());
 
         retval.emplace_back(indices, potential_type(
-            detail::read_local_potential_impl<potential_1_type>::invoke(pot1),
-            detail::read_local_potential_impl<potential_2_type>::invoke(pot2))
+            detail::read_local_potential_impl<potential_1_type>::invoke(pot1, env),
+            detail::read_local_potential_impl<potential_2_type>::invoke(pot2, env))
         );
     }
     return retval;

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -2,6 +2,8 @@
 #define MJOLNIR_INPUT_UTILITY_HPP
 #include <extlib/toml/toml.hpp>
 #include <mjolnir/util/type_traits.hpp>
+#include <mjolnir/util/string.hpp>
+#include <mjolnir/util/logger.hpp>
 
 namespace mjolnir
 {
@@ -11,6 +13,7 @@ typename std::enable_if<negation<std::is_same<T, std::string>>::value, T>::type
 find_parameter(const toml::value& params, const toml::value& env,
                const std::string& name)
 {
+    using ::mjolnir::literals::string_literals::operator"" _s;
     if(!params.is_table() || params.as_table().count(name) != 1)
     {
         throw std::out_of_range(toml::format_error("[error] value "_s + name +
@@ -23,7 +26,7 @@ find_parameter(const toml::value& params, const toml::value& env,
         const std::string& var = p.as_string();
         if(!env.is_table() || env.as_table().count(var) != 1)
         {
-            throw std::out_of_range(toml::format_error("[error] named variable "_s
+            throw std::out_of_range(toml::format_error("[error] named variable "_s +
                 var + " does not exists"_s, env, "in this table"_s));
         }
         return toml::get<T>(env.as_table().at(var));
@@ -71,7 +74,7 @@ find_parameter(const toml::value& params, const toml::value& env,
                             params.as_table().at(name1)          :
                             params.as_table().at(name2)          ;
 
-    if(params.as_table.count(name2) == 1)
+    if(params.as_table().count(name2) == 1)
     {
         MJOLNIR_LOG_WARN("[warning] deprecated name ", name2, " is used. Use ",
                          name1, " instead.");
@@ -82,7 +85,7 @@ find_parameter(const toml::value& params, const toml::value& env,
         const std::string& var = p.as_string();
         if(!env.is_table() || env.as_table().count(var) != 1)
         {
-            throw std::out_of_range(toml::format_error("[error] named variable "_s
+            throw std::out_of_range(toml::format_error("[error] named variable "_s +
                 var + " does not exists"_s, env, "in this table"_s));
         }
         return toml::get<T>(env.as_table().at(var));

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -76,8 +76,8 @@ find_parameter(const toml::value& params, const toml::value& env,
 
     if(params.as_table().count(name2) == 1)
     {
-        MJOLNIR_LOG_WARN("[warning] deprecated name ", name2, " is used. Use ",
-                         name1, " instead.");
+        MJOLNIR_LOG_WARN("deprecated name \"", name2, "\" is used. Use \"",
+                         name1, "\" instead.");
     }
     if(p.is_string())
     {

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -24,10 +24,15 @@ find_parameter(const toml::value& params, const toml::value& env,
     {
         // search inside of `env`
         const std::string& var = p.as_string();
+        if(env.is_uninitialized())
+        {
+            throw std::out_of_range(toml::format_error("[error] named variable \""_s +
+                var + "\" used but no env is defined"_s, params, "used here"_s));
+        }
         if(!env.is_table() || env.as_table().count(var) != 1)
         {
-            throw std::out_of_range(toml::format_error("[error] named variable "_s +
-                var + " does not exists"_s, env, "in this table"_s));
+            throw std::out_of_range(toml::format_error("[error] named variable \""_s +
+                var + "\" does not exists"_s, env, "in this table"_s));
         }
         return toml::get<T>(env.as_table().at(var));
     }
@@ -43,18 +48,27 @@ find_parameter(const toml::value& params, const toml::value& /* env */,
 {
     if(!params.is_table() || params.as_table().count(name) != 1)
     {
-        throw std::out_of_range(toml::format_error("[error] value "_s + name +
-            " does not exists"_s, params, "in this table"_s));
+        throw std::out_of_range(toml::format_error("[error] value \""_s + name +
+            "\" does not exists"_s, params, "in this table"_s));
     }
     const toml::value& p = params.as_table().at(name);
     return toml::get<T>(p);
 }
 
-// The previous versions of Mjolnir allow to use unicode character when defining
-// a parameter. But since it is a bit ambiguous because the same character might
-// appear in the unicode table several time with different styles, so I decided
-// to deprecate them. This function was introduced to support those multi-named
-// parameters but is planned to be removed in v1.4.0.
+// The current version of Mjolnir allow to use unicode character when defining
+// a parameter. But since it is a bit ambiguous because of some reasons. E.g.
+// - The same character might appear in the unicode table several time with
+//   different styles
+// - When the different parameters appear in different names, it is ofcourse
+//   ambiguous which one to be used.
+//
+// So I decided to deprecate them. At first I thought that a unicode names
+// ware covenient to reduce the size of input file. But now, since env is
+// introduced, it is more effective for reducing the file size. So if it works
+// nice after the next release, I will deprecate unicode names and warn if used.
+//
+// This function was introduced to support those
+// multi-named parameters but is planned to be removed in the later release.
 template<typename T>
 typename std::enable_if<negation<std::is_same<T, std::string>>::value, T>::type
 find_parameter(const toml::value& params, const toml::value& env,
@@ -66,27 +80,32 @@ find_parameter(const toml::value& params, const toml::value& env,
     if(!params.is_table() || (params.as_table().count(name1) == 0 &&
                               params.as_table().count(name2) == 0))
     {
-        throw std::out_of_range(toml::format_error("[error] value "_s + name1 +
-            " or "_s + name2 + " does not exists"_s, params, "in this table"_s));
+        throw std::out_of_range(toml::format_error("[error] value \""_s + name1 +
+            "\" or \""_s + name2 + "\" does not exists"_s, params, "in this table"_s));
     }
     // name1 has priority.
     const toml::value& p = (params.as_table().count(name1) == 1) ?
                             params.as_table().at(name1)          :
                             params.as_table().at(name2)          ;
 
-    if(params.as_table().count(name2) == 1)
-    {
-        MJOLNIR_LOG_WARN("deprecated name \"", name2, "\" is used. Use \"",
-                         name1, "\" instead.");
-    }
+//     if(params.as_table().count(name2) == 1)
+//     {
+//         MJOLNIR_LOG_WARN("deprecated name \"", name2, "\" is used. Use \"",
+//                          name1, "\" instead.");
+//     }
     if(p.is_string())
     {
         // search inside of `env`
         const std::string& var = p.as_string();
+        if(env.is_uninitialized())
+        {
+            throw std::out_of_range(toml::format_error("[error] named variable \""_s +
+                var + "\" used but no env is defined"_s, params, "used here"_s));
+        }
         if(!env.is_table() || env.as_table().count(var) != 1)
         {
-            throw std::out_of_range(toml::format_error("[error] named variable "_s +
-                var + " does not exists"_s, env, "in this table"_s));
+            throw std::out_of_range(toml::format_error("[error] named variable \""_s +
+                var + "\" does not exists"_s, env, "in this table"_s));
         }
         return toml::get<T>(env.as_table().at(var));
     }

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -1,0 +1,94 @@
+#ifndef MJOLNIR_INPUT_UTILITY_HPP
+#define MJOLNIR_INPUT_UTILITY_HPP
+#include <extlib/toml/toml.hpp>
+#include <mjolnir/util/type_traits.hpp>
+
+namespace mjolnir
+{
+
+template<typename T>
+typename std::enable_if<negation<std::is_same<T, std::string>>::value, T>::type
+find_parameter(const toml::value& params, const toml::value& env,
+               const std::string& name)
+{
+    if(!params.is_table() || params.as_table().count(name) != 1)
+    {
+        throw std::out_of_range(toml::format_error("[error] value "_s + name +
+            " does not exists"_s, params, "in this table"_s));
+    }
+    const toml::value& p = params.as_table().at(name);
+    if(p.is_string())
+    {
+        // search inside of `env`
+        const std::string& var = p.as_string();
+        if(!env.is_table() || env.as_table().count(var) != 1)
+        {
+            throw std::out_of_range(toml::format_error("[error] named variable "_s
+                var + " does not exists"_s, env, "in this table"_s));
+        }
+        return toml::get<T>(env.as_table().at(var));
+    }
+    return toml::get<T>(p);
+}
+
+// If the expected value is std::string, it is difficult to distinguish
+// variable name and the value itself. In that case, env would just be ignored.
+template<typename T>
+typename std::enable_if<std::is_same<T, std::string>::value, std::string>::type
+find_parameter(const toml::value& params, const toml::value& /* env */,
+               const std::string& name)
+{
+    if(!params.is_table() || params.as_table().count(name) != 1)
+    {
+        throw std::out_of_range(toml::format_error("[error] value "_s + name +
+            " does not exists"_s, params, "in this table"_s));
+    }
+    const toml::value& p = params.as_table().at(name);
+    return toml::get<T>(p);
+}
+
+// The previous versions of Mjolnir allow to use unicode character when defining
+// a parameter. But since it is a bit ambiguous because the same character might
+// appear in the unicode table several time with different styles, so I decided
+// to deprecate them. This function was introduced to support those multi-named
+// parameters but is planned to be removed in v1.4.0.
+template<typename T>
+typename std::enable_if<negation<std::is_same<T, std::string>>::value, T>::type
+find_parameter(const toml::value& params, const toml::value& env,
+               const std::string& name1,  const std::string& name2)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    MJOLNIR_LOG_FUNCTION();
+
+    if(!params.is_table() || (params.as_table().count(name1) == 0 &&
+                              params.as_table().count(name2) == 0))
+    {
+        throw std::out_of_range(toml::format_error("[error] value "_s + name1 +
+            " or "_s + name2 + " does not exists"_s, params, "in this table"_s));
+    }
+    // name1 has priority.
+    const toml::value& p = (params.as_table().count(name1) == 1) ?
+                            params.as_table().at(name1)          :
+                            params.as_table().at(name2)          ;
+
+    if(params.as_table.count(name2) == 1)
+    {
+        MJOLNIR_LOG_WARN("[warning] deprecated name ", name2, " is used. Use ",
+                         name1, " instead.");
+    }
+    if(p.is_string())
+    {
+        // search inside of `env`
+        const std::string& var = p.as_string();
+        if(!env.is_table() || env.as_table().count(var) != 1)
+        {
+            throw std::out_of_range(toml::format_error("[error] named variable "_s
+                var + " does not exists"_s, env, "in this table"_s));
+        }
+        return toml::get<T>(env.as_table().at(var));
+    }
+    return toml::get<T>(p);
+}
+
+} // mjolnir
+#endif// MJOLNIR_INPUT_UTILITY_HPP

--- a/test/core/test_read_clementi_dihedral_potential.cpp
+++ b/test/core/test_read_clementi_dihedral_potential.cpp
@@ -7,15 +7,25 @@
 #endif
 
 #include <mjolnir/input/read_local_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_clementi_dihedral_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_clementi_dihedral_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_clementi_dihedral.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
+        const toml::value env;
         const toml::value v = u8R"(
             indices = [1, 2, 3, 4]
             k1 = 3.14
@@ -23,44 +33,48 @@ BOOST_AUTO_TEST_CASE(read_clementi_dihedral_double)
             v0 = 2.71
         )"_toml;
 
-        const auto g = mjolnir::read_clementi_dihedral_potential<real_type>(v);
-        BOOST_TEST(g.k1() == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.k3() == 0.577, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0() == 2.71,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_clementi_dihedral_potential<real_type>(v, env);
+        BOOST_TEST(g.k1() == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.k3() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.v0() == real_type(2.71),  tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_clementi_dihedral_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_clementi_dihedral_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_clementi_dihedral.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
-        const toml::value v = u8R"(
+        const auto env = u8R"(
             indices = [1, 2, 3, 4]
             k1 = 3.14
             k3 = 0.577
             v0 = 2.71
         )"_toml;
+        const auto v = u8R"(
+            indices = "indices"
+            k1 = "k1"
+            k3 = "k3"
+            v0 = "v0"
+        )"_toml;
 
-        const auto g = mjolnir::read_clementi_dihedral_potential<real_type>(v);
-        BOOST_TEST(g.k1() == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.k3() == 0.577f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0() == 2.71f,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_clementi_dihedral_potential<real_type>(v, env);
+        BOOST_TEST(g.k1() == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.k3() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.v0() == real_type(2.71),  tolerance<real_type>());
     }
 }
 
 // ---------------------------------------------------------------------------
 // read_local_potential
 
-BOOST_AUTO_TEST_CASE(read_local_potential_clementi_dihedral_double)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_clementi_dihedral_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_clementi_dihedral.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -76,23 +90,25 @@ BOOST_AUTO_TEST_CASE(read_local_potential_clementi_dihedral_double)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k1() == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.k3() == 0.577, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0() == 2.71,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k1() == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.k3() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0() == real_type(2.71),  tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_clementi_dihedral_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_clementi_dihedral_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_clementi_dihedral.log");
 
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
+            env.pi    = 3.14
+            env.gamma = 0.577
+            env.e     = 2.71
             parameters = [
-                {indices = [1, 2, 3, 4], k1 = 3.14, k3 = 0.577, v0 = 2.71}
+                {indices = [1, 2, 3, 4], k1 = "pi", k3 = "gamma", v0 = "e"}
             ]
         )"_toml;
 
@@ -103,8 +119,8 @@ BOOST_AUTO_TEST_CASE(read_local_potential_clementi_dihedral_float)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k1() == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.k3() == 0.577f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0() == 2.71f,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k1() == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.k3() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0() == real_type(2.71),  tolerance<real_type>());
     }
 }

--- a/test/core/test_read_debye_huckel_potential.cpp
+++ b/test/core/test_read_debye_huckel_potential.cpp
@@ -7,13 +7,22 @@
 #endif
 
 #include <mjolnir/input/read_global_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_debye_huckel_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_debye_huckel_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_debye_huckel.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -51,20 +60,20 @@ BOOST_AUTO_TEST_CASE(read_debye_huckel_double)
         BOOST_TEST(g.participants().at(4)  ==   7u);
         BOOST_TEST(g.participants().at(5)  == 100u);
 
-        BOOST_TEST(g.charges().at(  0)  ==   1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  1)  ==  -1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  3)  ==   0.3, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  5)  ==   0.5, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  7)  ==   0.7, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(100)  == 100.0, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.charges().at(  0)  == real_type(  1.0), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  1)  == real_type( -1.0), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  3)  == real_type(  0.3), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  5)  == real_type(  0.5), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  7)  == real_type(  0.7), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(100)  == real_type(100.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_debye_huckel_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_debye_huckel_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_debye_huckel.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
+
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -74,13 +83,16 @@ BOOST_AUTO_TEST_CASE(read_debye_huckel_float)
             ignore.molecule                 = "Nothing"
             ignore.particles_within.bond    = 3
             ignore.particles_within.contact = 1
+            env.positive = 1.0
+            env.negative = -1.0
+            env.toomuch  = 100.0
             parameters = [
-                {index =   0, charge =   1.0},
-                {index =   1, charge =  -1.0},
+                {index =   0, charge = "positive"},
+                {index =   1, charge = "negative"},
                 {index =   3, charge =   0.3},
                 {index =   5, charge =   0.5},
                 {index =   7, charge =   0.7},
-                {index = 100, charge = 100.0},
+                {index = 100, charge = "toomuch"},
             ]
         )"_toml;
 
@@ -102,10 +114,11 @@ BOOST_AUTO_TEST_CASE(read_debye_huckel_float)
         BOOST_TEST(g.participants().at(4)  ==   7u);
         BOOST_TEST(g.participants().at(5)  == 100u);
 
-        BOOST_TEST(g.charges().at(  0)  ==   1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  1)  ==  -1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  3)  ==   0.3f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  5)  ==   0.5f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(  7)  ==   0.7f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.charges().at(100)  == 100.0f, boost::test_tools::tolerance(tol));
-    }}
+        BOOST_TEST(g.charges().at(  0)  == real_type(  1.0), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  1)  == real_type( -1.0), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  3)  == real_type(  0.3), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  5)  == real_type(  0.5), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(  7)  == real_type(  0.7), tolerance<real_type>());
+        BOOST_TEST(g.charges().at(100)  == real_type(100.0), tolerance<real_type>());
+    }
+}

--- a/test/core/test_read_excluded_volume_wall_potential.cpp
+++ b/test/core/test_read_excluded_volume_wall_potential.cpp
@@ -7,13 +7,22 @@
 #endif
 
 #include <mjolnir/input/read_external_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_excluded_volume_wall_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_excluded_volume_wall_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_excluded_volume_wall.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -33,39 +42,40 @@ BOOST_AUTO_TEST_CASE(read_excluded_volume_wall_double)
         const auto g = mjolnir::read_excluded_volume_wall_potential<real_type>(v);
 
         BOOST_TEST(g.parameters().size() == 2u);
-        BOOST_TEST(g.parameters().at(0)  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1)  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon()           == 3.14, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.parameters().at(0)  == real_type(2.0 ), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1)  == real_type(2.0 ), tolerance<real_type>());
+        BOOST_TEST(g.epsilon()           == real_type(3.14), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_excluded_volume_wall_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_excluded_volume_wall_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_excluded_volume_wall.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
-            interaction             = "Distance"
-            potential               = "ExcludedVolumeWall"
-            shape.name              = "AxisAlignedPlane"
-            shape.axis              = "-X"
-            shape.position          = 1.0
-            shape.margin            = 0.5
-            epsilon                 = 3.14
-            parameters  = [
-                {index = 0, radius = 2.0},
-                {index = 1, radius = 2.0},
+            interaction    = "Distance"
+            potential      = "ExcludedVolumeWall"
+            shape.name     = "AxisAlignedPlane"
+            shape.axis     = "-X"
+            shape.position = 1.0
+            shape.margin   = 0.5
+            epsilon        = 3.14
+            env.large = 10.0
+            env.small = 0.01
+            parameters     = [
+                {index = 0, radius = "large"},
+                {index = 1, radius = "small"},
             ]
         )"_toml;
 
         const auto g = mjolnir::read_excluded_volume_wall_potential<real_type>(v);
 
         BOOST_TEST(g.parameters().size() == 2u);
-        BOOST_TEST(g.parameters().at(0)  == 2.0f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1)  == 2.0f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon()           == 3.14f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.parameters().at(0)  == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1)  == real_type(0.01), tolerance<real_type>());
+        BOOST_TEST(g.epsilon()           == real_type(3.14), tolerance<real_type>());
     }
 }

--- a/test/core/test_read_flexible_local_angle_potential.cpp
+++ b/test/core/test_read_flexible_local_angle_potential.cpp
@@ -7,15 +7,25 @@
 #endif
 
 #include <mjolnir/input/read_local_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_flexible_local_angle_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_flexible_local_angle_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_angle.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
+        const toml::value env;
         const toml::value v = u8R"(
             indices = [1, 2, 3]
             k       = 3.14
@@ -23,79 +33,81 @@ BOOST_AUTO_TEST_CASE(read_flexible_local_angle_double)
             d2y     = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         )"_toml;
 
-        const auto g = mjolnir::read_flexible_local_angle_potential<real_type>(v);
-        BOOST_TEST(g.k()   == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[6] ==  7.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[7] ==  8.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[8] ==  9.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[9] == 10.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[6] ==  7.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[7] ==  8.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[8] ==  9.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[9] == 10.0, boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_flexible_local_angle_potential<real_type>(v, env);
+        BOOST_TEST(g.k()      == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.y()[0]   == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[1]   == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[2]   == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[3]   == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[4]   == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[5]   == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[6]   == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[7]   == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[8]   == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[9]   == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[6] == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[7] == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[8] == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[9] == real_type(10.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_flexible_local_angle_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_flexible_local_angle_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_angle.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
-        const toml::value v = u8R"(
+        const toml::value env = u8R"(
             indices = [1, 2, 3]
             k       = 3.14
             y       = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
             d2y     = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         )"_toml;
+        const toml::value v = u8R"(
+            indices = "indices"
+            k       = "k"
+            y       = "y"
+            d2y     = "d2y"
+        )"_toml;
 
-        const auto g = mjolnir::read_flexible_local_angle_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[6] ==  7.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[7] ==  8.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[8] ==  9.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.y()[9] == 10.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[6] ==  7.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[7] ==  8.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[8] ==  9.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.d2y()[9] == 10.0f, boost::test_tools::tolerance(tol));    }
+        const auto g = mjolnir::read_flexible_local_angle_potential<real_type>(v, env);
+        BOOST_TEST(g.k()      == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.y()[0]   == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[1]   == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[2]   == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[3]   == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[4]   == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[5]   == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[6]   == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[7]   == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[8]   == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.y()[9]   == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[6] == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[7] == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[8] == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.d2y()[9] == real_type(10.0), tolerance<real_type>());
+    }
 }
 
-// ---------------------------------------------------------------------------
-// read_local_potential
-
-BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_angle_double)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_flexible_local_angle_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_angle.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -111,41 +123,43 @@ BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_angle_double)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()   == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[6] ==  7.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[7] ==  8.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[8] ==  9.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[9] == 10.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[6] ==  7.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[7] ==  8.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[8] ==  9.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[9] == 10.0, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()      == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[0]   == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[1]   == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[2]   == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[3]   == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[4]   == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[5]   == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[6]   == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[7]   == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[8]   == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[9]   == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[6] == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[7] == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[8] == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[9] == real_type(10.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_angle_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_flexible_local_angle_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_angle.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
+            env.pi  = 3.14
+            env.y   = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+            env.d2y = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
             parameters = [
-                {indices = [1, 2, 3], k = 3.14, y = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0], d2y = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]}
+                {indices = [1, 2, 3], k = "pi", y = "y", d2y = "d2y"}
             ]
         )"_toml;
 
@@ -156,25 +170,26 @@ BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_angle_float)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[6] ==  7.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[7] ==  8.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[8] ==  9.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.y()[9] == 10.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[6] ==  7.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[7] ==  8.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[8] ==  9.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.d2y()[9] == 10.0f, boost::test_tools::tolerance(tol));    }
+        BOOST_TEST(g.at(0).second.k()      == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[0]   == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[1]   == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[2]   == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[3]   == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[4]   == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[5]   == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[6]   == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[7]   == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[8]   == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.y()[9]   == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[6] == real_type( 7.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[7] == real_type( 8.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[8] == real_type( 9.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.d2y()[9] == real_type(10.0), tolerance<real_type>());
+    }
 }

--- a/test/core/test_read_flexible_local_dihedral_potential.cpp
+++ b/test/core/test_read_flexible_local_dihedral_potential.cpp
@@ -7,65 +7,78 @@
 #endif
 
 #include <mjolnir/input/read_local_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_flexible_local_dihedral_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_flexible_local_dihedral_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_dihedral.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
+        const toml::value env;
         const toml::value v = u8R"(
             indices = [1, 2, 3, 4]
             k       = 3.14
             coef    = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         )"_toml;
 
-        const auto g = mjolnir::read_flexible_local_dihedral_potential<real_type>(v);
-        BOOST_TEST(g.k()       == 3.14, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[6] ==  7.0, boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_flexible_local_dihedral_potential<real_type>(v, env);
+        BOOST_TEST(g.k()       == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.coef()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[6] == real_type( 7.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_flexible_local_dihedral_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_flexible_local_dihedral_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_dihedral.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
-        const toml::value v = u8R"(
+        const toml::value env = u8R"(
             indices = [1, 2, 3, 4]
             k       = 3.14
             coef    = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
         )"_toml;
+        const toml::value v = u8R"(
+            indices = "indices"
+            k       = "k"
+            coef    = "coef"
+        )"_toml;
 
-        const auto g = mjolnir::read_flexible_local_dihedral_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.coef()[6] ==  7.0f, boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_flexible_local_dihedral_potential<real_type>(v, env);
+        BOOST_TEST(g.k()       == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.coef()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.coef()[6] == real_type( 7.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_dihedral_double)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_flexible_local_dihedral_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_dihedral.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -81,28 +94,29 @@ BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_dihedral_double)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()       == 3.14, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[0] ==  1.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[1] ==  2.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[2] ==  3.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[3] ==  4.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[4] ==  5.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[5] ==  6.0, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[6] ==  7.0, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()       == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[6] == real_type( 7.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_dihedral_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_flexible_local_dihedral_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_flexible_local_dihedral.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
+            env.pi = 3.14
+            env.coef = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
             parameters = [
-                {indices = [1, 2, 3, 4], k = 3.14, coef = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]}
+                {indices = [1, 2, 3, 4], k = "pi", coef = "coef"}
             ]
         )"_toml;
 
@@ -113,13 +127,13 @@ BOOST_AUTO_TEST_CASE(read_local_potential_flexible_local_dihedral_float)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()       == 3.14f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[0] ==  1.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[1] ==  2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[2] ==  3.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[3] ==  4.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[4] ==  5.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[5] ==  6.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.coef()[6] ==  7.0f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()       == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[0] == real_type( 1.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[1] == real_type( 2.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[2] == real_type( 3.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[3] == real_type( 4.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[4] == real_type( 5.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[5] == real_type( 6.0), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.coef()[6] == real_type( 7.0), tolerance<real_type>());
     }
 }

--- a/test/core/test_read_gaussian_potential.cpp
+++ b/test/core/test_read_gaussian_potential.cpp
@@ -7,125 +7,118 @@
 #endif
 
 #include <mjolnir/input/read_local_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_gaussian_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_gaussian_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_gaussian.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
-        const toml::value v = toml::table{
-            {"indices", toml::value({1, 2})},
-            {"k",       toml::value(3.14)},
-            {"sigma",   toml::value(.577)},
-            {"v0",      toml::value(2.71)}
-        };
-        const auto g = mjolnir::read_gaussian_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.sigma() == 0.577, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0()    == 2.71,  boost::test_tools::tolerance(tol));
-    }
+        using namespace toml::literals;
+        const toml::value env;
+        const auto v = u8R"(
+            indices = [1, 2]
+            k       = 3.14
+            sigma   = 0.577
+            v0      = 2.71
+        )"_toml;
 
-    {
-        const toml::value v = toml::table{
-            {"indices", toml::value({1, 2})},
-            {"k",       toml::value(3.14)},
-            {u8"σ",     toml::value(.577)},
-            {"v0",      toml::value(2.71)}
-        };
-        const auto g = mjolnir::read_gaussian_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.sigma() == 0.577, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0()    == 2.71,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_gaussian_potential<real_type>(v, env);
+        BOOST_TEST(g.k()     == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.sigma() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.v0()    == real_type(2.71),  tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_gaussian_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_gaussian_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_gaussian.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
-        const toml::value v = toml::table{
-            {"indices", toml::value({1, 2})},
-            {"k",       toml::value(3.14)},
-            {"sigma",   toml::value(.577)},
-            {"v0",      toml::value(2.71)}
-        };
-        const auto g = mjolnir::read_gaussian_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.sigma() == 0.577f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
-    }
+        using namespace toml::literals;
+        const auto env = u8R"(
+            indices = [1, 2]
+            k       = 3.14
+            sigma   = 0.577
+            v0      = 2.71
+        )"_toml;
+        const auto v = u8R"(
+            indices = "indices"
+            k       = "k"
+            sigma   = "sigma"
+            v0      = "v0"
+        )"_toml;
 
-    {
-        const toml::value v = toml::table{
-            {"indices", toml::value({1, 2})},
-            {"k",       toml::value(3.14)},
-            {u8"σ",     toml::value(.577)},
-            {"v0",      toml::value(2.71)}
-        };
-        const auto g = mjolnir::read_gaussian_potential<real_type>(v);
-        BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.sigma() == 0.577f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_gaussian_potential<real_type>(v, env);
+        BOOST_TEST(g.k()     == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.sigma() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.v0()    == real_type(2.71),  tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_gaussian_double)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_gaussian_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_gaussian.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
-        const toml::value v = toml::table{
-            {"parameters", toml::value({toml::table{
-                    {"indices", toml::value({1, 2})},
-                    {"k",       toml::value(3.14)},
-                    {"sigma",   toml::value(.577)},
-                    {"v0",      toml::value(2.71)}
-                }})}
-        };
+        using namespace toml::literals;
+        const auto v = u8R"(
+            parameters = [
+                {indices = [1,2], k = 3.14, sigma = 0.577, v0 = 2.71}
+            ]
+        )"_toml;
+
         const auto g = mjolnir::read_local_potential<2,
-              mjolnir::GaussianPotential<real_type>>(v);
+            mjolnir::GaussianPotential<real_type>>(v);
 
         const std::array<std::size_t, 2> ref_idx{{1, 2}};
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()     == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.sigma() == 0.577, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0()    == 2.71,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()     == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.sigma() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0()    == real_type(2.71),  tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_gaussian_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_gaussian_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_gaussian.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
-        const toml::value v = toml::table{
-            {"parameters", toml::value({toml::table{
-                    {"indices", toml::value({1, 2})},
-                    {"k",       toml::value(3.14)},
-                    {"sigma",   toml::value(.577)},
-                    {"v0",      toml::value(2.71)}
-                }})}
-        };
+        using namespace toml::literals;
+        const auto v = u8R"(
+            env.indices = [1, 2]
+            env.pi      = 3.14
+            env.e       = 2.71
+            env.gamma   = 0.577
+            parameters = [
+                {indices = [1,2], k = "pi", sigma = "gamma", v0 = "e"}
+            ]
+        )"_toml;
+
         const auto g = mjolnir::read_local_potential<2,
-              mjolnir::GaussianPotential<real_type>>(v);
+            mjolnir::GaussianPotential<real_type>>(v);
 
         const std::array<std::size_t, 2> ref_idx{{1, 2}};
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()     == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.sigma() == 0.577f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()     == real_type(3.14),  tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.sigma() == real_type(0.577), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0()    == real_type(2.71),  tolerance<real_type>());
     }
 }

--- a/test/core/test_read_go_contact_potential.cpp
+++ b/test/core/test_read_go_contact_potential.cpp
@@ -7,53 +7,66 @@
 #endif
 
 #include <mjolnir/input/read_local_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_go_contact_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_go_contact_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_go_contact.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
+        const toml::value env;
         const auto v = u8R"(
             indices = [1, 2]
             k       = 3.14
             v0      = 2.71
         )"_toml;
 
-        const auto g = mjolnir::read_go_contact_potential<real_type>(v);
-        BOOST_TEST(g.k()  == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0() == 2.71,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_go_contact_potential<real_type>(v, env);
+        BOOST_TEST(g.k()  == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.v0() == real_type(2.71), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_go_contact_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_go_contact_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_go_contact.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
-        const auto v = u8R"(
+        const auto env = u8R"(
             indices = [1, 2]
             k       = 3.14
             v0      = 2.71
         )"_toml;
+        const auto v = u8R"(
+            indices = "indices"
+            k       = "k"
+            v0      = "v0"
+        )"_toml;
 
-        const auto g = mjolnir::read_go_contact_potential<real_type>(v);
-        BOOST_TEST(g.k()  == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.v0() == 2.71f,  boost::test_tools::tolerance(tol));
+        const auto g = mjolnir::read_go_contact_potential<real_type>(v, env);
+        BOOST_TEST(g.k()  == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.v0() == real_type(2.71), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_go_contact_potential_double)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_go_contact_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_harmonic.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const auto v = u8R"(
@@ -69,22 +82,24 @@ BOOST_AUTO_TEST_CASE(read_local_potential_go_contact_potential_double)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()  == 3.14,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0() == 2.71,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()  == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0() == real_type(2.71), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_local_potential_go_contact_potential_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_local_potential_go_contact_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_harmonic.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const auto v = u8R"(
+            env.indices = [1, 2]
+            env.pi      = 3.14
+            env.e       = 2.71
             parameters = [
-                {indices = [1,2], k = 3.14, v0 = 2.71}
+                {indices = "indices", k = "pi", v0 = "e"}
             ]
         )"_toml;
 
@@ -95,7 +110,7 @@ BOOST_AUTO_TEST_CASE(read_local_potential_go_contact_potential_float)
 
         BOOST_TEST(g.size() == 1u);
         BOOST_TEST(g.at(0).first == ref_idx);
-        BOOST_TEST(g.at(0).second.k()  == 3.14f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.at(0).second.v0() == 2.71f,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.k()  == real_type(3.14), tolerance<real_type>());
+        BOOST_TEST(g.at(0).second.v0() == real_type(2.71), tolerance<real_type>());
     }
 }

--- a/test/core/test_read_harmonic_restraint_potential.cpp
+++ b/test/core/test_read_harmonic_restraint_potential.cpp
@@ -6,12 +6,22 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 #include <mjolnir/input/read_external_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_harmonic_restraint_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_harmonic_restraint_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_harmonic_restraint.log");
 
-    using real_type = double;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -26,36 +36,39 @@ BOOST_AUTO_TEST_CASE(read_harmonic_restraint_double)
         const auto h = mjolnir::read_harmonic_restraint_potential<real_type>(v);
 
         BOOST_TEST(h.parameters().size() == 2u);
-        BOOST_TEST(h.parameters().at(0).first  == 10.0);
-        BOOST_TEST(h.parameters().at(0).second ==  0.0);
-        BOOST_TEST(h.parameters().at(1).first  == 20.0);
-        BOOST_TEST(h.parameters().at(1).second ==  1.0);
+        BOOST_TEST(h.parameters().at(0).first  == real_type(10.0), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(0).second == real_type( 0.0), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(1).first  == real_type(20.0), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(1).second == real_type( 1.0), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_harmonic_restraint_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_harmonic_restraint_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_harmonic_restraint.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4; // for conversion between double <-> float
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
             interaction = "PositionRestraint"
             potential   = "Harmonic"
+            env.strong = 100.0
+            env.weak   =   0.1
+            env.just   =   0.0
+            env.far    = 100.0
             parameters  = [
-                {position = [0.0, 0.0, 0.0], index = 0, k = 10.0, v0 = 0.0},
-                {position = [1.0, 2.0, 2.0], index = 1, k = 20.0, v0 = 1.0},
+                {position = [0.0, 0.0, 0.0], index = 0, k = "strong", v0 = "just"},
+                {position = [1.0, 2.0, 2.0], index = 1, k = "weak",   v0 = "far"},
             ]
         )"_toml;
 
         const auto h = mjolnir::read_harmonic_restraint_potential<real_type>(v);
 
         BOOST_TEST(h.parameters().size() == 2u);
-        BOOST_TEST(h.parameters().at(0).first  == 10.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(h.parameters().at(0).second ==  0.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(h.parameters().at(1).first  == 20.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(h.parameters().at(1).second ==  1.0f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(h.parameters().at(0).first  == real_type(100.0), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(0).second == real_type(  0.0), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(1).first  == real_type(  0.1), tolerance<real_type>());
+        BOOST_TEST(h.parameters().at(1).second == real_type(100.0), tolerance<real_type>());
     }
 }

--- a/test/core/test_read_implicit_membrane_potential.cpp
+++ b/test/core/test_read_implicit_membrane_potential.cpp
@@ -6,13 +6,22 @@
 #include <boost/test/included/unit_test.hpp>
 #endif
 #include <mjolnir/input/read_external_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_implicit_membrane_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_implicit_membrane_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_implicit_membrane.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const auto v = u8R"(
@@ -33,21 +42,20 @@ BOOST_AUTO_TEST_CASE(read_implicit_membrane_double)
 
         const auto g = mjolnir::read_implicit_membrane_potential<real_type>(v);
 
-        BOOST_TEST(g.hydrophobicities().size()     == 2u);
-        BOOST_TEST(g.hydrophobicities().at(0)      == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.hydrophobicities().at(1)      == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.half_thick()            == 3.14 * 0.5, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.interaction_magnitude() == 6.28, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.bend()                  == 9.42, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.hydrophobicities().size() == 2u);
+        BOOST_TEST(g.hydrophobicities().at(0)  == real_type(2.0       ), tolerance<real_type>());
+        BOOST_TEST(g.hydrophobicities().at(1)  == real_type(2.0       ), tolerance<real_type>());
+        BOOST_TEST(g.half_thick()              == real_type(3.14 * 0.5), tolerance<real_type>());
+        BOOST_TEST(g.interaction_magnitude()   == real_type(6.28      ), tolerance<real_type>());
+        BOOST_TEST(g.bend()                    == real_type(9.42      ), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_implicit_membrane_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_implicit_membrane_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_implicit_membrane.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const auto v = u8R"(
@@ -60,19 +68,23 @@ BOOST_AUTO_TEST_CASE(read_implicit_membrane_float)
             thickness      = 3.14
             interaction_magnitude = 6.28
             bend                  = 9.42
+            env.hydrophilic =   0.0
+            env.hydrophobic = 100.0
             parameters = [
-                {index = 0, hydrophobicity = 2.0},
-                {index = 1, hydrophobicity = 2.0},
+                {index = 0, hydrophobicity = "hydrophilic"},
+                {index = 1, hydrophobicity = "hydrophobic"},
             ]
         )"_toml;
 
         const auto g = mjolnir::read_implicit_membrane_potential<real_type>(v);
 
-        BOOST_TEST(g.hydrophobicities().size()     == 2u);
-        BOOST_TEST(g.hydrophobicities().at(0)      == 2.0f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.hydrophobicities().at(1)      == 2.0f,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.half_thick()             == 3.14f * 0.5f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.interaction_magnitude() == 6.28f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.bend()                  == 9.42f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.hydrophobicities().size() == 2u);
+        BOOST_TEST(g.hydrophobicities().at(0)  == real_type(  0.0     ), tolerance<real_type>());
+        BOOST_TEST(g.hydrophobicities().at(1)  == real_type(100.0     ), tolerance<real_type>());
+        BOOST_TEST(g.half_thick()              == real_type(3.14 * 0.5), tolerance<real_type>());
+        BOOST_TEST(g.interaction_magnitude()   == real_type(6.28      ), tolerance<real_type>());
+        BOOST_TEST(g.bend()                    == real_type(9.42      ), tolerance<real_type>());
     }
 }
+
+

--- a/test/core/test_read_lennard_jones_wall_potential.cpp
+++ b/test/core/test_read_lennard_jones_wall_potential.cpp
@@ -7,13 +7,22 @@
 #endif
 
 #include <mjolnir/input/read_external_potential.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_lennard_jones_wall_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_lennard_jones_wall_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_lennard_jones_wall.log");
 
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -34,23 +43,22 @@ BOOST_AUTO_TEST_CASE(read_lennard_jones_wall_double)
         const auto g = mjolnir::read_lennard_jones_wall_potential<real_type>(v);
 
         BOOST_TEST(g.parameters().size() == 4u);
-        BOOST_TEST(g.parameters().at(0).first  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1).first  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(2).first  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(3).first  == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(0).second == 1.5,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1).second == 1.5,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(2).second == 1.5,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(3).second == 1.5,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.parameters().at(0).first  == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1).first  == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(2).first  == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(3).first  == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(0).second == real_type(1.5), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1).second == real_type(1.5), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(2).second == real_type(1.5), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(3).second == real_type(1.5), tolerance<real_type>());
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_lennard_jones_wall_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_lennard_jones_wall_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_lennard_jones_wall.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
 
+    using real_type = T;
     {
         using namespace toml::literals;
         const toml::value v = u8R"(
@@ -60,24 +68,28 @@ BOOST_AUTO_TEST_CASE(read_lennard_jones_wall_float)
             shape.axis     = "+X"
             shape.position = 1.0
             shape.margin   = 0.5
+            env.large  = 10.0
+            env.small  = 0.01
+            env.strong = 100.0
+            env.weak   = 0.001
             parameters     = [
-                {index = 0, sigma = 2.0, epsilon = 1.5},
-                {index = 1, "σ"   = 2.0, epsilon = 1.5},
-                {index = 2, sigma = 2.0, "ε"     = 1.5},
-                {index = 3, "σ"   = 2.0, "ε"     = 1.5},
+                {index = 0, sigma = "large", epsilon = "strong"},
+                {index = 1, "σ"   = "large", epsilon = "weak"},
+                {index = 2, sigma = "small", "ε"     = "strong"},
+                {index = 3, "σ"   = "small", "ε"     = "weak"},
             ]
         )"_toml;
 
         const auto g = mjolnir::read_lennard_jones_wall_potential<real_type>(v);
 
         BOOST_TEST(g.parameters().size() == 4u);
-        BOOST_TEST(g.parameters().at(0).first  == 2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1).first  == 2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(2).first  == 2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(3).first  == 2.0f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(0).second == 1.5f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(1).second == 1.5f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(2).second == 1.5f, boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.parameters().at(3).second == 1.5f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.parameters().at(0).first  == real_type(10.0),  tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1).first  == real_type(10.0),  tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(2).first  == real_type(0.01),  tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(3).first  == real_type(0.01),  tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(0).second == real_type(100.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(1).second == real_type(0.001), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(2).second == real_type(100.0), tolerance<real_type>());
+        BOOST_TEST(g.parameters().at(3).second == real_type(0.001), tolerance<real_type>());
     }
 }

--- a/test/core/test_read_periodic_gaussian_potential.cpp
+++ b/test/core/test_read_periodic_gaussian_potential.cpp
@@ -11,11 +11,12 @@
 BOOST_AUTO_TEST_CASE(read_periodic_gaussian_double)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_periodic_gaussian.log");
-
     using real_type = double;
+    using namespace toml::literals;
+
     constexpr real_type tol = 1e-8;
     {
-        using namespace toml::literals;
+        const toml::value env; // empty env
         const auto v = u8R"(
             indices = [1, 2]
             k       = 3.14
@@ -23,14 +24,14 @@ BOOST_AUTO_TEST_CASE(read_periodic_gaussian_double)
             v0      = 2.71
         )"_toml;
 
-        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v);
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
         BOOST_TEST(g.k()     == 3.14,  boost::test_tools::tolerance(tol));
         BOOST_TEST(g.sigma() == 0.577, boost::test_tools::tolerance(tol));
         BOOST_TEST(g.v0()    == 2.71,  boost::test_tools::tolerance(tol));
     }
 
     {
-        using namespace toml::literals;
+        const toml::value env; // empty env
         const auto v = u8R"(
             indices = [1, 2]
             k       = 3.14
@@ -38,7 +39,28 @@ BOOST_AUTO_TEST_CASE(read_periodic_gaussian_double)
             v0      = 2.71
         )"_toml;
 
-        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v);
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
+        BOOST_TEST(g.k()     == 3.14,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.sigma() == 0.577, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.v0()    == 2.71,  boost::test_tools::tolerance(tol));
+    }
+
+    {
+        const toml::value env = u8R"(
+            indices = [1, 2]
+            k       = 3.14
+            sigma   = 0.577
+            v0      = 2.71
+        )"_toml;
+
+        const auto v = u8R"(
+            indices = "indices"
+            k       = "k"
+            sigma   = "sigma"
+            v0      = "v0"
+        )"_toml;
+
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
         BOOST_TEST(g.k()     == 3.14,  boost::test_tools::tolerance(tol));
         BOOST_TEST(g.sigma() == 0.577, boost::test_tools::tolerance(tol));
         BOOST_TEST(g.v0()    == 2.71,  boost::test_tools::tolerance(tol));
@@ -49,24 +71,25 @@ BOOST_AUTO_TEST_CASE(read_periodic_gaussian_float)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_periodic_gaussian.log");
     using real_type = float;
+using namespace toml::literals;
     constexpr real_type tol = 1e-4;
 
     {
-        using namespace toml::literals;
+        const toml::value env; // empty env
         const auto v = u8R"(
             indices = [1, 2]
             k       = 3.14
             sigma   = 0.577
             v0      = 2.71
         )"_toml;
-        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v);
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
         BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
         BOOST_TEST(g.sigma() == 0.577f, boost::test_tools::tolerance(tol));
         BOOST_TEST(g.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
     }
 
     {
-        using namespace toml::literals;
+        const toml::value env; // empty env
         const auto v = u8R"(
             indices = [1, 2]
             k       = 3.14
@@ -74,7 +97,28 @@ BOOST_AUTO_TEST_CASE(read_periodic_gaussian_float)
             v0      = 2.71
         )"_toml;
 
-        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v);
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
+        BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.sigma() == 0.577f, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
+    }
+
+    {
+        const toml::value env = u8R"(
+            indices = [1, 2]
+            k       = 3.14
+            sigma   = 0.577
+            v0      = 2.71
+        )"_toml;
+
+        const auto v = u8R"(
+            indices = "indices"
+            k       = "k"
+            sigma   = "sigma"
+            v0      = "v0"
+        )"_toml;
+
+        const auto g = mjolnir::read_periodic_gaussian_potential<real_type>(v, env);
         BOOST_TEST(g.k()     == 3.14f,  boost::test_tools::tolerance(tol));
         BOOST_TEST(g.sigma() == 0.577f, boost::test_tools::tolerance(tol));
         BOOST_TEST(g.v0()    == 2.71f,  boost::test_tools::tolerance(tol));
@@ -109,6 +153,27 @@ BOOST_AUTO_TEST_CASE(read_local_potential_periodic_gaussian_double)
         BOOST_TEST(g.at(0).second.sigma() == 0.577, boost::test_tools::tolerance(tol));
         BOOST_TEST(g.at(0).second.v0()    == 2.71,  boost::test_tools::tolerance(tol));
     }
+    {
+        using namespace toml::literals;
+        const auto v = u8R"(
+            env.pi = 3.14
+            parameters = [
+                {indices = [1, 2], k = "pi", sigma = 0.577, v0 = 2.71}
+            ]
+        )"_toml;
+
+        const auto g = mjolnir::read_local_potential<2,
+              mjolnir::PeriodicGaussianPotential<real_type>>(v);
+
+        const std::array<std::size_t, 2> ref_idx{{1, 2}};
+
+        BOOST_TEST(g.size() == 1u);
+        BOOST_TEST(g.at(0).first == ref_idx);
+        BOOST_TEST(g.at(0).second.k()     == 3.14,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.sigma() == 0.577, boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.at(0).second.v0()    == 2.71,  boost::test_tools::tolerance(tol));
+    }
+
 }
 
 BOOST_AUTO_TEST_CASE(read_local_potential_periodic_gaussian_float)

--- a/test/core/test_read_uniform_lennard_jones_potential.cpp
+++ b/test/core/test_read_uniform_lennard_jones_potential.cpp
@@ -9,12 +9,21 @@
 
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
+#include <tuple>
 
-BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_double)
+using test_types = std::tuple<double, float>;
+
+constexpr inline float  tolerance_value(float)  noexcept {return 1e-4;}
+constexpr inline double tolerance_value(double) noexcept {return 1e-8;}
+
+template<typename Real>
+decltype(boost::test_tools::tolerance(std::declval<Real>()))
+tolerance() {return boost::test_tools::tolerance(tolerance_value(Real()));}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_uniform_lennard_jones_noenv, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_uniform_lennard_jones.log");
-    using real_type = double;
-    constexpr real_type tol = 1e-8;
+    using real_type = T;
 
     // a dummy system for testing `initialize` method
     using traits_type   = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
@@ -42,8 +51,8 @@ BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_double)
         BOOST_TEST(g.ignore_within().size() == 2u);
         BOOST_TEST(within.at("bond")    == 3ul);
         BOOST_TEST(within.at("contact") == 1ul);
-        BOOST_TEST(g.sigma()   == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon() == 1.5,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.sigma()   == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.epsilon() == real_type(1.5), tolerance<real_type>());
         BOOST_TEST(g.participants().empty());
 
         g.initialize(sys);
@@ -81,8 +90,8 @@ BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_double)
         BOOST_TEST(g.ignore_within().size() == 2u);
         BOOST_TEST(within.at("bond")    == 3ul);
         BOOST_TEST(within.at("contact") == 1ul);
-        BOOST_TEST(g.sigma()   == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon() == 1.5,  boost::test_tools::tolerance(tol));
+        BOOST_TEST(g.sigma()   == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.epsilon() == real_type(1.5), tolerance<real_type>());
         BOOST_TEST(g.participants().empty());
 
         g.initialize(sys);
@@ -97,58 +106,60 @@ BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_double)
         BOOST_TEST(g.participants().at(7) == 7u);
         BOOST_TEST(g.participants().at(8) == 8u);
         BOOST_TEST(g.participants().at(9) == 9u);
+    }
+    {
+        using namespace toml::literals;
+        const auto v = u8R"(
+            interaction = "Pair"
+            potential   = "UniformLennardJones"
+            spatial_partition.type  = "CellList"
+            ignore.molecule         = "Nothing"
+            ignore.particles_within.bond    = 3
+            ignore.particles_within.contact = 1
+            "σ" = 2.0
+            "ε" = 1.5
+            parameters = [
+                {index = 1},
+                {index = 2},
+                {index = 3},
+                {index = 4},
+                {index = 5},
+            ]
+        )"_toml;
+
+        auto g = mjolnir::read_uniform_lennard_jones_potential<real_type>(v);
+
+        const auto ignore_within = g.ignore_within();
+        const std::map<std::string, std::size_t> within(
+                ignore_within.begin(), ignore_within.end());
+
+        BOOST_TEST(g.ignore_within().size() == 2u);
+        BOOST_TEST(within.at("bond")    == 3ul);
+        BOOST_TEST(within.at("contact") == 1ul);
+        BOOST_TEST(g.sigma()   == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.epsilon() == real_type(1.5), tolerance<real_type>());
+        BOOST_TEST(g.participants().size() == 5u);
+
+        g.initialize(sys);
+        BOOST_TEST(g.participants().size() == 5u);
+        BOOST_TEST(g.participants().at(0)  == 1u);
+        BOOST_TEST(g.participants().at(1)  == 2u);
+        BOOST_TEST(g.participants().at(2)  == 3u);
+        BOOST_TEST(g.participants().at(3)  == 4u);
+        BOOST_TEST(g.participants().at(4)  == 5u);
     }
 }
 
-BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_float)
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_uniform_lennard_jones_env, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_uniform_lennard_jones.log");
-    using real_type = float;
-    constexpr real_type tol = 1e-4;
+    using real_type = T;
 
     // a dummy system for testing `initialize` method
     using traits_type   = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
     using boundary_type = typename traits_type::boundary_type;
     mjolnir::System<traits_type> sys(10, boundary_type{});
-    {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            interaction = "Pair"
-            potential   = "UniformLennardJones"
-            spatial_partition.type  = "CellList"
-            ignore.molecule         = "Nothing"
-            ignore.particles_within.bond    = 3
-            ignore.particles_within.contact = 1
-            sigma   = 2.0
-            epsilon = 1.5
-        )"_toml;
 
-        auto g = mjolnir::read_uniform_lennard_jones_potential<real_type>(v);
-
-        const auto ignore_within = g.ignore_within();
-        const std::map<std::string, std::size_t> within(
-                ignore_within.begin(), ignore_within.end());
-
-        BOOST_TEST(g.ignore_within().size() == 2u);
-        BOOST_TEST(within.at("bond")    == 3ul);
-        BOOST_TEST(within.at("contact") == 1ul);
-        BOOST_TEST(g.sigma()   == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon() == 1.5,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.participants().empty());
-
-        g.initialize(sys);
-        BOOST_TEST(g.participants().size() == 10u);
-        BOOST_TEST(g.participants().at(0) == 0u);
-        BOOST_TEST(g.participants().at(1) == 1u);
-        BOOST_TEST(g.participants().at(2) == 2u);
-        BOOST_TEST(g.participants().at(3) == 3u);
-        BOOST_TEST(g.participants().at(4) == 4u);
-        BOOST_TEST(g.participants().at(5) == 5u);
-        BOOST_TEST(g.participants().at(6) == 6u);
-        BOOST_TEST(g.participants().at(7) == 7u);
-        BOOST_TEST(g.participants().at(8) == 8u);
-        BOOST_TEST(g.participants().at(9) == 9u);
-    }
     {
         using namespace toml::literals;
         const auto v = u8R"(
@@ -160,6 +171,14 @@ BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_float)
             ignore.particles_within.contact = 1
             "σ" = 2.0
             "ε" = 1.5
+            env.three = 3
+            parameters = [
+                {index = 1},
+                {index = 2},
+                {index = "three"},
+                {index = 4},
+                {index = 5},
+            ]
         )"_toml;
 
         auto g = mjolnir::read_uniform_lennard_jones_potential<real_type>(v);
@@ -171,21 +190,16 @@ BOOST_AUTO_TEST_CASE(read_uniform_lennard_jones_float)
         BOOST_TEST(g.ignore_within().size() == 2u);
         BOOST_TEST(within.at("bond")    == 3ul);
         BOOST_TEST(within.at("contact") == 1ul);
-        BOOST_TEST(g.sigma()   == 2.0,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.epsilon() == 1.5,  boost::test_tools::tolerance(tol));
-        BOOST_TEST(g.participants().empty());
+        BOOST_TEST(g.sigma()   == real_type(2.0), tolerance<real_type>());
+        BOOST_TEST(g.epsilon() == real_type(1.5), tolerance<real_type>());
+        BOOST_TEST(g.participants().size() == 5u);
 
         g.initialize(sys);
-        BOOST_TEST(g.participants().size() == 10u);
-        BOOST_TEST(g.participants().at(0) == 0u);
-        BOOST_TEST(g.participants().at(1) == 1u);
-        BOOST_TEST(g.participants().at(2) == 2u);
-        BOOST_TEST(g.participants().at(3) == 3u);
-        BOOST_TEST(g.participants().at(4) == 4u);
-        BOOST_TEST(g.participants().at(5) == 5u);
-        BOOST_TEST(g.participants().at(6) == 6u);
-        BOOST_TEST(g.participants().at(7) == 7u);
-        BOOST_TEST(g.participants().at(8) == 8u);
-        BOOST_TEST(g.participants().at(9) == 9u);
+        BOOST_TEST(g.participants().size() == 5u);
+        BOOST_TEST(g.participants().at(0)  == 1u);
+        BOOST_TEST(g.participants().at(1)  == 2u);
+        BOOST_TEST(g.participants().at(2)  == 3u);
+        BOOST_TEST(g.participants().at(3)  == 4u);
+        BOOST_TEST(g.participants().at(4)  == 5u);
     }
 }


### PR DESCRIPTION
This PR enables to define variables that can be used in the force-field parameter.

```toml
[[forcefields.local]]
env.large = 100.0
parameters = [
    {indices = [0, 1], k = "large"}, # k becomes 100.0
]
```

It would be useful to reduce file size and improve readability in some cases.