### PR TITLE
refactoring: read_simulator

### DIFF
--- a/mjolnir/input/CMakeLists.txt
+++ b/mjolnir/input/CMakeLists.txt
@@ -9,6 +9,7 @@ set(mjolnir_input_cpp_files
     "${CMAKE_CURRENT_SOURCE_DIR}/read_local_interaction.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/read_local_potential.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/read_observer.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/read_random_number_generator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/read_simulator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/read_spatial_partition.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/read_system.cpp"

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -86,6 +86,45 @@ read_BAOAB_langevin_integrator(const toml::value& simulator)
     return BAOABLangevinIntegrator<traitsT>(delta_t, std::move(gamma));
 }
 
+// A mapping object from type information (template parameter) to the actual
+// read_xxx_integrator function
+
+template<typename T>
+struct read_integrator_impl;
+
+template<typename traitsT>
+struct read_integrator_impl<VelocityVerletIntegrator<traitsT>>
+{
+    static VelocityVerletIntegrator<traitsT> invoke(const toml::value& sim)
+    {
+        return read_velocity_verlet_integrator<traitsT>(sim);
+    }
+};
+
+template<typename traitsT>
+struct read_integrator_impl<UnderdampedLangevinIntegrator<traitsT>>
+{
+    static UnderdampedLangevinIntegrator<traitsT> invoke(const toml::value& sim)
+    {
+        return read_underdamped_langevin_integrator<traitsT>(sim);
+    }
+};
+
+template<typename traitsT>
+struct read_integrator_impl<BAOABLangevinIntegrator<traitsT>>
+{
+    static BAOABLangevinIntegrator<traitsT> invoke(const toml::value& sim)
+    {
+        return read_underdamped_langevin_integrator<traitsT>(sim);
+    }
+};
+
+template<typename integratorT>
+integratorT read_integrator(const toml::value& sim)
+{
+    return read_integrator_impl<integratorT>::invoke(sim);
+}
+
 #ifdef MJOLNIR_SEPARATE_BUILD
 extern template VelocityVerletIntegrator<SimulatorTraits<double, UnlimitedBoundary>       > read_velocity_verlet_integrator(const toml::value& simulator);
 extern template VelocityVerletIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       > read_velocity_verlet_integrator(const toml::value& simulator);

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -115,28 +115,24 @@ struct read_integrator_impl<BAOABLangevinIntegrator<traitsT>>
 {
     static BAOABLangevinIntegrator<traitsT> invoke(const toml::value& sim)
     {
-        return read_underdamped_langevin_integrator<traitsT>(sim);
-    }
-};
-
-// An empty struct that represents there is no integrator definition.
-struct NoIntegrator{};
-
-template<>
-struct read_integrator_impl<NoIntegrator>
-{
-    [[noreturn]]
-    static NoIntegrator invoke(const toml::value& sim)
-    {
-        throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_integrator: No integrator is defined. ",
-            sim, "here", {}));
+        return read_BAOAB_langevin_integrator<traitsT>(sim);
     }
 };
 
 template<typename integratorT>
 integratorT read_integrator(const toml::value& sim)
 {
+    if(sim.as_table().count("integrator") == 0)
+    {
+        throw_exception<std::runtime_error>(toml::format_error("[error] "
+            "mjolnir::read_integrator: No integrator defined: ", sim, "here", {
+            "expected value is one of the following.",
+            "- \"VelocityVerlet\"     : simple and standard Velocity Verlet integrator.",
+            "- \"UnderdampedLangevin\": simple Underdamped Langevin Integrator"
+                                      " based on the Velocity Verlet",
+            "- \"BAOABLangevin\"      : well-known BAOAB Langevin Integrator"
+            }));
+    }
     return read_integrator_impl<integratorT>::invoke(sim);
 }
 

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -6,6 +6,7 @@
 #include <mjolnir/core/BAOABLangevinIntegrator.hpp>
 #include <mjolnir/input/utility.hpp>
 #include <mjolnir/util/logger.hpp>
