### PR TITLE
refactor: math vector related stuffs and AxisAlignedPlane

### DIFF
--- a/mjolnir/core/AxisAlignedPlane.hpp
+++ b/mjolnir/core/AxisAlignedPlane.hpp
@@ -9,141 +9,123 @@ namespace mjolnir
 {
 
 /* These classes represents Normal Vectors. (+/- * XYZ) */
-template<typename traitsT>
-class PositiveXDirection
+
+template<typename realT>
+class PositiveDirection
+{
+  public:
+    using real_type = realT;
+    static constexpr real_type sign() {return real_type(1);}
+};
+template<typename realT>
+class NegativeDirection
+{
+  public:
+    using real_type = realT;
+    static constexpr real_type sign() {return real_type(-1);}
+};
+
+template<typename traitsT, template<typename> class Direction>
+class XAxis
 {
   public:
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using direction_type  = Direction<real_type>;
 
-    static constexpr std::size_t index = 0; // index in coordinate_type
-    static constexpr real_type   sign  = 1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(length, 0, 0);}
+    static constexpr real_type sign() noexcept {return direction_type::sign();}
+
+    static coordinate_type get_normal_vector() noexcept
+    {
+        return math::make_coordinate<coordinate_type>(
+                direction_type::sign() * 1.0, 0, 0);
+    }
+    static real_type& get_coordinate(coordinate_type&       v) noexcept {return math::X(v);}
+    static real_type  get_coordinate(coordinate_type const& v) noexcept {return math::X(v);}
 };
-template<typename T>
-constexpr std::size_t PositiveXDirection<T>::index;
-template<typename T>
-constexpr typename PositiveXDirection<T>::real_type PositiveXDirection<T>::sign;
 
-template<typename traitsT>
-class NegativeXDirection
+template<typename traitsT, template<typename> class Direction>
+class YAxis
 {
   public:
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using direction_type  = Direction<real_type>;
 
-    static constexpr std::size_t index =  0;
-    static constexpr real_type   sign  = -1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(-length, 0, 0);}
+    static constexpr real_type sign() noexcept {return direction_type::sign();}
+
+    static coordinate_type get_normal_vector() noexcept
+    {
+        return math::make_coordinate<coordinate_type>(
+                0, direction_type::sign() * 1.0, 0);
+    }
+    static real_type& get_coordinate(coordinate_type&       v) noexcept {return math::Y(v);}
+    static real_type  get_coordinate(coordinate_type const& v) noexcept {return math::Y(v);}
 };
-template<typename T>
-constexpr std::size_t NegativeXDirection<T>::index;
-template<typename T>
-constexpr typename NegativeXDirection<T>::real_type NegativeXDirection<T>::sign;
 
-template<typename traitsT>
-class PositiveYDirection
+template<typename traitsT, template<typename> class Direction>
+class ZAxis
 {
   public:
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using direction_type  = Direction<real_type>;
 
-    static constexpr std::size_t index = 1; // index in coordinate_type
-    static constexpr real_type   sign  = 1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(0, length, 0);}
+    static constexpr real_type sign() noexcept {return direction_type::sign();}
+
+    static coordinate_type get_normal_vector() noexcept
+    {
+        return math::make_coordinate<coordinate_type>(
+                0, 0, direction_type::sign() * 1.0);
+    }
+    static real_type& get_coordinate(coordinate_type&       v) noexcept {return math::Z(v);}
+    static real_type  get_coordinate(coordinate_type const& v) noexcept {return math::Z(v);}
 };
-template<typename T>
-constexpr std::size_t PositiveYDirection<T>::index;
-template<typename T>
-constexpr typename PositiveYDirection<T>::real_type PositiveYDirection<T>::sign;
 
 template<typename traitsT>
-class NegativeYDirection
-{
-  public:
-    using traits_type     = traitsT;
-    using real_type       = typename traits_type::real_type;
-    using coordinate_type = typename traits_type::coordinate_type;
-
-    static constexpr std::size_t index =  1;
-    static constexpr real_type   sign  = -1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(0, -length, 0);}
-};
-template<typename T>
-constexpr std::size_t NegativeYDirection<T>::index;
-template<typename T>
-constexpr typename NegativeYDirection<T>::real_type NegativeYDirection<T>::sign;
+using PositiveXDirection = XAxis<traitsT, PositiveDirection>;
+template<typename traitsT>
+using NegativeXDirection = XAxis<traitsT, NegativeDirection>;
 
 template<typename traitsT>
