### PR TITLE
fix openmp implementations of cell lists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,12 @@ matrix:
     language: cpp
     compiler: clang
     env: COMPILER="clang++" SEPARATE="OFF"
+    addons:
+      homebrew:
+        packages:
+        - cmake
+        - boost
+        update: true
 
 before_install:
 - |
@@ -109,8 +115,6 @@ before_install:
     travis_retry wget "https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5-Linux-x86_64.tar.gz"
     tar xf cmake-3.14.5-Linux-x86_64.tar.gz -C cmake --strip-components=1
     export PATH=${TRAVIS_BUILD_DIR}/cmake/bin:${PATH}
-  else
-    brew upgrade cmake boost
   fi
 - cmake --version
 

--- a/mjolnir/omp/PeriodicGridCellList.hpp
+++ b/mjolnir/omp/PeriodicGridCellList.hpp
@@ -168,11 +168,11 @@ class PeriodicGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         const auto& participants = pot.participants();
 
         neighbors.clear();
-        if(index_by_cell_    .size() != sys.size() ||
-           index_by_cell_buf_.size() != sys.size())
+        if(index_by_cell_    .size() != participants.size() ||
+           index_by_cell_buf_.size() != participants.size())
         {
-            index_by_cell_    .resize(sys.size());
-            index_by_cell_buf_.resize(sys.size());
+            index_by_cell_    .resize(participants.size());
+            index_by_cell_buf_.resize(participants.size());
         }
 
 #pragma omp parallel for

--- a/mjolnir/omp/UnlimitedGridCellList.hpp
+++ b/mjolnir/omp/UnlimitedGridCellList.hpp
@@ -128,19 +128,19 @@ class UnlimitedGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
     void make(neighbor_list_type& neighbors,
               const system_type& sys, const potential_type& pot) override
     {
-	MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
-	MJOLNIR_LOG_FUNCTION_DEBUG();
+        MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+        MJOLNIR_LOG_FUNCTION_DEBUG();
 
         // `participants` is a list that contains indices of particles that are
         // related to the potential.
         const auto& participants = pot.participants();
 
         neighbors.clear();
-        if(index_by_cell_    .size() != sys.size() ||
-           index_by_cell_buf_.size() != sys.size())
+        if(index_by_cell_    .size() != participants.size() ||
+           index_by_cell_buf_.size() != participants.size())
         {
-            index_by_cell_    .resize(sys.size());
-            index_by_cell_buf_.resize(sys.size());
+            index_by_cell_    .resize(participants.size());
+            index_by_cell_buf_.resize(participants.size());
         }
 
 #pragma omp parallel for

--- a/mjolnir/omp/sort.hpp
+++ b/mjolnir/omp/sort.hpp
@@ -18,6 +18,7 @@ void sort(std::vector<Value, Alloc>& vec, std::vector<Value, Alloc>& buf,
           Comparator comp)
 {
     const std::size_t max_threads = omp_get_max_threads();
+    const std::size_t vec_size = vec.size();
     if(max_threads == 1 || vec.size() < max_threads * 4)
     {
         std::sort(vec.begin(), vec.end(), comp);
@@ -83,6 +84,7 @@ void sort(std::vector<Value, Alloc>& vec, std::vector<Value, Alloc>& buf,
             } // an implicit barrier here
         }
     }
+    assert(vec.size() == vec_size);
     return;
 }
 

--- a/mjolnir/util/logger.hpp
+++ b/mjolnir/util/logger.hpp
@@ -4,6 +4,7 @@
 #include <mjolnir/util/make_unique.hpp>
 #include <mjolnir/util/throw_exception.hpp>
 #include <mjolnir/util/color.hpp>
+#include <mjolnir/util/range.hpp>
 #include <array>
 #include <vector>
 #include <map>
@@ -39,6 +40,16 @@ namespace logger_detail
 // To avoid fixing the output format, these are defined in the special namespace
 // `logger_detail`. loggers first imports this namespace and output using these
 // operators.
+
+template<typename charT, typename traits, typename Iterator>
+std::basic_ostream<charT, traits>&
+operator<<(std::basic_ostream<charT, traits>& os, const range<Iterator>& rg)
+{
+    os << '[';
+    for(const auto& v : rg){os << v << ", ";}
+    os << ']';
+    return os;
+}
 
 template<typename charT, typename traits, typename T, std::size_t N>
 std::basic_ostream<charT, traits>&


### PR DESCRIPTION
When it is used with a potential that is applied to not all the particles, it causes an error and the simulation explodes.

Global potentials that are applied to all the particles, such as Lennard-Jones, are not affected by this bug.