+#include <mjolnir/util/throw_exception.hpp>
 
 namespace mjolnir
 {
@@ -88,7 +89,6 @@ read_BAOAB_langevin_integrator(const toml::value& simulator)
 
 // A mapping object from type information (template parameter) to the actual
 // read_xxx_integrator function
-
 template<typename T>
 struct read_integrator_impl;
 
@@ -116,6 +116,21 @@ struct read_integrator_impl<BAOABLangevinIntegrator<traitsT>>
     static BAOABLangevinIntegrator<traitsT> invoke(const toml::value& sim)
     {
         return read_underdamped_langevin_integrator<traitsT>(sim);
+    }
+};
+
+// An empty struct that represents there is no integrator definition.
+struct NoIntegrator{};
+
+template<>
+struct read_integrator_impl<NoIntegrator>
+{
+    [[noreturn]]
+    static NoIntegrator invoke(const toml::value& sim)
+    {
+        throw_exception<std::runtime_error>(toml::format_error("[error] "
+            "mjolnir::read_integrator: No integrator is defined. ",
+            sim, "here", {}));
     }
 };
 

--- a/mjolnir/input/read_random_number_generator.cpp
+++ b/mjolnir/input/read_random_number_generator.cpp
@@ -1,0 +1,13 @@
+#include <mjolnir/input/read_random_number_generator.hpp>
+
+#ifndef MJOLNIR_SEPARATE_BUILD
+#error "MJOLNIR_SEPARATE_BUILD flag is required"
+#endif
+
+namespace mjolnir
+{
+template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+} // mjolnir

--- a/mjolnir/input/read_random_number_generator.hpp
+++ b/mjolnir/input/read_random_number_generator.hpp
@@ -1,0 +1,57 @@
+#ifndef MJOLNIR_INPUT_READ_RANDOM_NUMBER_GENERATOR_HPP
+#define MJOLNIR_INPUT_READ_RANDOM_NUMBER_GENERATOR_HPP
+#include <extlib/toml/toml.hpp>
+#include <mjolnir/util/logger.hpp>
+#include <mjolnir/core/RandomNumberGenerator.hpp>
+
+namespace mjolnir
+{
+
+template<typename traitsT>
+RandomNumberGenerator<traitsT> read_rng(const toml::value& simulator)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    MJOLNIR_LOG_FUNCTION();
+
+    std::uint32_t seed = 0;
+    if(simulator.as_table().count("integrator") != 0)
+    {
+        const auto& integrator = toml::find(simulator, "integrator");
+        if(integrator.as_table().count("seed") != 0)
+        {
+            MJOLNIR_LOG_WARN("deprecated: put `seed` under [simulator] table.");
+            MJOLNIR_LOG_WARN("deprecated: ```toml");
+            MJOLNIR_LOG_WARN("deprecated: [simulator]");
+            MJOLNIR_LOG_WARN("deprecated: seed = 12345");
+            MJOLNIR_LOG_WARN("deprecated: ```");
+            seed = toml::find<std::uint32_t>(integrator, "seed");
+        }
+        else
+        {
+            seed = toml::find<std::uint32_t>(simulator, "seed");
+        }
+    }
+    else
+    {
+        seed = toml::find<std::uint32_t>(simulator, "seed");
+    }
+    MJOLNIR_LOG_NOTICE("seed is ", seed);
+    return RandomNumberGenerator<traitsT>(seed);
+}
+
+} // mjolnir
+
+#ifdef MJOLNIR_SEPARATE_BUILD
+#include <mjolnir/core/SimulatorTraits.hpp>
+#include <mjolnir/core/BoundaryCondition.hpp>
+
+namespace mjolnir
+{
+extern template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
+extern template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
+extern template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+extern template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+}
+#endif // MJOLNIR_SEPARATE_BUILD
+
+#endif// MJOLNIR_INPUT_READ_RANDOM_NUMBER_GENERATOR_HPP