-class PositiveZDirection
-{
-  public:
-    using traits_type     = traitsT;
-    using real_type       = typename traits_type::real_type;
-    using coordinate_type = typename traits_type::coordinate_type;
-
-    static constexpr std::size_t index = 2; // index in coordinate_type
-    static constexpr real_type   sign  = 1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(0, 0, length);}
-};
-template<typename T>
-constexpr std::size_t PositiveZDirection<T>::index;
-template<typename T>
-constexpr typename PositiveZDirection<T>::real_type PositiveZDirection<T>::sign;
+using PositiveYDirection = YAxis<traitsT, PositiveDirection>;
+template<typename traitsT>
+using NegativeYDirection = YAxis<traitsT, NegativeDirection>;
 
 template<typename traitsT>
-class NegativeZDirection
-{
-  public:
-    using traits_type     = traitsT;
-    using real_type       = typename traits_type::real_type;
-    using coordinate_type = typename traits_type::coordinate_type;
-
-    static constexpr std::size_t index =  2;
-    static constexpr real_type   sign  = -1.0;
-    static coordinate_type invoke(const real_type length = 1.0) noexcept
-    {return math::make_coordinate<coordinate_type>(0, 0, -length);}
-};
-template<typename T>
-constexpr std::size_t NegativeZDirection<T>::index;
-template<typename T>
-constexpr typename NegativeZDirection<T>::real_type NegativeZDirection<T>::sign;
+using PositiveZDirection = ZAxis<traitsT, PositiveDirection>;
+template<typename traitsT>
+using NegativeZDirection = ZAxis<traitsT, NegativeDirection>;
 
 /*! @brief axis aligned Plane for ExternalDistanceInteraction.                *
  *  @details represents flat Plane. It provides a method to calculate         *
  *           a distance between particle and the plane, force direction       *
  *           a position of a particle. It also provide a functionality of     *
  *           a neighbor-list.                                                 */
-template<typename traitsT, template<typename> class normal_axisT>
+template<typename traitsT, typename axisT>
 class AxisAlignedPlane
 {
   public:
     using traits_type      = traitsT;
+    using axis_type        = axisT;
     using system_type      = System<traits_type>;
     using real_type        = typename traits_type::real_type;
     using coordinate_type  = typename traits_type::coordinate_type;
     using boundary_type    = typename traits_type::boundary_type;
-    using normal_axis_type = normal_axisT<traits_type>;
-    static constexpr std::size_t axis_index = normal_axis_type::index;
-    static constexpr real_type   axis_sign  = normal_axis_type::sign;
 
   public:
 
     AxisAlignedPlane(const real_type position, const real_type margin = 1)
-        : margin_(margin), current_margin_(-1), origin_(0, 0, 0)
+        : margin_(margin), current_margin_(-1),
+          origin_(math::make_coordinate<coordinate_type>(0,0,0))
     {
         MJOLNIR_GET_DEFAULT_LOGGER();
         MJOLNIR_LOG_FUNCTION();
 
-        this->origin_[axis_index] = position;
+        axis_type::get_coordinate(this->origin_) = position;
 
         MJOLNIR_LOG_INFO("position        = ", position);
         MJOLNIR_LOG_INFO("origin of plane = ", this->origin_);
@@ -154,7 +136,8 @@ class AxisAlignedPlane
     inline real_type
     calc_distance(const coordinate_type& pos, const boundary_type& bd) const
     {
-        return axis_sign * bd.adjust_direction(pos - this->origin_)[axis_index];
+        return axis_type::sign() * axis_type::get_coordinate(
+                bd.adjust_direction(pos - this->origin_));
     }
 
     //XXX take care. the actual force that would be applied to a particle is
@@ -162,7 +145,7 @@ class AxisAlignedPlane
     coordinate_type calc_force_direction(
             const coordinate_type&, const boundary_type&) const
     {
-        return normal_axis_type::invoke();
+        return axis_type::get_normal_vector();
     }
 
     template<typename Potential>
@@ -186,8 +169,34 @@ class AxisAlignedPlane
     }
 
     // neighbor-list stuff
-    void make  (const system_type& sys);
-    void update(const real_type dm, const system_type& sys);
+    void make  (const system_type& sys)
+    {
+        this->neighbors_.clear();
+        const real_type threshold = this->cutoff_ * (1 + this->margin_);
+        const real_type thr2 = threshold * threshold;
+
+        for(std::size_t i : this->participant_)
+        {
+            const auto d = this->calc_distance(sys.position(i), sys.boundary());
+            if(d * d <= thr2)
+            {
+                this->neighbors_.push_back(i);
+            }
+        }
+
+        this->current_margin_ = this->cutoff_ * this->margin_;
+        return;
+    }
+
+    void update(const real_type dmargin, const system_type& sys)
+    {
+        this->current_margin_ -= dmargin;
+        if(this->current_margin_ < 0)
+        {
+            this->make(sys);
+        }
+        return;
+    }
 
     std::vector<std::size_t> const& neighbors() const noexcept
     {return this->neighbors_;}
@@ -199,43 +208,6 @@ class AxisAlignedPlane
     std::vector<std::size_t> neighbors_;   // being inside of cutoff range
     std::vector<std::size_t> participant_; // particle that interacts with
 };
