### PR TITLE
split participants into two, left and right sides in the pair list

### DIFF
--- a/mjolnir/core/NaivePairCalculation.hpp
+++ b/mjolnir/core/NaivePairCalculation.hpp
@@ -58,16 +58,15 @@ void NaivePairCalculation<traitsT, potentialT>::make(neighbor_list_type& neighbo
 {
     neighbors.clear();
 
-    const auto& participants = pot.participants();
+    const auto leading_participants = pot.leading_participants();
 
     std::vector<neighbor_type> partners;
-    for(std::size_t idx=0; idx<participants.size(); ++idx)
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
         partners.clear();
-        const auto   i = participants[idx];
-        for(std::size_t jdx=idx+1; jdx<participants.size(); ++jdx)
+        const auto i = leading_participants[idx];
+        for(const auto j : pot.possible_partners_of(idx, i))
         {
-            const auto j = participants[jdx];
             if(pot.has_interaction(i, j)) // likely
             {
                 partners.emplace_back(j, pot.prepare_params(i, j));

--- a/mjolnir/core/NeighborList.hpp
+++ b/mjolnir/core/NeighborList.hpp
@@ -211,6 +211,9 @@ class NeighborList
         {
             this->ranges_.resize(i+2, 0);
         }
+
+        assert(ranges_[i] == 0 || ranges_[i] == this->neighbors_.size());
+
         this->ranges_[i]   = this->neighbors_.size();
         this->ranges_[i+1] = this->neighbors_.size() + std::distance(first, last);
 

--- a/mjolnir/core/PeriodicGridCellList.hpp
+++ b/mjolnir/core/PeriodicGridCellList.hpp
@@ -195,11 +195,13 @@ void PeriodicGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighbo
     const real_type r_c  = cutoff_ * (1. + margin_);
     const real_type r_c2 = r_c * r_c;
 
+    const auto leading_participants = pot.leading_participants();
+
     std::vector<neighbor_type> partner;
-    for(std::size_t idx=0; idx<participants.size(); ++idx)
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
         partner.clear();
-        const auto   i = participants[idx];
+        const auto   i = leading_participants[idx];
         const auto& ri = sys.position(i);
 
         const auto& cell = cell_list_[calc_index(ri)];
@@ -214,7 +216,7 @@ void PeriodicGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighbo
             {
                 const auto j = pici.first;
                 MJOLNIR_LOG_DEBUG("looking particle", j);
-                if(j <= i || !pot.has_interaction(i, j))
+                if(!pot.has_interaction(i, j))
                 {
                     continue;
                 }

--- a/mjolnir/core/UnlimitedGridCellList.hpp
+++ b/mjolnir/core/UnlimitedGridCellList.hpp
@@ -180,11 +180,13 @@ void UnlimitedGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighb
     const real_type r_c  = cutoff_ * (1 + margin_);
     const real_type r_c2 = r_c * r_c;
 
+    const auto leading_participants = pot.leading_participants();
+
     std::vector<neighbor_type> partner;
-    for(std::size_t idx=0; idx<participants.size(); ++idx)
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
         partner.clear();
-        const auto   i = participants[idx];
+        const auto   i = leading_participants[idx];
         const auto& ri = sys.position(i);
 
         const auto& cell = cell_list_[this->calc_index(ri)];
@@ -200,7 +202,7 @@ void UnlimitedGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighb
             {
                 const auto j = pici.first;
                 MJOLNIR_LOG_DEBUG("looking particle ", j);
-                if(j <= i || !pot.has_interaction(i, j))
+                if(!pot.has_interaction(i, j))
                 {
                     continue;
                 }

--- a/mjolnir/core/VerletList.hpp
+++ b/mjolnir/core/VerletList.hpp
@@ -83,23 +83,20 @@ void VerletList<traitsT, potentialT>::make(neighbor_list_type& neighbors,
 {
     neighbors.clear();
 
-    // `participants` is a list that contains indices of particles that are
-    // related to the potential.
-    const auto& participants = pot.participants();
-
     const real_type rc = cutoff_ * (1. + margin_);
     const real_type rc2 = rc * rc;
 
+    const auto leading_participants = pot.leading_participants();
+
     std::vector<neighbor_type> partner;
-    for(std::size_t idx=0; idx<participants.size(); ++idx)
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
         partner.clear();
-        const auto   i = participants[idx];
+        const auto   i = leading_participants[idx];
         const auto& ri = sys.position(i);
 
-        for(std::size_t jdx=idx+1; jdx<participants.size(); ++jdx)
+        for(const auto j : pot.possible_partners_of(idx, i))
         {
-            const auto j = participants[jdx];
             if(!pot.has_interaction(i, j))
             {
                 continue;

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -99,8 +99,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
     constexpr auto two_pi    = math::constants<real_type>::two_pi();
     constexpr auto tolerance = math::abs_tolerance<real_type>();
 
-    for(const auto Bi : this->potential_.participants())
+    const auto leading_participants = this->potential_.leading_participants();
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
+        const auto   Bi = leading_participants[idx];
         const auto& rBi = sys.position(Bi);
         for(const auto& ptnr : this->partition_.partners(Bi))
         {
@@ -531,8 +533,11 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_energy(
 
     real_type E_BP = 0.0;
     real_type E_CS = 0.0;
-    for(const auto Bi : this->potential_.participants())
+
+    const auto leading_participants = this->potential_.leading_participants();
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
+        const auto   Bi = leading_participants[idx];
         const auto& rBi = sys.position(Bi);
 
         for(const auto& ptnr : this->partition_.partners(Bi))

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
@@ -489,7 +489,8 @@ class ThreeSPN2BaseBaseInteractionPotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
@@ -497,7 +497,7 @@ class ThreeSPN2BaseBaseInteractionPotential
     // to check bases has base-pairing interaction.
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
-        if(exclusion_list_.is_excluded(i, j))
+        if(j <= i || exclusion_list_.is_excluded(i, j))
         {
             return false;
         }

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteractionPotential.hpp
@@ -478,7 +478,22 @@ class ThreeSPN2BaseBaseInteractionPotential
         return;
     }
 
-    // ------------------------------------------------------------------------
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
+
     // to check bases has base-pairing interaction.
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
@@ -508,8 +523,6 @@ class ThreeSPN2BaseBaseInteractionPotential
     // access to the parameters...
     std::vector<parameter_type>&       parameters()       noexcept {return parameters_;}
     std::vector<parameter_type> const& parameters() const noexcept {return parameters_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
   private:
 

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
@@ -242,6 +242,22 @@ class ThreeSPN2ExcludedVolumePotential
         return;
     }
 
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
+
     // ------------------------------------------------------------------------
     // to check bases has base-pairing interaction.
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
@@ -308,8 +324,6 @@ class ThreeSPN2ExcludedVolumePotential
             default:{assert(false);}
         }
     }
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
   private:
 

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
@@ -262,7 +262,7 @@ class ThreeSPN2ExcludedVolumePotential
     // to check bases has base-pairing interaction.
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
-        if(exclusion_list_.is_excluded(i, j))
+        if(j <= i || exclusion_list_.is_excluded(i, j))
         {
             return false;
         }

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2ExcludedVolumePotential.hpp
@@ -253,7 +253,8 @@ class ThreeSPN2ExcludedVolumePotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/interaction/global/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairExcludedVolumeInteraction.hpp
@@ -75,8 +75,11 @@ class GlobalPairInteraction<
         const auto cutoff_ratio    = potential_.cutoff_ratio();
         const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
         const auto epsilon12       = 12 * potential_.epsilon();
-        for(const auto i : this->potential_.participants())
+
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;
@@ -116,8 +119,11 @@ class GlobalPairInteraction<
         const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
         const auto coef_at_cutoff  = potential_.coef_at_cutoff();
         const auto epsilon         = potential_.epsilon();
-        for(const auto i : this->potential_.participants())
+
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;

--- a/mjolnir/interaction/global/GlobalPairInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairInteraction.hpp
@@ -102,21 +102,16 @@ template<typename traitsT, typename potT>
 void GlobalPairInteraction<traitsT, potT>::calc_force(
         system_type& sys) const noexcept
 {
-    MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
-    MJOLNIR_LOG_FUNCTION_DEBUG();
-
-    for(const auto i : this->potential_.participants())
+    const auto leading_participants = this->potential_.leading_participants();
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
-        MJOLNIR_LOG_DEBUG("partners number of particle ", i,
-                          " is ", partition_.partners(i).size());
+        const auto i = leading_participants[idx];
         for(const auto& ptnr : this->partition_.partners(i))
         {
             const auto  j     = ptnr.index;
             const auto& param = ptnr.parameter();
 
-            MJOLNIR_LOG_DEBUG("calculating force between ", i, " and", j);
-
-            const coordinate_type rij =
+            const auto rij =
                 sys.adjust_direction(sys.position(j) - sys.position(i));
             const real_type l2 = math::length_sq(rij); // |rij|^2
             const real_type rl = math::rsqrt(l2);      // 1 / |rij|
@@ -139,9 +134,12 @@ typename GlobalPairInteraction<traitsT, potT>::real_type
 GlobalPairInteraction<traitsT, potT>::calc_energy(
         const system_type& sys) const noexcept
 {
-    real_type e = 0.0;
-    for(const auto i : this->potential_.participants())
+    real_type E = 0.0;
+
+    const auto leading_participants = this->potential_.leading_participants();
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
     {
+        const auto i = leading_participants[idx];
         for(const auto& ptnr : this->partition_.partners(i))
         {
             const auto  j     = ptnr.index;
@@ -149,10 +147,10 @@ GlobalPairInteraction<traitsT, potT>::calc_energy(
 
             const real_type l = math::length(
                 sys.adjust_direction(sys.position(j) - sys.position(i)));
-            e += potential_.potential(l, param);
+            E += potential_.potential(l, param);
         }
     }
-    return e;
+    return E;
 }
 
 } // mjolnir

--- a/mjolnir/interaction/global/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairLennardJonesInteraction.hpp
@@ -72,8 +72,12 @@ class GlobalPairInteraction<
     {
         const auto  cutoff_ratio    = potential_.cutoff_ratio();
         const auto  cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
-        for(const auto i : this->potential_.participants())
+
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
+
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;
@@ -109,8 +113,12 @@ class GlobalPairInteraction<
         const auto cutoff_ratio    = potential_.cutoff_ratio();
         const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
         const auto coef_at_cutoff  = potential_.coef_at_cutoff();
-        for(const auto i : this->potential_.participants())
+
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
+
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;

--- a/mjolnir/interaction/global/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/interaction/global/GlobalPairUniformLennardJonesInteraction.hpp
@@ -76,8 +76,11 @@ class GlobalPairInteraction<
         const auto r_cutoff_sq     = cutoff_ratio_sq * sigma_sq;
         const auto epsilon         = this->potential_.epsilon();
 
-        for(const auto i : this->potential_.participants())
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
+
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto j = ptnr.index;
@@ -114,8 +117,10 @@ class GlobalPairInteraction<
         const auto r_cutoff_sq     = cutoff_ratio_sq * sigma_sq;
         const auto epsilon         = this->potential_.epsilon();
 
-        for(const auto i : this->potential_.participants())
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
         {
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto j = ptnr.index;

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -72,10 +72,11 @@ class GlobalPairInteraction<
         const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
         const auto epsilon12       = 12 * potential_.epsilon();
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp for nowait
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;
@@ -117,10 +118,11 @@ class GlobalPairInteraction<
         const auto coef_at_cutoff  = potential_.coef_at_cutoff();
         const auto epsilon         = potential_.epsilon();
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp parallel for reduction(+:E)
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;

--- a/mjolnir/omp/GlobalPairInteraction.hpp
+++ b/mjolnir/omp/GlobalPairInteraction.hpp
@@ -64,10 +64,11 @@ class GlobalPairInteraction<
 
     void calc_force (system_type& sys) const noexcept override
     {
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp for nowait
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;
@@ -94,10 +95,11 @@ class GlobalPairInteraction<
     real_type calc_energy(const system_type& sys) const noexcept override
     {
         real_type E = 0.0;
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp parallel for reduction(+:E)
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -69,10 +69,11 @@ class GlobalPairInteraction<
         const auto  cutoff_ratio    = potential_.cutoff_ratio();
         const auto  cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp for nowait
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;
@@ -109,10 +110,12 @@ class GlobalPairInteraction<
         const auto  cutoff_ratio    = potential_.cutoff_ratio();
         const auto  cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
         const auto  coef_at_cutoff  = potential_.coef_at_cutoff();
+
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp parallel for reduction(+:E)
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto  j     = ptnr.index;

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -73,10 +73,11 @@ class GlobalPairInteraction<
         const auto r_cutoff_sq     = cutoff_ratio_sq * sigma_sq;
         const auto epsilon         = this->potential_.epsilon();
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp for nowait
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto j = ptnr.index;
@@ -114,10 +115,11 @@ class GlobalPairInteraction<
         const auto r_cutoff_sq     = cutoff_ratio_sq * sigma_sq;
         const auto epsilon         = this->potential_.epsilon();
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp parallel for reduction(+:E)
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto i = this->potential_.participants()[idx];
+            const auto i = leading_participants[idx];
             for(const auto& ptnr : this->partition_.partners(i))
             {
                 const auto j = ptnr.index;

--- a/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
@@ -78,12 +78,13 @@ class ThreeSPN2BaseBaseInteraction<
         constexpr auto two_pi    = math::constants<real_type>::two_pi();
         constexpr auto tolerance = math::abs_tolerance<real_type>();
 
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp for nowait
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
             const std::size_t thread_id = omp_get_thread_num();
 
-            const auto Bi = this->potential_.participants()[idx];
+            const auto   Bi = leading_participants[idx];
             const auto& rBi = sys.position(Bi);
             for(const auto& ptnr : this->partition_.partners(Bi))
             {
@@ -510,10 +511,12 @@ class ThreeSPN2BaseBaseInteraction<
         constexpr auto two_pi    = math::constants<real_type>::two_pi();
 
         real_type E = 0.0;
+
+        const auto leading_participants = this->potential_.leading_participants();
 #pragma omp parallel for reduction(+:E)
-        for(std::size_t idx=0; idx < this->potential_.participants().size(); ++idx)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
         {
-            const auto   Bi = this->potential_.participants()[idx];
+            const auto   Bi = leading_participants[idx];
             const auto& rBi = sys.position(Bi);
 
             for(const auto& ptnr : this->partition_.partners(Bi))

--- a/mjolnir/potential/global/DebyeHuckelPotential.hpp
+++ b/mjolnir/potential/global/DebyeHuckelPotential.hpp
@@ -168,7 +168,8 @@ class DebyeHuckelPotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/potential/global/DebyeHuckelPotential.hpp
+++ b/mjolnir/potential/global/DebyeHuckelPotential.hpp
@@ -157,16 +157,31 @@ class DebyeHuckelPotential
         return;
     }
 
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
+
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
         return !exclusion_list_.is_excluded(i, j);
     }
 
-    // for testing
     exclusion_list_type const& exclusion_list() const noexcept
     {
-        return exclusion_list_;
+        return exclusion_list_; // for testing
     }
 
     // ------------------------------------------------------------------------
@@ -179,8 +194,6 @@ class DebyeHuckelPotential
     // access to the parameters.
     std::vector<real_type>&       charges()       noexcept {return parameters_;}
     std::vector<real_type> const& charges() const noexcept {return parameters_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
     real_type debye_length() const noexcept {return this->debye_length_;}
 

--- a/mjolnir/potential/global/DebyeHuckelPotential.hpp
+++ b/mjolnir/potential/global/DebyeHuckelPotential.hpp
@@ -75,7 +75,6 @@ class DebyeHuckelPotential
             }
             this->parameters_.at(idx) = idxp.second;
         }
-
         // XXX should be updated before use because T and ion conc are default!
         this->calc_parameters();
     }
@@ -158,6 +157,13 @@ class DebyeHuckelPotential
 
     // -----------------------------------------------------------------------
     // for spatial partitions
+    //
+    // Here, the default implementation uses Newton's 3rd law to reduce
+    // calculation. For an interacting pair (i, j), forces applied to i and j
+    // are equal in magnitude and opposite in direction. So, if a pair (i, j) is
+    // listed, (j, i) is not needed.
+    //     See implementation of VerletList, CellList and GlobalPairInteraction
+    // for more details about the usage of these functions.
 
     std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
@@ -170,13 +176,12 @@ class DebyeHuckelPotential
     possible_partners_of(const std::size_t participant_idx,
                          const std::size_t /*particle_idx*/) const noexcept
     {
-        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+        return make_range(participants_.begin() + participant_idx + 1,
+                          participants_.end());
     }
-
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
-        // if not excluded, the pair has interaction.
-        return !exclusion_list_.is_excluded(i, j);
+        return (i < j) && !exclusion_list_.is_excluded(i, j);
     }
 
     exclusion_list_type const& exclusion_list() const noexcept

--- a/mjolnir/potential/global/ExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/ExcludedVolumePotential.hpp
@@ -174,7 +174,8 @@ class ExcludedVolumePotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/potential/global/ExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/ExcludedVolumePotential.hpp
@@ -163,6 +163,22 @@ class ExcludedVolumePotential
         return 2 * max_sigma * this->cutoff_ratio_;
     }
 
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
+
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
@@ -186,8 +202,6 @@ class ExcludedVolumePotential
     real_type  epsilon() const noexcept {return this->epsilon_;}
     std::vector<real_type>&       parameters()       noexcept {return this->parameters_;}
     std::vector<real_type> const& parameters() const noexcept {return this->parameters_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
   private:
 

--- a/mjolnir/potential/global/ExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/ExcludedVolumePotential.hpp
@@ -164,6 +164,13 @@ class ExcludedVolumePotential
 
     // -----------------------------------------------------------------------
     // for spatial partitions
+    //
+    // Here, the default implementation uses Newton's 3rd law to reduce
+    // calculation. For an interacting pair (i, j), forces applied to i and j
+    // are equal in magnitude and opposite in direction. So, if a pair (i, j) is
+    // listed, (j, i) is not needed.
+    //     See implementation of VerletList, CellList and GlobalPairInteraction
+    // for more details about the usage of these functions.
 
     std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
@@ -176,13 +183,13 @@ class ExcludedVolumePotential
     possible_partners_of(const std::size_t participant_idx,
                          const std::size_t /*particle_idx*/) const noexcept
     {
-        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+        return make_range(participants_.begin() + participant_idx + 1,
+                          participants_.end());
     }
-
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
-        return !exclusion_list_.is_excluded(i, j);
+        return (i < j) && !exclusion_list_.is_excluded(i, j);
     }
     // for testing
     exclusion_list_type const& exclusion_list() const noexcept

--- a/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
@@ -172,7 +172,8 @@ class HardCoreExcludedVolumePotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
@@ -161,6 +161,22 @@ class HardCoreExcludedVolumePotential
         return max_param.first * this->cutoff_ratio_ + max_param.second;
     }
 
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
+
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
@@ -183,8 +199,6 @@ class HardCoreExcludedVolumePotential
     real_type  epsilon() const noexcept {return this->epsilon_;}
     std::vector<parameter_type>&       parameters()       noexcept {return parameters_;}
     std::vector<parameter_type> const& parameters() const noexcept {return parameters_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
  private:
     real_type epsilon_;

--- a/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
+++ b/mjolnir/potential/global/HardCoreExcludedVolumePotential.hpp
@@ -161,6 +161,13 @@ class HardCoreExcludedVolumePotential
 
     // -----------------------------------------------------------------------
     // for spatial partitions
+    //
+    // Here, the default implementation uses Newton's 3rd law to reduce
+    // calculation. For an interacting pair (i, j), forces applied to i and j
+    // are equal in magnitude and opposite in direction. So, if a pair (i, j) is
+    // listed, (j, i) is not needed.
+    //     See implementation of VerletList, CellList and GlobalPairInteraction
+    // for more details about the usage of these functions.
 
     std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
@@ -173,14 +180,14 @@ class HardCoreExcludedVolumePotential
     possible_partners_of(const std::size_t participant_idx,
                          const std::size_t /*particle_idx*/) const noexcept
     {
-        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+        return make_range(participants_.begin() + participant_idx + 1,
+                          participants_.end());
     }
-
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
-        // if not excluded, the pair has interaction.
-        return !exclusion_list_.is_excluded(i, j);
+        return (i < j) && !exclusion_list_.is_excluded(i, j);
     }
+
     // for testing
     exclusion_list_type const& exclusion_list() const noexcept
     {

--- a/mjolnir/potential/global/LennardJonesPotential.hpp
+++ b/mjolnir/potential/global/LennardJonesPotential.hpp
@@ -156,6 +156,22 @@ class LennardJonesPotential
         exclusion_list_.make(sys);
         return;
     }
+
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
@@ -177,8 +193,6 @@ class LennardJonesPotential
     // access to the parameters...
     std::vector<parameter_type>&       parameters()       noexcept {return parameters_;}
     std::vector<parameter_type> const& parameters() const noexcept {return parameters_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
   private:
 

--- a/mjolnir/potential/global/LennardJonesPotential.hpp
+++ b/mjolnir/potential/global/LennardJonesPotential.hpp
@@ -168,7 +168,8 @@ class LennardJonesPotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/mjolnir/potential/global/LennardJonesPotential.hpp
+++ b/mjolnir/potential/global/LennardJonesPotential.hpp
@@ -158,6 +158,13 @@ class LennardJonesPotential
 
     // -----------------------------------------------------------------------
     // for spatial partitions
+    //
+    // Here, the default implementation uses Newton's 3rd law to reduce
+    // calculation. For an interacting pair (i, j), forces applied to i and j
+    // are equal in magnitude and opposite in direction. So, if a pair (i, j) is
+    // listed, (j, i) is not needed.
+    //     See implementation of VerletList, CellList and GlobalPairInteraction
+    // for more details about the usage of these functions.
 
     std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
@@ -175,7 +182,7 @@ class LennardJonesPotential
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
-        return !exclusion_list_.is_excluded(i, j);
+        return (i < j) && !exclusion_list_.is_excluded(i, j);
     }
     // for testing
     exclusion_list_type const& exclusion_list() const noexcept

--- a/mjolnir/potential/global/UniformLennardJonesPotential.hpp
+++ b/mjolnir/potential/global/UniformLennardJonesPotential.hpp
@@ -145,6 +145,22 @@ class UniformLennardJonesPotential
         exclusion_list_.make(sys);
         return;
     }
+
+    // -----------------------------------------------------------------------
+    // for spatial partitions
+
+    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
+
+    range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    {
+        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+    }
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
@@ -167,8 +183,6 @@ class UniformLennardJonesPotential
     real_type  sigma()   const noexcept {return sigma_;}
     real_type& epsilon()       noexcept {return epsilon_;}
     real_type  epsilon() const noexcept {return epsilon_;}
-
-    std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
   private:
 

--- a/mjolnir/potential/global/UniformLennardJonesPotential.hpp
+++ b/mjolnir/potential/global/UniformLennardJonesPotential.hpp
@@ -147,6 +147,13 @@ class UniformLennardJonesPotential
 
     // -----------------------------------------------------------------------
     // for spatial partitions
+    //
+    // Here, the default implementation uses Newton's 3rd law to reduce
+    // calculation. For an interacting pair (i, j), forces applied to i and j
+    // are equal in magnitude and opposite in direction. So, if a pair (i, j) is
+    // listed, (j, i) is not needed.
+    //     See implementation of VerletList, CellList and GlobalPairInteraction
+    // for more details about the usage of these functions.
 
     std::vector<std::size_t> const& participants() const noexcept {return participants_;}
 
@@ -159,12 +166,13 @@ class UniformLennardJonesPotential
     possible_partners_of(const std::size_t participant_idx,
                          const std::size_t /*particle_idx*/) const noexcept
     {
-        return make_range(participants_.begin() + participant_idx + 1, participants_.end());
+        return make_range(participants_.begin() + participant_idx + 1,
+                          participants_.end());
     }
     bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
     {
         // if not excluded, the pair has interaction.
-        return !exclusion_list_.is_excluded(i, j);
+        return (i < j) && !exclusion_list_.is_excluded(i, j);
     }
     exclusion_list_type const& exclusion_list() const noexcept
     {

--- a/mjolnir/potential/global/UniformLennardJonesPotential.hpp
+++ b/mjolnir/potential/global/UniformLennardJonesPotential.hpp
@@ -157,7 +157,8 @@ class UniformLennardJonesPotential
         return make_range(participants_.begin(), std::prev(participants_.end()));
     }
     range<typename std::vector<std::size_t>::const_iterator>
-    possible_partners_of(const std::size_t participant_idx, const std::size_t particle_idx) const noexcept
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
     {
         return make_range(participants_.begin() + participant_idx + 1, participants_.end());
     }

--- a/test/core/test_periodic_verlet_list.cpp
+++ b/test/core/test_periodic_verlet_list.cpp
@@ -8,6 +8,7 @@
 
 #include <mjolnir/util/empty.hpp>
 #include <mjolnir/util/logger.hpp>
+#include <mjolnir/util/range.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/VerletList.hpp>
@@ -41,7 +42,6 @@ struct dummy_potential
 
     bool is_ignored_molecule(std::size_t, std::size_t) const {return false;}
     bool is_ignored_group   (std::string, std::string) const {return false;}
-    bool has_interaction    (std::size_t, std::size_t) const {return true;}
 
     std::vector<std::pair<connection_kind_type, std::size_t>> ignore_within() const
     {
@@ -52,6 +52,23 @@ struct dummy_potential
     {
         return this->participants_;
     }
+    mjolnir::range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return mjolnir::make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    mjolnir::range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
+    {
+        return mjolnir::make_range(participants_.begin() + participant_idx + 1,
+                                   participants_.end());
+    }
+    bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
+    {
+        return (i < j);
+    }
+
 
     std::string name() const {return "dummy potential";}
 
@@ -109,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_VerletList_PeriodicBoundary)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         for(std::size_t j=i+1; j<N; ++j)
         {
@@ -134,7 +151,7 @@ BOOST_AUTO_TEST_CASE(test_VerletList_PeriodicBoundary)
     }
 
     // check parameter_type.
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         for(const auto& p_j : vlist.partners(i))
         {
@@ -196,7 +213,7 @@ BOOST_AUTO_TEST_CASE(test_VerletList_PeriodicBoundary_partial)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         const auto partners = vlist.partners(i);
 
@@ -296,7 +313,7 @@ BOOST_AUTO_TEST_CASE(test_VerletList_PeriodicBoundary_partial_2)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         const auto partners = vlist.partners(i);
 

--- a/test/core/test_unlimited_cell_list.cpp
+++ b/test/core/test_unlimited_cell_list.cpp
@@ -8,6 +8,7 @@
 
 #include <mjolnir/util/empty.hpp>
 #include <mjolnir/util/logger.hpp>
+#include <mjolnir/util/range.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/UnlimitedGridCellList.hpp>
@@ -41,7 +42,6 @@ struct dummy_potential
 
     bool is_ignored_molecule(std::size_t, std::size_t) const {return false;}
     bool is_ignored_group   (std::string, std::string) const {return false;}
-    bool has_interaction    (std::size_t, std::size_t) const {return true;}
 
     std::vector<std::pair<connection_kind_type, std::size_t>> ignore_within() const
     {
@@ -51,6 +51,22 @@ struct dummy_potential
     std::vector<std::size_t> const& participants() const noexcept
     {
         return this->participants_;
+    }
+    mjolnir::range<typename std::vector<std::size_t>::const_iterator>
+    leading_participants() const noexcept
+    {
+        return mjolnir::make_range(participants_.begin(), std::prev(participants_.end()));
+    }
+    mjolnir::range<typename std::vector<std::size_t>::const_iterator>
+    possible_partners_of(const std::size_t participant_idx,
+                         const std::size_t /*particle_idx*/) const noexcept
+    {
+        return mjolnir::make_range(participants_.begin() + participant_idx + 1,
+                          participants_.end());
+    }
+    bool has_interaction(const std::size_t i, const std::size_t j) const noexcept
+    {
+        return (i < j);
     }
 
     std::string name() const {return "dummy potential";}
@@ -110,7 +126,7 @@ BOOST_AUTO_TEST_CASE(test_CellList_UnlimitedBoundary)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         for(std::size_t j=i+1; j<N; ++j)
         {
@@ -187,7 +203,7 @@ BOOST_AUTO_TEST_CASE(test_CellList_UnlimitedBoundary_partial)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         const auto partners = vlist.partners(i);
 
@@ -288,7 +304,7 @@ BOOST_AUTO_TEST_CASE(test_CellList_UnlimitedBoundary_partial_2)
     vlist.make(sys, pot);
     BOOST_TEST(vlist.valid());
 
-    for(const auto i : participants)
+    for(const auto i : pot.leading_participants())
     {
         const auto partners = vlist.partners(i);
 


### PR DESCRIPTION
related to #153 and #161; to support such kinds of interactions in the fastest and simplest way.

The interaction implemented in #161 can be implemented without this, but implementing it without this change requires to re-implement Verlet list that is specific to the interaction and it might slow down the simulation. Also, this PR makes the input table consistent with other global interactions.