--- a/mjolnir/input/read_simulator.cpp
+++ b/mjolnir/input/read_simulator.cpp
@@ -6,33 +6,97 @@
 
 namespace mjolnir
 {
-template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
 
-template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+// ----------------------------------------------------------------------------
+// read_molecular_dynamics_simulator
+
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+// ----------------------------------------------------------------------------
+// read_simulated_annealing_simulator
+
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulated_annealing_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+// ----------------------------------------------------------------------------
+// read_steepest_descent_simulator
 
 template std::unique_ptr<SimulatorBase> read_steepest_descent_simulator<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
 template std::unique_ptr<SimulatorBase> read_steepest_descent_simulator<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
 template std::unique_ptr<SimulatorBase> read_steepest_descent_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
 template std::unique_ptr<SimulatorBase> read_steepest_descent_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
 
-template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_molecular_dynamics_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+// ----------------------------------------------------------------------------
+// read_switching_forcefield_simulator
 
-template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
-template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
 
-template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_switching_forcefield_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+// ----------------------------------------------------------------------------
+// read_simulator
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , VelocityVerletIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, VelocityVerletIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , UnderdampedLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, UnderdampedLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  UnlimitedBoundary>       , BAOABLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       >>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<double, CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_simulator<SimulatorTraits<float,  CuboidalPeriodicBoundary>, BAOABLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>>(const toml::value&, const toml::value&);
+
+// ----------------------------------------------------------------------------
+// read_integrator_type
+
+template std::unique_ptr<SimulatorBase> read_integrator_type<SimulatorTraits<double, UnlimitedBoundary>       >(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_integrator_type<SimulatorTraits<float,  UnlimitedBoundary>       >(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_integrator_type<SimulatorTraits<double, CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+template std::unique_ptr<SimulatorBase> read_integrator_type<SimulatorTraits<float,  CuboidalPeriodicBoundary>>(const toml::value&, const toml::value&);
+
+
 } // mjolnir

--- a/mjolnir/input/read_simulator.cpp
+++ b/mjolnir/input/read_simulator.cpp
@@ -6,10 +6,6 @@
 
 namespace mjolnir
 {
-template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
-template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
 
 // ----------------------------------------------------------------------------
 // read_molecular_dynamics_simulator

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -12,42 +12,11 @@
 #include <mjolnir/input/read_forcefield.hpp>
 #include <mjolnir/input/read_integrator.hpp>
 #include <mjolnir/input/read_observer.hpp>
+#include <mjolnir/input/read_random_number_generator.hpp>
 #include <mjolnir/input/read_path.hpp>
 
 namespace mjolnir
 {
-
-template<typename traitsT>
-RandomNumberGenerator<traitsT> read_rng(const toml::value& simulator)
-{
-    MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_LOG_FUNCTION();
-
-    std::uint32_t seed = 0;
-    if(simulator.as_table().count("integrator") != 0)
-    {
-        const auto& integrator = toml::find(simulator, "integrator");
-        if(integrator.as_table().count("seed") != 0)
-        {
-            MJOLNIR_LOG_WARN("deprecated: put `seed` under [simulator] table.");
-            MJOLNIR_LOG_WARN("deprecated: ```toml");
-            MJOLNIR_LOG_WARN("deprecated: [simulator]");
-            MJOLNIR_LOG_WARN("deprecated: seed = 12345");
-            MJOLNIR_LOG_WARN("deprecated: ```");
-            seed = toml::find<std::uint32_t>(integrator, "seed");
-        }
-        else
-        {
-            seed = toml::find<std::uint32_t>(simulator, "seed");
-        }
-    }
-    else
-    {
-        seed = toml::find<std::uint32_t>(simulator, "seed");
-    }
-    MJOLNIR_LOG_NOTICE("seed is ", seed);
-    return RandomNumberGenerator<traitsT>(seed);
-}
 
 template<typename traitsT, typename integratorT>
 std::unique_ptr<SimulatorBase>
@@ -363,11 +332,6 @@ read_integrator_type(const toml::value& root, const toml::value& simulator)
 
 namespace mjolnir
 {
-extern template RandomNumberGenerator<SimulatorTraits<double, UnlimitedBoundary>       > read_rng(const toml::value&);
-extern template RandomNumberGenerator<SimulatorTraits<float,  UnlimitedBoundary>       > read_rng(const toml::value&);
-extern template RandomNumberGenerator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_rng(const toml::value&);
-extern template RandomNumberGenerator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_rng(const toml::value&);
-
 // ----------------------------------------------------------------------------
 // read_molecular_dynamics_simulator
 

--- a/mjolnir/input/read_units.hpp
+++ b/mjolnir/input/read_units.hpp
@@ -128,7 +128,7 @@ read_units(const toml::value& root, const toml::value& simulator)
     MJOLNIR_LOG_INFO(u8"phys::ε0 = ", phys_type::eps0(),
                      " [e^2 / (", energy, '*', length, ")]");
 
-    return read_simulator<traitsT>(root, simulator);
+    return read_integrator_type<traitsT>(root, simulator);
 }
 
 #ifdef MJOLNIR_SEPARATE_BUILD

--- a/test/core/test_read_molecular_dynamics_simulator.cpp
+++ b/test/core/test_read_molecular_dynamics_simulator.cpp
@@ -14,28 +14,52 @@ BOOST_AUTO_TEST_CASE(read_newtonian_molecular_dynamics_simulator)
 
     using real_type = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
-    constexpr real_type tol = 1e-8;
-    auto root = mjolnir::test::make_empty_input();
-    {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            type            = "MolecularDynamics"
-            integrator.type = "VelocityVerlet"
-            precision       = "double"
-            boundary_type   = "Unlimited"
-            seed            = 12345
-            delta_t         = 0.1
-            total_step      = 100
-            save_step       = 10
-        )"_toml;
+    using integrator_type = mjolnir::VelocityVerletIntegrator<traits_type>;
 
-        root.as_table()["simulator"] = v;
-        const auto sim = mjolnir::read_simulator<traits_type>(root, v);
-        BOOST_TEST(static_cast<bool>(sim));
+    constexpr real_type tol = 1e-8;
+
+    auto root = mjolnir::test::make_empty_input();
+    using namespace toml::literals;
+    const auto v = u8R"(
+        type            = "MolecularDynamics"
+        integrator.type = "VelocityVerlet"
+        precision       = "double"
+        boundary_type   = "Unlimited"
+        seed            = 12345
+        delta_t         = 0.1
+        total_step      = 100
+        save_step       = 10
+    )"_toml;
+    root.as_table()["simulator"] = v;
+
+    {
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
 
         const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
-            traits_type, mjolnir::VelocityVerletIntegrator<traits_type>>*>(sim.get());
-        BOOST_TEST(static_cast<bool>(mdsim));
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        sim->initialize();
+        for(std::size_t i=0; i<99; ++i)
+        {
+            BOOST_TEST(mdsim->time() == i * 0.1, boost::test_tools::tolerance(tol));
+            BOOST_TEST(sim->step()); // check it can step
+        }
+        // at the last (100-th) step, it returns false to stop the simulation.
+        BOOST_TEST(!sim->step());
+        sim->finalize();
+    }
+
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
 
         BOOST_TEST(mdsim->rng().seed() == 12345u);
 
@@ -57,30 +81,32 @@ BOOST_AUTO_TEST_CASE(read_langevin_molecular_dynamics_simulator)
 
     using real_type = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::UnderdampedLangevinIntegrator<traits_type>;
+
     constexpr real_type tol = 1e-8;
+
     auto root = mjolnir::test::make_empty_input();
+    using namespace toml::literals;
+    const auto v = u8R"(
+        type            = "MolecularDynamics"
+        integrator.type = "UnderdampedLangevin"
+        integrator.parameters = []
+        seed            = 12345
+        precision       = "double"
+        boundary_type   = "Unlimited"
+        delta_t         = 0.1
+        total_step      = 100
+        save_step       = 10
+    )"_toml;
+    root.as_table()["simulator"] = v;
 
     {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            type            = "MolecularDynamics"
-            integrator.type = "UnderdampedLangevin"
-            integrator.parameters = []
-            seed            = 12345
-            precision       = "double"
-            boundary_type   = "Unlimited"
-            delta_t         = 0.1
-            total_step      = 100
-            save_step       = 10
-        )"_toml;
-
-        root.as_table()["simulator"] = v;
-        const auto sim = mjolnir::read_simulator<traits_type>(root, v);
-        BOOST_TEST(static_cast<bool>(sim));
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
 
         const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
-            traits_type, mjolnir::UnderdampedLangevinIntegrator<traits_type>>*>(sim.get());
-        BOOST_TEST(static_cast<bool>(mdsim));
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
 
         BOOST_TEST(mdsim->rng().seed() == 12345u);
 
@@ -94,6 +120,28 @@ BOOST_AUTO_TEST_CASE(read_langevin_molecular_dynamics_simulator)
         BOOST_TEST(!sim->step());
         sim->finalize();
     }
+
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        sim->initialize();
+        for(std::size_t i=0; i<99; ++i)
+        {
+            BOOST_TEST(mdsim->time() == i * 0.1, boost::test_tools::tolerance(tol));
+            BOOST_TEST(sim->step()); // check it can step
+        }
+        // at the last (100-th) step, it returns false to stop the simulation.
+        BOOST_TEST(!sim->step());
+        sim->finalize();
+    }
+
 }
 
 BOOST_AUTO_TEST_CASE(read_BAOAB_langevin_molecular_dynamics_simulator)