-template<typename traitsT, template<typename> class NormalAxis>
-constexpr std::size_t AxisAlignedPlane<traitsT, NormalAxis>::axis_index;
-template<typename traitsT, template<typename> class NormalAxis>
-constexpr typename AxisAlignedPlane<traitsT, NormalAxis>::real_type
-    AxisAlignedPlane<traitsT, NormalAxis>::axis_sign;
-
-template<typename traitsT, template<typename> class NormalAxis>
-void AxisAlignedPlane<traitsT, NormalAxis>::update(
-        const real_type dmargin, const system_type& sys)
-{
-    this->current_margin_ -= dmargin;
-    if(this->current_margin_ < 0)
-    {
-        this->make(sys);
-    }
-    return;
-}
-
-template<typename traitsT, template<typename> class NormalAxis>
-void AxisAlignedPlane<traitsT, NormalAxis>::make(const system_type& sys)
-{
-    this->neighbors_.clear();
-    const real_type threshold = this->cutoff_ * (1 + this->margin_);
-    const real_type thr2 = threshold * threshold;
-
-    for(std::size_t i : this->participant_)
-    {
-        const auto d = this->calc_distance(sys.position(i), sys.boundary());
-        if(d * d <= thr2)
-        {
-            this->neighbors_.push_back(i);
-        }
-    }
-
-    this->current_margin_ = this->cutoff_ * this->margin_;
-    return;
-}
 
 } // mjolnir
 #endif // MJOLNIR_AXIS_ALIGNED_PLANE_HPP

--- a/mjolnir/input/read_external_interaction.hpp
+++ b/mjolnir/input/read_external_interaction.hpp
@@ -92,42 +92,43 @@ read_external_distance_interaction_shape(const toml::value& external)
         if(axis == "X" || axis == "+X")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is YZ-Plane (+).");
-            using shape_t = AxisAlignedPlane<traitsT, PositiveXDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, PositiveXDirection<traitsT>>;
+
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }
         else if(axis == "-X")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is YZ-Plane (-).");
-            using shape_t = AxisAlignedPlane<traitsT, NegativeXDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, NegativeXDirection<traitsT>>;
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }
         else if(axis == "Y" || axis == "+Y")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is ZX-Plane (+).");
-            using shape_t = AxisAlignedPlane<traitsT, PositiveYDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, PositiveYDirection<traitsT>>;
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }
         else if(axis == "-Y")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is ZX-Plane (-).");
-            using shape_t = AxisAlignedPlane<traitsT, NegativeYDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, NegativeYDirection<traitsT>>;
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }
         else if(axis == "Z" || axis == "+Z")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is XY-Plane (+).");