@@ -102,30 +150,52 @@ BOOST_AUTO_TEST_CASE(read_BAOAB_langevin_molecular_dynamics_simulator)
 
     using real_type = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::BAOABLangevinIntegrator<traits_type>;
+
     constexpr real_type tol = 1e-8;
     auto root = mjolnir::test::make_empty_input();
+    using namespace toml::literals;
+    const auto v = u8R"(
+        type            = "MolecularDynamics"
+        integrator.type = "BAOABLangevin"
+        integrator.parameters = []
+        seed            = 12345
+        precision       = "double"
+        boundary_type   = "Unlimited"
+        delta_t         = 0.1
+        total_step      = 100
+        save_step       = 10
+    )"_toml;
+    root.as_table()["simulator"] = v;
 
     {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            type            = "MolecularDynamics"
-            integrator.type = "BAOABLangevin"
-            integrator.parameters = []
-            seed            = 12345
-            precision       = "double"
-            boundary_type   = "Unlimited"
-            delta_t         = 0.1
-            total_step      = 100
-            save_step       = 10
-        )"_toml;
-
-        root.as_table()["simulator"] = v;
-        const auto sim = mjolnir::read_simulator<traits_type>(root, v);
-        BOOST_TEST(static_cast<bool>(sim));
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
 
         const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
-            traits_type, mjolnir::BAOABLangevinIntegrator<traits_type>>*>(sim.get());
-        BOOST_TEST(static_cast<bool>(mdsim));
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        sim->initialize();
+        for(std::size_t i=0; i<99; ++i)
+        {
+            BOOST_TEST(mdsim->time() == i * 0.1, boost::test_tools::tolerance(tol));
+            BOOST_TEST(sim->step()); // check it can step
+        }
+        // at the last (100-th) step, it returns false to stop the simulation.
+        BOOST_TEST(!sim->step());
+        sim->finalize();
+    }
+
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, v);
+        BOOST_TEST_REQUIRE(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::MolecularDynamicsSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST_REQUIRE(static_cast<bool>(mdsim));
 
         BOOST_TEST(mdsim->rng().seed() == 12345u);
 

--- a/test/core/test_read_simulated_annealing_simulator.cpp
+++ b/test/core/test_read_simulated_annealing_simulator.cpp
@@ -14,34 +14,58 @@ BOOST_AUTO_TEST_CASE(read_simulated_annealing_simulator)
 
     using real_type = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::UnderdampedLangevinIntegrator<traits_type>;
+
     constexpr real_type tol = 1e-8;
     auto root = mjolnir::test::make_empty_input();
+
+    using namespace toml::literals;
+    const auto v = u8R"(
+        type            = "SimulatedAnnealing"
+        integrator.type = "UnderdampedLangevin"
+        integrator.parameters = []
+        precision       = "double"
+        boundary_type   = "Unlimited"
+        seed            = 12345
+        total_step      = 100
+        save_step       = 10
+        each_step       = 1
+        delta_t         = 0.1
+        schedule.type  = "linear"
+        schedule.begin = 300.0
+        schedule.end   =  10.0
+
+    )"_toml;
+    root.as_table()["simulator"] = v;
+
     {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            type            = "SimulatedAnnealing"
-            integrator.type = "UnderdampedLangevin"
-            integrator.parameters = []
-            precision       = "double"
-            boundary_type   = "Unlimited"
-            seed            = 12345
-            total_step      = 100
-            save_step       = 10
-            each_step       = 1
-            delta_t         = 0.1
-            schedule.type  = "linear"
-            schedule.begin = 300.0
-            schedule.end   =  10.0
-
-        )"_toml;
-
-        root.as_table()["simulator"] = v;
-        const auto sim = mjolnir::read_simulator<traits_type>(root, v);
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, v);
         BOOST_TEST(static_cast<bool>(sim));
 
         const auto sasim = dynamic_cast<mjolnir::SimulatedAnnealingSimulator<