-            using shape_t = AxisAlignedPlane<traitsT, PositiveZDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, PositiveZDirection<traitsT>>;
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }
         else if(axis == "-Z")
         {
             MJOLNIR_LOG_NOTICE("-- interaction shape is XY-Plane (-).");
-            using shape_t = AxisAlignedPlane<traitsT, NegativeZDirection>;
+            using shape_t = AxisAlignedPlane<traitsT, NegativeZDirection<traitsT>>;
             return read_external_distance_interaction<traitsT, shape_t>(
                     external, shape_t(pos, margin));
         }

--- a/mjolnir/input/read_external_interaction.hpp
+++ b/mjolnir/input/read_external_interaction.hpp
@@ -159,6 +159,7 @@ read_external_position_restraint_interaction(const toml::value& external)
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_LOG_FUNCTION();
     using real_type       = typename traitsT::real_type;
+    using coordinate_type = typename traitsT::coordinate_type;
 
     const auto& env = external.as_table().count("env") == 1 ?
                       external.as_table().at("env") : toml::value{};
@@ -180,13 +181,14 @@ read_external_position_restraint_interaction(const toml::value& external)
         {
             const auto idx = find_parameter<std::size_t>(para, env, "index");
             const auto pos = find_parameter<std::array<real_type, 3>>(para, env, "position");
+            const auto crd = math::make_coordinate<coordinate_type>(pos[0], pos[1], pos[2]);
 
             // suppress warnings in read_harmonic_potential
             para.as_table().erase("index");
             para.as_table().erase("position");
 
             const auto pot = read_harmonic_potential<real_type>(para, env);
-            potentials.emplace_back(idx, pos, pot);
+            potentials.emplace_back(idx, crd, pot);
         }
         return make_unique<interaction_t>(std::move(potentials));
     }

--- a/mjolnir/input/read_system.hpp
+++ b/mjolnir/input/read_system.hpp
@@ -56,7 +56,9 @@ struct read_boundary_impl<CuboidalPeriodicBoundary<realT, coordT>>
         }
         MJOLNIR_LOG_INFO("upper limit of the boundary = ", upper);
         MJOLNIR_LOG_INFO("lower limit of the boundary = ", lower);
-        return CuboidalPeriodicBoundary<realT, coordT>(lower, upper);
+        return CuboidalPeriodicBoundary<realT, coordT>(
+            math::make_coordinate<coordT>(lower[0], lower[1], lower[2]),
+            math::make_coordinate<coordT>(upper[0], upper[1], upper[2]));
     }
 };
 
@@ -130,13 +132,16 @@ read_system(const toml::value& root, const std::size_t N)
         check_keys_available(p, {"mass"_s, "m"_s, "position"_s, "pos"_s,
                 "velocity"_s, "vel"_s, "name"_s, "group"_s});
 
-        sys.mass(i)     = toml::get<real_type>(find_either(p, "m",   "mass"));
-        sys.position(i) = toml::get< vec_type>(find_either(p, "pos", "position"));
+        sys.mass(i) = toml::get<real_type>(find_either(p, "m", "mass"));
+
+        const auto pos = toml::get<vec_type>(find_either(p, "pos", "position"));
+        sys.position(i) = math::make_coordinate<coordinate_type>(pos[0], pos[1], pos[2]);
         sys.velocity(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
 
         if(sys.velocity_initialized()) // it requires `velocity`.
         {
-            sys.velocity(i) = toml::get<vec_type>(find_either(p, "vel", "velocity"));
+            const auto vel = toml::get<vec_type>(find_either(p, "vel", "velocity"));
+            sys.velocity(i) = math::make_coordinate<coordinate_type>(vel[0], vel[1], vel[2]);
         }
         else // velocity should not be there. check it.
         {

--- a/mjolnir/omp/sort.hpp
+++ b/mjolnir/omp/sort.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <utility>
 #include <vector>
+#include <cassert>
 #include <omp.h>
 
 namespace mjolnir

--- a/test/core/test_axis_aligned_plane_shape.cpp
+++ b/test/core/test_axis_aligned_plane_shape.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedPlane_PositiveZ_geometry_unlimited)
     std::uniform_real_distribution<double> uni(-100, 100);
 
     boundary_type bdry;
-    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection> xyplane(0.0);
+    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>> xyplane(0.0);
 
     for(std::size_t i=0; i<100000; ++i)
     {
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedPlane_NegativeZ_geometry_unlimited)
     std::uniform_real_distribution<double> uni(-100, 100);
 
     boundary_type bdry;
-    mjolnir::AxisAlignedPlane<traits_type, mjolnir::NegativeZDirection> xyplane(0.0);
+    mjolnir::AxisAlignedPlane<traits_type, mjolnir::NegativeZDirection<traits_type>> xyplane(0.0);
 
     for(std::size_t i=0; i<100000; ++i)
     {
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedPlane_geometry_periodic)
 
     const coord_type lower(0, 0, 0), upper(100, 100, 100);
     boundary_type bdry(lower, upper);
-    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection> xyplane(0.0);
+    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>> xyplane(0.0);
 
     for(std::size_t i=0; i<100000; ++i)
     {
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(AxisAlignedPlane_neighbors_unlimited)
     }
 
     dummy_potential<double> dummy; dummy.cutoff = 1.0; dummy.N = 1000;
-    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection>
+    mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>>
         xyplane(0.0, 0.0); // no mergin here
     xyplane.initialize(sys, dummy);
 

--- a/test/core/test_read_external_forcefield.cpp
+++ b/test/core/test_read_external_forcefield.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(read_external_forcefield)
 
         const auto derived_ptr  = dynamic_cast<mjolnir::ExternalDistanceInteraction<
             traits_type, mjolnir::ExcludedVolumeWallPotential<real_type>,
-            mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection>
+            mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection<traits_type>>
             >*>(interaction_ptr.get());
         BOOST_TEST(static_cast<bool>(derived_ptr));
     }