-            traits_type, mjolnir::UnderdampedLangevinIntegrator<traits_type>,
-            mjolnir::LinearScheduler>*>(sim.get());
+            traits_type, integrator_type, mjolnir::LinearScheduler>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(sasim));
+
+        BOOST_TEST(sasim->rng().seed() == 12345u);
+
+        sim->initialize();
+        for(std::size_t i=0; i<99; ++i)
+        {
+            BOOST_TEST(sasim->system().attribute("temperature") ==
+                       300.0 * ((100-i) / 100.0) + 10.0 * (i / 100.0),
+                       boost::test_tools::tolerance(tol));
+            BOOST_TEST(sim->step()); // check it can step
+        }
+        // at the last (100-th) step, it returns false to stop the simulation.
+        BOOST_TEST(!sim->step());
+        sim->finalize();
+    }
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, v);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto sasim = dynamic_cast<mjolnir::SimulatedAnnealingSimulator<
+            traits_type, integrator_type, mjolnir::LinearScheduler>*>(sim.get());
         BOOST_TEST(static_cast<bool>(sasim));
 
         BOOST_TEST(sasim->rng().seed() == 12345u);
@@ -66,34 +90,58 @@ BOOST_AUTO_TEST_CASE(read_BAOAB_Langevin_simulated_annealing_simulator)
 
     using real_type = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::BAOABLangevinIntegrator<traits_type>;
+
     constexpr real_type tol = 1e-8;
     auto root = mjolnir::test::make_empty_input();
+
+    using namespace toml::literals;
+    const auto v = u8R"(
+        type            = "SimulatedAnnealing"
+        integrator.type = "BAOABLangevin"
+        integrator.parameters = []
+        precision       = "double"
+        boundary_type   = "Unlimited"
+        seed            = 12345
+        total_step      = 100
+        save_step       = 10
+        each_step       = 1
+        delta_t         = 0.1
+        schedule.type  = "linear"
+        schedule.begin = 300.0
+        schedule.end   =  10.0
+
+    )"_toml;
+
+    root.as_table()["simulator"] = v;
     {
-        using namespace toml::literals;
-        const auto v = u8R"(
-            type            = "SimulatedAnnealing"
-            integrator.type = "BAOABLangevin"
-            integrator.parameters = []
-            precision       = "double"
-            boundary_type   = "Unlimited"
-            seed            = 12345
-            total_step      = 100
-            save_step       = 10
-            each_step       = 1
-            delta_t         = 0.1
-            schedule.type  = "linear"
-            schedule.begin = 300.0
-            schedule.end   =  10.0
-
-        )"_toml;
-
-        root.as_table()["simulator"] = v;
-        const auto sim = mjolnir::read_simulator<traits_type>(root, v);
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, v);
         BOOST_TEST(static_cast<bool>(sim));
 
         const auto sasim = dynamic_cast<mjolnir::SimulatedAnnealingSimulator<
-            traits_type, mjolnir::BAOABLangevinIntegrator<traits_type>,
-            mjolnir::LinearScheduler>*>(sim.get());
+            traits_type, integrator_type, mjolnir::LinearScheduler>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(sasim));
+
+        BOOST_TEST(sasim->rng().seed() == 12345u);
+
+        sim->initialize();
+        for(std::size_t i=0; i<99; ++i)
+        {
+            BOOST_TEST(sasim->system().attribute("temperature") ==
+                       300.0 * ((100-i) / 100.0) + 10.0 * (i / 100.0),
+                       boost::test_tools::tolerance(tol));
+            BOOST_TEST(sim->step()); // check it can step
+        }
+        // at the last (100-th) step, it returns false to stop the simulation.
+        BOOST_TEST(!sim->step());
+        sim->finalize();
+    }
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, v);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto sasim = dynamic_cast<mjolnir::SimulatedAnnealingSimulator<
+            traits_type, integrator_type, mjolnir::LinearScheduler>*>(sim.get());
         BOOST_TEST(static_cast<bool>(sasim));
 
         BOOST_TEST(sasim->rng().seed() == 12345u);