@@ -115,11 +115,11 @@ BOOST_AUTO_TEST_CASE(read_several_external_forcefield)
 
         using exv_interaction = mjolnir::ExternalDistanceInteraction<
             traits_type, mjolnir::ExcludedVolumeWallPotential<real_type>,
-            mjolnir::AxisAlignedPlane<traits_type, mjolnir::NegativeXDirection>
+            mjolnir::AxisAlignedPlane<traits_type, mjolnir::NegativeXDirection<traits_type>>
             >;
         using lj_interaction = mjolnir::ExternalDistanceInteraction<
             traits_type, mjolnir::LennardJonesWallPotential<real_type>,
-            mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection>
+            mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection<traits_type>>
             >;
 
         std::map<std::type_index, bool> found;

--- a/test/integration/test_BAOABIntegrator/test_BAOABIntegrator.cpp
+++ b/test/integration/test_BAOABIntegrator/test_BAOABIntegrator.cpp
@@ -59,7 +59,7 @@ bool inject_test_potential(std::unique_ptr<mjolnir::SimulatorBase>& sim_base)
     using integrator_type = mjolnir::BAOABLangevinIntegrator<traits_type>;
     using simulator_type  = mjolnir::MolecularDynamicsSimulator<traits_type, integrator_type>;
 
-    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection>;
+    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveXDirection<traits_type>>;
     using potential_type   = mjolnir::TestPotential<typename traits_type::real_type>;
     using interaction_type = mjolnir::ExternalDistanceInteraction<traits_type, potential_type, shape_type>;
 

--- a/test/omp/test_omp_external_distance_interaction.cpp
+++ b/test/omp/test_omp_external_distance_interaction.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(omp_ExternalDistacne_calc_force)
     using system_type      = mjolnir::System<traits_type>;
     using potential_type   = mjolnir::LennardJonesWallPotential<real_type>;
     using parameter_type   = typename potential_type::parameter_type;
-    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection>;
+    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>>;
     using interaction_type = mjolnir::ExternalDistanceInteraction<traits_type, potential_type, shape_type>;
     using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
 
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(omp_ExternalDistacne_calc_force)
         mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>>;
     using sequencial_shape_type       = mjolnir::AxisAlignedPlane<
         mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>,
-        mjolnir::PositiveZDirection>;
+        mjolnir::PositiveZDirection<traits_type>>;
     using sequencial_interaction_type = mjolnir::ExternalDistanceInteraction<
         mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>,
         potential_type, sequencial_shape_type>;


### PR DESCRIPTION
- always use `math::X` and others instead of `operator[]`.
- always use `math::make_coordinate` instead of `coordinate_type(1,2,3)`
- refactor AxisAlignedPlane a bit