--- a/test/core/test_read_switching_forcefield_simulator.cpp
+++ b/test/core/test_read_switching_forcefield_simulator.cpp
@@ -14,6 +14,7 @@ BOOST_AUTO_TEST_CASE(read_newtonian_switching_forcefield_simulator)
 
     using real_type   = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::VelocityVerletIntegrator<traits_type>;
     auto root = mjolnir::test::make_empty_input();
 
     using namespace toml::literals;
@@ -60,52 +61,102 @@ BOOST_AUTO_TEST_CASE(read_newtonian_switching_forcefield_simulator)
     )"_toml;
     root.as_table()["systems"] = toml::array{system};
 
-    const auto sim = mjolnir::read_simulator<traits_type>(root, simulator);
-    BOOST_TEST(static_cast<bool>(sim));
-
-    const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
-        traits_type, mjolnir::VelocityVerletIntegrator<traits_type>>*>(sim.get());
-    BOOST_TEST(static_cast<bool>(mdsim));
-
-    BOOST_TEST(mdsim->rng().seed() == 12345u);
-
-    BOOST_TEST(mdsim->forcefields().size() == 2u);
-
-    BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
-    BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
-
-    for(const auto& kv : mdsim->schedule())
     {
-        std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
-    }
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
 
-    BOOST_TEST(mdsim->schedule().size() == 3u);
-    BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
-    BOOST_TEST(mdsim->schedule().at(0).second == "open");
-    BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
-    BOOST_TEST(mdsim->schedule().at(1).second == "close");
-    BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
-    BOOST_TEST(mdsim->schedule().at(2).second == "open");
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
 
-    BOOST_TEST(mdsim->system().size() == 2u);
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
 
-    mdsim->initialize();
-    for(std::size_t i=0; i<10; ++i)
-    {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
     }
-    for(std::size_t i=0; i<10; ++i)
     {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
-        mdsim->step();
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
     }
-    for(std::size_t i=0; i<10; ++i)
-    {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
-    }
-    mdsim->finalize();
 }
 
 BOOST_AUTO_TEST_CASE(read_underdamped_langevin_switching_forcefield_simulator)
@@ -114,6 +165,7 @@ BOOST_AUTO_TEST_CASE(read_underdamped_langevin_switching_forcefield_simulator)
 
     using real_type   = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::UnderdampedLangevinIntegrator<traits_type>;
     auto root = mjolnir::test::make_empty_input();
 
     using namespace toml::literals;
@@ -162,55 +214,109 @@ BOOST_AUTO_TEST_CASE(read_underdamped_langevin_switching_forcefield_simulator)
     )"_toml;
     root.as_table()["systems"] = toml::array{system};
 
-    const auto sim = mjolnir::read_simulator<traits_type>(root, simulator);
-    BOOST_TEST(static_cast<bool>(sim));
-
-    const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
-        traits_type, mjolnir::UnderdampedLangevinIntegrator<traits_type>>*>(sim.get());
-    BOOST_TEST(static_cast<bool>(mdsim));
-
-    BOOST_TEST(mdsim->rng().seed() == 12345u);
-
-    BOOST_TEST(mdsim->forcefields().size() == 2u);
-
-    BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
-    BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
-
-    for(const auto& kv : mdsim->schedule())
     {
-        std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // empty forcefield. no forces.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // harmonic potential is applied. non-zero force.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // empty forcefield. no forces.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
+    }
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // empty forcefield. no forces.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // harmonic potential is applied. non-zero force.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            // empty forcefield. no forces.
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
     }
 
-    BOOST_TEST(mdsim->schedule().size() == 3u);
-    BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
-    BOOST_TEST(mdsim->schedule().at(0).second == "open");
-    BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
-    BOOST_TEST(mdsim->schedule().at(1).second == "close");
-    BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
-    BOOST_TEST(mdsim->schedule().at(2).second == "open");
-
-    BOOST_TEST(mdsim->system().size() == 2u);
-
-    mdsim->initialize();
-    for(std::size_t i=0; i<10; ++i)
-    {
-        // empty forcefield. no forces.
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
-    }
-    for(std::size_t i=0; i<10; ++i)
-    {
-        // harmonic potential is applied. non-zero force.
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
-        mdsim->step();
-    }
-    for(std::size_t i=0; i<10; ++i)
-    {
-        // empty forcefield. no forces.
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
-    }
-    mdsim->finalize();
 }
 
 BOOST_AUTO_TEST_CASE(read_BAOAB_langevin_switching_forcefield_simulator)
@@ -219,6 +325,7 @@ BOOST_AUTO_TEST_CASE(read_BAOAB_langevin_switching_forcefield_simulator)
 
     using real_type   = double;
     using traits_type = mjolnir::SimulatorTraits<real_type, mjolnir::UnlimitedBoundary>;
+    using integrator_type = mjolnir::BAOABLangevinIntegrator<traits_type>;
     auto root = mjolnir::test::make_empty_input();
 
     using namespace toml::literals;
@@ -267,50 +374,101 @@ BOOST_AUTO_TEST_CASE(read_BAOAB_langevin_switching_forcefield_simulator)
     )"_toml;
     root.as_table()["systems"] = toml::array{system};
 
-    const auto sim = mjolnir::read_simulator<traits_type>(root, simulator);
-    BOOST_TEST(static_cast<bool>(sim));
-
-    const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
-        traits_type, mjolnir::BAOABLangevinIntegrator<traits_type>>*>(sim.get());
-    BOOST_TEST(static_cast<bool>(mdsim));
-
-    BOOST_TEST(mdsim->rng().seed() == 12345u);
-
-    BOOST_TEST(mdsim->forcefields().size() == 2u);
-
-    BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
-    BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
-
-    for(const auto& kv : mdsim->schedule())
     {
-        std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        const auto sim = mjolnir::read_simulator<traits_type, integrator_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
+    }
+    {
+        const auto sim = mjolnir::read_integrator_type<traits_type>(root, simulator);
+        BOOST_TEST(static_cast<bool>(sim));
+
+        const auto mdsim = dynamic_cast<mjolnir::SwitchingForceFieldSimulator<
+            traits_type, integrator_type>*>(sim.get());
+        BOOST_TEST(static_cast<bool>(mdsim));
+
+        BOOST_TEST(mdsim->rng().seed() == 12345u);
+
+        BOOST_TEST(mdsim->forcefields().size() == 2u);
+
+        BOOST_TEST(mdsim->forcefield_index().at("open" ) == 0u);
+        BOOST_TEST(mdsim->forcefield_index().at("close") == 1u);
+
+        for(const auto& kv : mdsim->schedule())
+        {
+            std::cout << '{' << kv.first << ':' << kv.second << '}' << std::endl;
+        }
+
+        BOOST_TEST(mdsim->schedule().size() == 3u);
+        BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
+        BOOST_TEST(mdsim->schedule().at(0).second == "open");
+        BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
+        BOOST_TEST(mdsim->schedule().at(1).second == "close");
+        BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
+        BOOST_TEST(mdsim->schedule().at(2).second == "open");
+
+        BOOST_TEST(mdsim->system().size() == 2u);
+
+        mdsim->initialize();
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
+            mdsim->step();
+        }
+        for(std::size_t i=0; i<10; ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
+            mdsim->step();
+        }
+        mdsim->finalize();
     }
 
-    BOOST_TEST(mdsim->schedule().size() == 3u);
-    BOOST_TEST(mdsim->schedule().at(0).first  == 10u);
-    BOOST_TEST(mdsim->schedule().at(0).second == "open");
-    BOOST_TEST(mdsim->schedule().at(1).first  == 20u);
-    BOOST_TEST(mdsim->schedule().at(1).second == "close");
-    BOOST_TEST(mdsim->schedule().at(2).first  == 30u);
-    BOOST_TEST(mdsim->schedule().at(2).second == "open");
-
-    BOOST_TEST(mdsim->system().size() == 2u);
-
-    mdsim->initialize();
-    for(std::size_t i=0; i<10; ++i)
-    {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
-    }
-    for(std::size_t i=0; i<10; ++i)
-    {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) != 0.0);
-        mdsim->step();
-    }
-    for(std::size_t i=0; i<10; ++i)
-    {
-        BOOST_TEST(mjolnir::math::X(mdsim->system().force(0)) == 0.0);
-        mdsim->step();
-    }
-    mdsim->finalize();
 }


### PR DESCRIPTION
- add `read_random_number_generator.?pp`
- add `read_integrator_type` to determine which integrator to be used
  - this simplify each `read_xxx_simulator` but increases number of template instances
- add test code related to `read_integrator_type`