### PR TITLE
Enable restarting via msgpack file

### DIFF
--- a/mjolnir/core/BoundaryCondition.hpp
+++ b/mjolnir/core/BoundaryCondition.hpp
@@ -30,6 +30,11 @@ struct CuboidalPeriodicBoundary
 
   public:
 
+    CuboidalPeriodicBoundary() noexcept: CuboidalPeriodicBoundary(
+            math::make_coordinate<coordinate_type>(0, 0, 0),
+            math::make_coordinate<coordinate_type>(0, 0, 0))
+    {}
+
     CuboidalPeriodicBoundary(
             const coordinate_type& lw, const coordinate_type& up) noexcept
         : lower_(lw), upper_(up), width_(up - lw), halfw_((up - lw) / 2)

--- a/mjolnir/core/CMakeLists.txt
+++ b/mjolnir/core/CMakeLists.txt
@@ -21,6 +21,7 @@ set(mjolnir_core_cpp_files
     "${CMAKE_CURRENT_SOURCE_DIR}/XYZObserver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/DCDObserver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/TRRObserver.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/MsgPackObserver.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/ObserverContainer.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/LoaderBase.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/XYZLoader.cpp"

--- a/mjolnir/core/MsgPackObserver.cpp
+++ b/mjolnir/core/MsgPackObserver.cpp
@@ -1,0 +1,13 @@
+#include <mjolnir/core/MsgPackObserver.hpp>
+
+#ifndef MJOLNIR_SEPARATE_BUILD
+#error "MJOLNIR_SEPARATE_BUILD flag is required"
+#endif
+
+namespace mjolnir
+{
+template class MsgPackObserver<SimulatorTraits<double, UnlimitedBoundary>       >;
+template class MsgPackObserver<SimulatorTraits<float,  UnlimitedBoundary>       >;
+template class MsgPackObserver<SimulatorTraits<double, CuboidalPeriodicBoundary>>;
+template class MsgPackObserver<SimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+} // mjolnir

--- a/mjolnir/core/MsgPackObserver.hpp
+++ b/mjolnir/core/MsgPackObserver.hpp
@@ -14,19 +14,20 @@ namespace mjolnir
 // Serialize System into MsgPack format that is equivalent to the following JSON
 // In the current implementation, the order should be preserved.
 // fixmap<3> {
-//     "boundary"     : {"lower": [float, float, float],
-//                       "upper": [float, float, float]} or nil,
-//     "particles"    : [fixmap<7>{
-//          "mass"    : float,
-//          "rmass"   : float,
-//          "position": [float, float, float],
-//          "velocity": [float, float, float],
-//          "force"   : [float, float, float],
-//          "name"    : string,
-//          "group"   : string,
-//          }, ...
+//     "boundary"     : fixmap<2>{"lower": [real, real, real],
+//                                "upper": [real, real, real]}
+//                   or nil,
+//     "particles"    : array<N>[
+//         fixmap<6>{
+//             "mass"    : real,
+//             "position": [real, real, real],
+//             "velocity": [real, real, real],
+//             "force"   : [real, real, real],
+//             "name"    : string,
+//             "group"   : string,
+//         }, ...
 //     ]
-//     "attributres"  : {"temperature": float, ...},
+//     "attributres"  : map<N>{"temperature": real, ...},
 // }
 
 template<typename traitsT>

--- a/mjolnir/core/MsgPackObserver.hpp
+++ b/mjolnir/core/MsgPackObserver.hpp
@@ -10,6 +10,7 @@
 
 namespace mjolnir
 {
+
 // Serialize System into MsgPack format that is equivalent to the following JSON
 // {
 //     "num_particles": integer,
@@ -52,6 +53,7 @@ class MsgPackObserver final : public ObserverBase<traitsT>
     {
         MJOLNIR_GET_DEFAULT_LOGGER();
         MJOLNIR_LOG_FUNCTION();
+        MJOLNIR_LOG_NOTICE("checkpoint file is ", filename_);
 
         // check the specified file can be opened.
         // Here, it does not clear the content.

--- a/mjolnir/core/MsgPackObserver.hpp
+++ b/mjolnir/core/MsgPackObserver.hpp
@@ -1,0 +1,418 @@
+#ifndef MJOLNIR_CORE_MSGPACK_OBSERVER_HPP
+#define MJOLNIR_CORE_MSGPACK_OBSERVER_HPP
+#include <mjolnir/util/macro.hpp>
+#include <mjolnir/core/ObserverBase.hpp>
+#include <mjolnir/core/BoundaryCondition.hpp>
+#include <mjolnir/core/System.hpp>
+#include <mjolnir/core/Unit.hpp>
+#include <fstream>
+#include <iomanip>
+
+namespace mjolnir
+{
+// Serialize System into MsgPack format that is equivalent to the following JSON
+// {
+//     "num_particles": integer,
+//     "boundary"     : {"lower": {"x":float, "y":float, "z":float},
+//                       "upper": {"x":float, "y":float, "z":float}} or nil,
+//     "attributres"  : {"temperature": float, ...},
+//     "masses"       : [float, ...],
+//     "rmasses"      : [float, ...],
+//     "positions"    : [{"x":float, "y":float, "z":float},  ...],
+//     "velocities"   : [{"x":float, "y":float, "z":float},  ...],
+//     "forces"       : [{"x":float, "y":float, "z":float},  ...],
+//     "names"        : [str, ...],
+//     "groups"       : [str, ...]
+// }
+
+template<typename traitsT>
+class MsgPackObserver final : public ObserverBase<traitsT>
+{
+  public:
+    using base_type         = ObserverBase<traitsT>;
+    using traits_type       = typename base_type::traits_type;
+    using real_type         = typename base_type::real_type;
+    using coordinate_type   = typename base_type::coordinate_type;
+    using system_type       = typename base_type::system_type;
+    using forcefield_type   = typename base_type::forcefield_type;
+
+    // system attribute container type. map-like class.
+    using attribute_type    = typename system_type::attribute_type;
+
+  public:
+
+    explicit MsgPackObserver(const std::string& filename_prefix)
+      : base_type(), prefix_(filename_prefix),
+        filename_(filename_prefix + std::string(".msg"))
+    {}
+    ~MsgPackObserver() override {}
+
+    void initialize(const std::size_t,  const real_type,
+                    const system_type&, const forcefield_type&) override
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        // check the specified file can be opened.
+        // Here, it does not clear the content.
+        std::ofstream ofs(filename_, std::ios_base::app);
+        if(!ofs.good())
+        {
+            MJOLNIR_LOG_ERROR("file open error: ", filename_);
+            throw std::runtime_error("file open error");
+        }
+        ofs.close();
+        return;
+    }
+
+    void update(const std::size_t,  const real_type,
+                const system_type&, const forcefield_type&) override
+    {
+        return; // do nothing.
+    }
+
+    void output(const std::size_t, const real_type,
+                const system_type& sys, const forcefield_type&) override
+    {
+        // 0b'1000'1010
+        // 0x    8    a
+        constexpr std::uint8_t fixmap10_code = 0x8a;
+
+        // ---------------------------------------------------------------------
+        // clear buffer before writing to it.
+        this->buffer_.clear();
+
+        // ---------------------------------------------------------------------
+        // System is represented as a map with 10 elements.
+        // See the top of this file.
+        this->buffer_.push_back(fixmap10_code);
+
+        // ---------------------------------------------------------------------
+        // append boundary and attributes, that are independent from particles
+
+        const std::size_t num_particles = sys.size();
+
+        to_msgpack("num_particles", std::back_inserter(buffer_));
+        to_msgpack(num_particles,   std::back_inserter(buffer_));
+
+        to_msgpack("boundary",     std::back_inserter(buffer_));
+        to_msgpack(sys.boundary(), std::back_inserter(buffer_));
+
+        to_msgpack("attributes",     std::back_inserter(buffer_));
+        to_msgpack(sys.attributes(), std::back_inserter(buffer_));
+
+        // ---------------------------------------------------------------------
+        // update byte code of an array that has the same number of elements as
+        // the number of particles.
+
+        this->array_code_.clear();
+        if(num_particles < 16)
+        {
+            // 0b'1001'0000
+            // 0x    9    0
+            std::uint8_t fixary_code = num_particles;
+            fixary_code |= std::uint8_t(0x90);
+            this->array_code_.push_back(fixary_code);
+        }
+        else if(num_particles < 65536)
+        {
+            const std::uint16_t size = num_particles;
+            this->array_code_.push_back(std::uint8_t(0xdc));
+            to_big_endian(size, std::back_inserter(array_code_));
+        }
+        else
+        {
+            const std::uint32_t size = num_particles;
+            this->array_code_.push_back(std::uint8_t(0xdd));
+            to_big_endian(size, std::back_inserter(array_code_));
+        }
+
+        // ---------------------------------------------------------------------
+        // append particle status.
+
+        to_msgpack("masses", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.mass(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("rmasses", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.rmass(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("positions", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.position(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("velocities", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.velocity(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("forces", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.force(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("names", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.name(i), std::back_inserter(buffer_));
+        }
+
+        to_msgpack("groups", std::back_inserter(buffer_));
+        std::copy(array_code_.begin(), array_code_.end(), std::back_inserter(buffer_));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            to_msgpack(sys.group(i), std::back_inserter(buffer_));
+        }
+
+        // -------------------------------------------------------------------
+        // overwrite .msg file by the current status
+
+        std::ofstream ofs(filename_);
+        if(!ofs.good())
+        {
+            throw std::runtime_error("file open error: " + filename_);
+        }
+        ofs.write(reinterpret_cast<const char*>(buffer_.data()),buffer_.size());
+        ofs.close();
+        return;
+    }
+
+    void finalize(const std::size_t step, const real_type t,
+                  const system_type& sys, const forcefield_type& ff) override
+    {
+        this->output(step, t, sys, ff);
+        return;
+    }
+
+    std::string const& prefix() const noexcept override {return prefix_;}
+
+  private:
+
+    template<typename OutputIterator>
+    void to_msgpack(const std::string& str, OutputIterator out)
+    {
+        constexpr std::uint8_t str8_code  = 0xd9;
+        constexpr std::uint8_t str16_code = 0xda;
+        constexpr std::uint8_t str32_code = 0xdb;
+
+        // add a byte tag and length
+        if(str.size() < 32)
+        {
+            // 0b'1010'0000
+            // 0x    a    0
+            std::uint8_t fixstr_code = str.size();
+            fixstr_code |= std::uint8_t(0xa0);
+            *out = fixstr_code; ++out;
+        }
+        else if(str.size() <= 0xFF)
+        {
+            const std::uint8_t size = str.size();
+            *out = str8_code; ++out;
+            *out = size;      ++out;
+        }
+        else if(str.size() <= 0xFFFF)
+        {
+            const std::uint16_t size = str.size();
+            *out = str16_code; ++out;
+            to_big_endian(size, out);
+        }
+        else
+        {
+            const std::uint32_t size = str.size();
+            *out = str32_code; ++out;
+            to_big_endian(size, out);
+        }
+
+        // write string body
+        for(const std::uint8_t c : str)
+        {
+            *out = c; ++out;
+        }
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(const float& x, OutputIterator out)
+    {
+        constexpr std::uint8_t f32_code = 0xca;
+        *out = f32_code; ++out;
+        to_big_endian(x, out);
+        return ;
+    }
+    template<typename OutputIterator>
+    void to_msgpack(const double& x, OutputIterator out)
+    {
+        constexpr std::uint8_t f64_code = 0xcb;
+        *out = f64_code; ++out;
+        to_big_endian(x, out);
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(const coordinate_type& v, OutputIterator out)
+    {
+        // fixmap (3)     fixstr (1)
+        // 0b'1000'0011   0b'1010'0001
+        // 0x    8    3   0x    a    1
+        constexpr std::uint8_t fixmap3_code = 0x83;
+        constexpr std::uint8_t fixstr1_code = 0xa1;
+        *out = fixmap3_code; ++out;
+
+        *out = fixstr1_code; ++out;
+        *out = std::uint8_t(0x78); ++out; // "x"
+        to_msgpack(math::X(v), out);
+
+        *out = fixstr1_code; ++out;
+        *out = std::uint8_t(0x79); ++out; // "y"
+        to_msgpack(math::Y(v), out);
+
+        *out = fixstr1_code; ++out;
+        *out = std::uint8_t(0x7a); ++out; // "z"
+        to_msgpack(math::Z(v), out);
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(const UnlimitedBoundary<real_type, coordinate_type>&,
+                    OutputIterator out)
+    {
+        // UnlimitedBoundary is represented as nil
+        *out = std::uint8_t(0xc0); ++out;
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(
+        const CuboidalPeriodicBoundary<real_type, coordinate_type>& boundary,
+        OutputIterator out)
+    {
+        constexpr std::uint8_t fixmap2_t = 0x82;
+        *out = fixmap2_t; ++out;
+        to_msgpack("lower", out);
+        to_msgpack(boundary.lower_bound(), out);
+        to_msgpack("upper", out);
+        to_msgpack(boundary.upper_bound(), out);
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(const attribute_type& attr, OutputIterator out)
+    {
+        constexpr std::uint8_t map16_code = 0xde;
+        constexpr std::uint8_t map32_code = 0xdf;
+
+        if(attr.size() < 16)
+        {
+            std::uint8_t fixmap_code = attr.size();
+            fixmap_code |= std::uint8_t(0x80);
+            *out = fixmap_code; ++out;
+        }
+        else if(attr.size() < 65536)
+        {
+            const std::uint16_t size = attr.size();
+            *out = map16_code; ++out;
+            to_big_endian(size, out);
+        }
+        else
+        {
+            const std::uint32_t size = attr.size();
+            *out = map32_code; ++out;
+            to_big_endian(size, out);
+        }
+
+        for(const auto& keyval : attr)
+        {
+            // string -> real
+            to_msgpack(keyval.first,  out);
+            to_msgpack(keyval.second, out);
+        }
+        return ;
+    }
+
+    template<typename OutputIterator>
+    void to_msgpack(const std::size_t num, OutputIterator out)
+    {
+        constexpr std::uint8_t uint8_code  = 0xcc;
+        constexpr std::uint8_t uint16_code = 0xcd;
+        constexpr std::uint8_t uint32_code = 0xce;
+        constexpr std::uint8_t uint64_code = 0xcf;
+        if(num < 128)
+        {
+            const std::uint8_t n = num;
+            *out = n; ++out;
+        }
+        else if(num < 256)
+        {
+            const std::uint8_t n = num;
+            *out = uint8_code; ++out;
+            *out = n;          ++out;
+        }
+        else if(num < 65536)
+        {
+            const std::uint16_t n = num;
+            *out = uint16_code; ++out;
+            to_big_endian(n, out);
+        }
+        else if(num < 0xFFFFFFFF)
+        {
+            const std::uint32_t n = num;
+            *out = uint32_code; ++out;
+            to_big_endian(n, out);
+        }
+        else
+        {
+            const std::uint64_t n = num;
+            *out = uint64_code; ++out;
+            to_big_endian(n, out);
+        }
+        return ;
+    }
+
+    template<typename T, typename OutputIterator>
+    void to_big_endian(const T& val, OutputIterator dst)
+    {
+        const char* src = reinterpret_cast<const char*>(std::addressof(val));
+
+#if defined(MJOLNIR_WITH_LITTLE_ENDIAN)
+        // If the architecture uses little endian, we need to reverse bytes.
+        std::reverse_copy(src, src + sizeof(T), dst);
+#elif defined(MJOLNIR_WITH_BIG_ENDIAN)
+        // If the architecture uses big endian, we don't need to do anything.
+        std::copy(src, src + sizeof(T), dst);
+#else
+#  error "Unknown platform."
+#endif
+        return ;
+    }
+
+  private:
+
+    std::string prefix_;
+    std::string filename_;
+    std::vector<std::uint8_t> buffer_;
+    std::vector<std::uint8_t> array_code_;
+};
+#ifdef MJOLNIR_SEPARATE_BUILD
+extern template class MsgPackObserver<SimulatorTraits<double, UnlimitedBoundary>       >;
+extern template class MsgPackObserver<SimulatorTraits<float,  UnlimitedBoundary>       >;
+extern template class MsgPackObserver<SimulatorTraits<double, CuboidalPeriodicBoundary>>;
+extern template class MsgPackObserver<SimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+#endif
+
+} // mjolnir
+#endif // MJOLNIR_CORE_MSGPACK_OBSERVER_HPP

--- a/mjolnir/core/MsgPackObserver.hpp
+++ b/mjolnir/core/MsgPackObserver.hpp
@@ -107,9 +107,7 @@ class MsgPackObserver final : public ObserverBase<traitsT>
         {
             // 0b'1001'0000
             // 0x    9    0
-            std::uint8_t fixarray_code = num_particles;
-            fixarray_code |= std::uint8_t(0x90);
-            buffer_.push_back(fixarray_code);
+            buffer_.push_back(std::uint8_t(num_particles) + std::uint8_t(0x90));
         }
         else if(num_particles < 65536)
         {
@@ -184,9 +182,7 @@ class MsgPackObserver final : public ObserverBase<traitsT>
         {
             // 0b'1010'0000
             // 0x    a    0
-            std::uint8_t fixstr_code = str.size();
-            fixstr_code |= std::uint8_t(0xa0);
-            *out = fixstr_code; ++out;
+            *out = (std::uint8_t(str.size()) + std::uint8_t(0xa0)); ++out;
         }
         else if(str.size() <= 0xFF)
         {
@@ -278,9 +274,7 @@ class MsgPackObserver final : public ObserverBase<traitsT>
 
         if(attr.size() < 16)
         {
-            std::uint8_t fixmap_code = attr.size();
-            fixmap_code |= std::uint8_t(0x80);
-            *out = fixmap_code; ++out;
+            *out = (std::uint8_t(attr.size()) + std::uint8_t(0x80)); ++out;
         }
         else if(attr.size() < 65536)
         {

--- a/mjolnir/input/read_observer.hpp
+++ b/mjolnir/input/read_observer.hpp
@@ -7,6 +7,7 @@
 #include <mjolnir/core/XYZObserver.hpp>
 #include <mjolnir/core/DCDObserver.hpp>
 #include <mjolnir/core/TRRObserver.hpp>
+#include <mjolnir/core/MsgPackObserver.hpp>
 #include <mjolnir/util/logger.hpp>
 #include <mjolnir/util/make_unique.hpp>
 
@@ -97,6 +98,8 @@ read_observer(const toml::value& root)
             add_observer(observers, fmt, file_prefix);
         }
     }
+
+    observers.push_back(make_unique<MsgPackObserver<traitsT>>(file_prefix));
 
     // Energy is always written to "prefix.ene".
     observers.push_back(make_unique<EnergyObserver<traitsT>>(file_prefix));

--- a/mjolnir/input/read_system.hpp
+++ b/mjolnir/input/read_system.hpp
@@ -336,7 +336,8 @@ void check_msgpack_key(const std::string& expected,
                        InputIterator& iter, InputIterator sentinel)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_LOG_FUNCTION();
+    // It's called so many times, thus it does not make a log-scope.
+
     // check key before reading body
     const auto key = from_msgpack<std::string>(iter, sentinel);
     if(key != expected)

--- a/mjolnir/input/read_system.hpp
+++ b/mjolnir/input/read_system.hpp
@@ -376,22 +376,46 @@ void load_boundary_from_msgpack(CuboidalPeriodicBoundary<realT, coordT>& bdry,
     //   "upper": [float, float, float]
     // }
     {
+        constexpr std::uint8_t fixmap2_code = 0x82;
         const std::uint8_t tag = read_a_byte(iter, sentinel);
-        MJOLNIR_LOG_ERROR("invalid format in system .msg file. "
-                          "expected ", 0x82, ", got ", tag);
-        throw_exception<std::runtime_error>("failed to load .msg file");
+        if(tag != fixmap2_code)
+        {
+            MJOLNIR_LOG_ERROR("invalid format in system .msg file. "
+                              "expected 0x82, got ", std::uint32_t(tag));
+            throw_exception<std::runtime_error>("failed to load .msg file");
+        }
     }
 
     coordT lower, upper;
     check_msgpack_key("lower", iter, sentinel);
+    {
+        constexpr std::uint8_t fixarray3_code = 0x93;
+        const std::uint8_t tag = read_a_byte(iter, sentinel);
+        if(tag != fixarray3_code)
+        {
+            MJOLNIR_LOG_ERROR("invalid format in system .msg file. "
+                              "expected 0x93, got ", std::uint32_t(tag));
+            throw_exception<std::runtime_error>("failed to load .msg file");
+        }
+    }
     math::X(lower) = from_msgpack<realT>(iter, sentinel);
     math::Y(lower) = from_msgpack<realT>(iter, sentinel);
     math::Z(lower) = from_msgpack<realT>(iter, sentinel);
 
     check_msgpack_key("upper", iter, sentinel);
-    math::X(lower) = from_msgpack<realT>(iter, sentinel);
-    math::Y(lower) = from_msgpack<realT>(iter, sentinel);
-    math::Z(lower) = from_msgpack<realT>(iter, sentinel);
+    {
+        constexpr std::uint8_t fixarray3_code = 0x93;
+        const std::uint8_t tag = read_a_byte(iter, sentinel);
+        if(tag != fixarray3_code)
+        {
+            MJOLNIR_LOG_ERROR("invalid format in system .msg file. "
+                              "expected 0x93, got ", std::uint32_t(tag));
+            throw_exception<std::runtime_error>("failed to load .msg file");
+        }
+    }
+    math::X(upper) = from_msgpack<realT>(iter, sentinel);
+    math::Y(upper) = from_msgpack<realT>(iter, sentinel);
+    math::Z(upper) = from_msgpack<realT>(iter, sentinel);
 
     bdry.set_boundary(lower, upper);
     return ;

--- a/mjolnir/input/read_system.hpp
+++ b/mjolnir/input/read_system.hpp
@@ -423,18 +423,20 @@ void load_boundary_from_msgpack(CuboidalPeriodicBoundary<realT, coordT>& bdry,
 
 // The order should be preserved.
 // fixmap<3> {
-//     "boundary"     : {"lower": [float, float, float],
-//                       "upper": [float, float, float]} or nil,
-//     "particles"    : [fixmap<6>{
-//          "mass"    : float,
-//          "position": [float, float, float],
-//          "velocity": [float, float, float],
-//          "force"   : [float, float, float],
-//          "name"    : string,
-//          "group"   : string,
-//          }, ...
+//     "boundary"     : fixmap<2>{"lower": [real, real, real],
+//                                "upper": [real, real, real]}
+//                   or nil,
+//     "particles"    : array<N>[
+//         fixmap<6>{
+//             "mass"    : real,
+//             "position": [real, real, real],
+//             "velocity": [real, real, real],
+//             "force"   : [real, real, real],
+//             "name"    : string,
+//             "group"   : string,
+//         }, ...
 //     ]
-//     "attributres"  : {"temperature": float, ...},
+//     "attributres"  : map<N>{"temperature": real, ...},
 // }
 template<typename traitsT>
 System<traitsT> load_system_from_msgpack(const std::string& msg_file)

--- a/mjolnir/util/macro.hpp
+++ b/mjolnir/util/macro.hpp
@@ -14,4 +14,31 @@
 #  define MJOLNIR_FUNC_NAME __func__
 #endif
 
+// check the architecture uses little endian or big endian.
+// GCC and clang have __BYTE_ORDER__ macro. The value of the macro is equal to
+// __ORDER_BIG_ENDIAN__ if the platform uses big endian, or
+// __ORDER_BIG_ENDIAN__ if the platform uses little endian.
+//
+// MSVC seems not to have this macro. But, practically, we can assume all the
+// windows machines use little endian.
+//
+// For other platform, define MJOLNIR_WITH_LITTLE_ENDIAN or BIG_ENDIAN manually.
+// It does not overwrite the status.
+#if !defined(MJOLNIR_WITH_LITTLE_ENDIAN) && !defined(MJOLNIR_WITH_BIG_ENDIAN)
+#  ifdef __GNUC__
+#    if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#      define MJOLNIR_WITH_BIG_ENDIAN
+#    elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#      define MJOLNIR_WITH_LITTLE_ENDIAN
+#    else
+#      error "Mjolnir supports only little or big endian."
+#    endif
+#  elif defined(_MSC_VER)
+#      pragma message("Now compiling on Windows, assuming little endian...")
+#      define MJOLNIR_WITH_LITTLE_ENDIAN
+#  else
+#    error "Unknown platform. Please define MJOLNIR_WITH_LITTLE_ENDIAN or MJOLNIR_WITH_BIG_ENDIAN"
+#  endif
+#endif
+
 #endif // MJOLNIR_UTIL_MACRO_HPP

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -111,6 +111,8 @@ set(TEST_NAMES
     test_read_system
     test_read_unit
     test_read_path
+
+    test_save_load_msgpack
     )
 
 if (Boost_UNIT_TEST_FRAMEWORK_FOUND)

--- a/test/core/test_read_observer.cpp
+++ b/test/core/test_read_observer.cpp
@@ -26,17 +26,36 @@ BOOST_AUTO_TEST_CASE(read_observer)
         )"_toml);
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
         BOOST_TEST(obs.observers().at(0)->prefix() == "./test");
         BOOST_TEST(obs.observers().at(1)->prefix() == "./test");
+        BOOST_TEST(obs.observers().at(2)->prefix() == "./test");
 
-        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(xyz));
+        bool has_xyz = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(xyz))
+            {
+                has_xyz = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
 
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        BOOST_TEST(has_xyz);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
     {
         using namespace toml::literals;
@@ -47,17 +66,35 @@ BOOST_AUTO_TEST_CASE(read_observer)
         )"_toml);
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
         BOOST_TEST(obs.observers().at(0)->prefix() == "./test");
         BOOST_TEST(obs.observers().at(1)->prefix() == "./test");
+        BOOST_TEST(obs.observers().at(2)->prefix() == "./test");
 
-        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(xyz));
-
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        bool has_xyz = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(xyz))
+            {
+                has_xyz = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
+        BOOST_TEST(has_xyz);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
 
     // XXX
@@ -76,17 +113,35 @@ BOOST_AUTO_TEST_CASE(read_observer)
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
 
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
         BOOST_TEST(obs.observers().at(0)->prefix() == "./test/test");
         BOOST_TEST(obs.observers().at(1)->prefix() == "./test/test");
+        BOOST_TEST(obs.observers().at(2)->prefix() == "./test/test");
 
-        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(xyz));
-
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        bool has_xyz = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(xyz))
+            {
+                has_xyz = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
+        BOOST_TEST(has_xyz);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
 }
 
@@ -107,15 +162,32 @@ BOOST_AUTO_TEST_CASE(read_xyz_observer)
         )"_toml);
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
 
-        const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(xyz));
-
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        bool has_xyz = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(xyz))
+            {
+                has_xyz = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
+        BOOST_TEST(has_xyz);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
 }
 
@@ -136,15 +208,32 @@ BOOST_AUTO_TEST_CASE(read_dcd_observer)
         )"_toml);
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
 
-        const auto dcd = dynamic_cast<mjolnir::DCDObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(dcd));
-
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        bool has_dcd = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto dcd = dynamic_cast<mjolnir::DCDObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(dcd))
+            {
+                has_dcd = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
+        BOOST_TEST(has_dcd);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
 }
 
@@ -165,14 +254,31 @@ BOOST_AUTO_TEST_CASE(read_trr_observer)
         )"_toml);
 
         const auto obs = mjolnir::read_observer<traits_type>(v);
-        BOOST_TEST(obs.observers().size() == 2u);
+        BOOST_TEST(obs.observers().size() == 3u);
 
-        const auto trr = dynamic_cast<mjolnir::TRRObserver<traits_type>*>(
-                             obs.observers().at(0).get());
-        BOOST_TEST(static_cast<bool>(trr));
-
-        const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(
-                             obs.observers().at(1).get());
-        BOOST_TEST(static_cast<bool>(ene));
+        bool has_trr = false;
+        bool has_ene = false;
+        bool has_msg = false;
+        for(const auto ptr : obs.observers())
+        {
+            const auto trr = dynamic_cast<mjolnir::TRRObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(trr))
+            {
+                has_trr = true;
+            }
+            const auto ene = dynamic_cast<mjolnir::EnergyObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(ene))
+            {
+                has_ene = true;
+            }
+            const auto msg = dynamic_cast<mjolnir::MsgPackObserver<traits_type>*>(ptr.get());
+            if(static_cast<bool>(msg))
+            {
+                has_msg = true;
+            }
+        }
+        BOOST_TEST(has_trr);
+        BOOST_TEST(has_ene);
+        BOOST_TEST(has_msg);
     }
 }

--- a/test/core/test_read_observer.cpp
+++ b/test/core/test_read_observer.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(read_observer)
         bool has_xyz = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(xyz))
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(read_observer)
         bool has_xyz = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(xyz))
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(read_observer)
         bool has_xyz = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(xyz))
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(read_xyz_observer)
         bool has_xyz = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto xyz = dynamic_cast<mjolnir::XYZObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(xyz))
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(read_dcd_observer)
         bool has_dcd = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto dcd = dynamic_cast<mjolnir::DCDObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(dcd))
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(read_trr_observer)
         bool has_trr = false;
         bool has_ene = false;
         bool has_msg = false;
-        for(const auto ptr : obs.observers())
+        for(const auto& ptr : obs.observers())
         {
             const auto trr = dynamic_cast<mjolnir::TRRObserver<traits_type>*>(ptr.get());
             if(static_cast<bool>(trr))

--- a/test/core/test_save_load_msgpack.cpp
+++ b/test/core/test_save_load_msgpack.cpp
@@ -1,0 +1,152 @@
+#define BOOST_TEST_MODULE "test_save_load_msgpack"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <mjolnir/core/BoundaryCondition.hpp>
+#include <mjolnir/core/SimulatorTraits.hpp>
+#include <mjolnir/core/System.hpp>
+#include <mjolnir/core/ForceField.hpp>
+#include <mjolnir/core/MsgPackObserver.hpp>
+#include <mjolnir/input/read_system.hpp>
+
+using real_types = std::tuple<double, float>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_save_load_msgpack_unlimited, realT, real_types)
+{
+    using namespace mjolnir;
+    LoggerManager::set_default_logger("test_save_load_msgpack.log");
+    using traits_type     = SimulatorTraits<realT, UnlimitedBoundary>;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using system_type     = System<traits_type>;
+    using forcefield_type = ForceField<traits_type>;
+    using msgpackobs_type = MsgPackObserver<traits_type>;
+    using boundary_type   = typename system_type::boundary_type;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<realT> uni(-10.0, 10.0);
+    system_type sys(100, boundary_type());
+    forcefield_type ff;
+
+    sys.attribute("pi") = 3.14;
+    sys.attribute("e")  = 2.71;
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)     = uni(mt);
+        sys.rmass(i)    = realT(1.0) / sys.mass(i);
+        sys.position(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.velocity(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.force(i)    = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.name(i)     = std::string("particle") + std::to_string(i);
+        sys.group(i)    = std::string("group")    + std::to_string(i);
+    }
+
+    {
+        msgpackobs_type obs("test_save_load_msgpack_unlimited");
+        obs.initialize(0, 0.1, sys, ff);
+        obs.output(0, 0.1, sys, ff);
+    }
+    const system_type loaded = load_system_from_msgpack<traits_type>("test_save_load_msgpack_unlimited.msg");
+
+    // It should be bitwise-same.
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        BOOST_TEST(sys.mass(i)     == loaded.mass(i)    );
+        BOOST_TEST(sys.rmass(i)    == loaded.rmass(i)   );
+
+        BOOST_TEST(math::X(sys.position(i)) == math::X(loaded.position(i)));
+        BOOST_TEST(math::Y(sys.position(i)) == math::Y(loaded.position(i)));
+        BOOST_TEST(math::Z(sys.position(i)) == math::Z(loaded.position(i)));
+
+        BOOST_TEST(math::X(sys.velocity(i)) == math::X(loaded.velocity(i)));
+        BOOST_TEST(math::Y(sys.velocity(i)) == math::Y(loaded.velocity(i)));
+        BOOST_TEST(math::Z(sys.velocity(i)) == math::Z(loaded.velocity(i)));
+
+        BOOST_TEST(math::X(sys.force(i))    == math::X(loaded.force(i))   );
+        BOOST_TEST(math::Y(sys.force(i))    == math::Y(loaded.force(i))   );
+        BOOST_TEST(math::Z(sys.force(i))    == math::Z(loaded.force(i))   );
+
+        BOOST_TEST(sys.name(i)     == loaded.name(i)    );
+        BOOST_TEST(sys.group(i)    == loaded.group(i)   );
+    }
+    BOOST_TEST(sys.attribute("pi") == loaded.attribute("pi"));
+    BOOST_TEST(sys.attribute("e")  == loaded.attribute("e") );
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_save_load_msgpack_periodic, realT, real_types)
+{
+    using namespace mjolnir;
+    LoggerManager::set_default_logger("test_save_load_msgpack.log");
+    using traits_type   = SimulatorTraits<realT, CuboidalPeriodicBoundary>;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using system_type   = System<traits_type>;
+    using forcefield_type = ForceField<traits_type>;
+    using msgpackobs_type = MsgPackObserver<traits_type>;
+    using boundary_type = typename system_type::boundary_type;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<realT> uni(-10.0, 10.0);
+    system_type sys(100, boundary_type(
+        math::make_coordinate<coordinate_type>(-1.0, -2.0, -3.0),
+        math::make_coordinate<coordinate_type>( 1.0,  2.0,  3.0)));
+
+    forcefield_type ff;
+
+    sys.attribute("pi") = 3.14;
+    sys.attribute("e")  = 2.71;
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)     = uni(mt);
+        sys.rmass(i)    = realT(1.0) / sys.mass(i);
+        sys.position(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.velocity(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.force(i)    = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.name(i)     = std::string("particle") + std::to_string(i);
+        sys.group(i)    = std::string("group")    + std::to_string(i);
+    }
+
+    {
+        msgpackobs_type obs("test_save_load_msgpack_periodic");
+        obs.initialize(0, 0.1, sys, ff);
+        obs.output(0, 0.1, sys, ff);
+    }
+    const system_type loaded = load_system_from_msgpack<traits_type>("test_save_load_msgpack_periodic.msg");
+
+    // It should be bitwise-same.
+
+    BOOST_TEST(math::X(sys.boundary().lower_bound()) == math::X(loaded.boundary().lower_bound()));
+    BOOST_TEST(math::Y(sys.boundary().lower_bound()) == math::Y(loaded.boundary().lower_bound()));
+    BOOST_TEST(math::Z(sys.boundary().lower_bound()) == math::Z(loaded.boundary().lower_bound()));
+
+    BOOST_TEST(math::X(sys.boundary().upper_bound()) == math::X(loaded.boundary().upper_bound()));
+    BOOST_TEST(math::Y(sys.boundary().upper_bound()) == math::Y(loaded.boundary().upper_bound()));
+    BOOST_TEST(math::Z(sys.boundary().upper_bound()) == math::Z(loaded.boundary().upper_bound()));
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        BOOST_TEST(sys.mass(i)     == loaded.mass(i)    );
+        BOOST_TEST(sys.rmass(i)    == loaded.rmass(i)   );
+
+        BOOST_TEST(math::X(sys.position(i)) == math::X(loaded.position(i)));
+        BOOST_TEST(math::Y(sys.position(i)) == math::Y(loaded.position(i)));
+        BOOST_TEST(math::Z(sys.position(i)) == math::Z(loaded.position(i)));
+
+        BOOST_TEST(math::X(sys.velocity(i)) == math::X(loaded.velocity(i)));
+        BOOST_TEST(math::Y(sys.velocity(i)) == math::Y(loaded.velocity(i)));
+        BOOST_TEST(math::Z(sys.velocity(i)) == math::Z(loaded.velocity(i)));
+
+        BOOST_TEST(math::X(sys.force(i))    == math::X(loaded.force(i))   );
+        BOOST_TEST(math::Y(sys.force(i))    == math::Y(loaded.force(i))   );
+        BOOST_TEST(math::Z(sys.force(i))    == math::Z(loaded.force(i))   );
+
+        BOOST_TEST(sys.name(i)     == loaded.name(i)    );
+        BOOST_TEST(sys.group(i)    == loaded.group(i)   );
+    }
+    BOOST_TEST(sys.attribute("pi") == loaded.attribute("pi"));
+    BOOST_TEST(sys.attribute("e")  == loaded.attribute("e") );
+}

--- a/test/omp/CMakeLists.txt
+++ b/test/omp/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_NAMES
     test_omp_sort
     test_omp_random_number_generator
+    test_omp_save_load_msgpack
 
     test_omp_bond_length_interaction
     test_omp_bond_length_gocontact_interaction

--- a/test/omp/test_omp_save_load_msgpack.cpp
+++ b/test/omp/test_omp_save_load_msgpack.cpp
@@ -1,0 +1,153 @@
+#define BOOST_TEST_MODULE "test_save_load_msgpack"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <mjolnir/omp/omp.hpp>
+#include <mjolnir/core/BoundaryCondition.hpp>
+#include <mjolnir/core/SimulatorTraits.hpp>
+#include <mjolnir/core/System.hpp>
+#include <mjolnir/core/ForceField.hpp>
+#include <mjolnir/core/MsgPackObserver.hpp>
+#include <mjolnir/input/read_system.hpp>
+
+using real_types = std::tuple<double, float>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_save_load_msgpack_unlimited, realT, real_types)
+{
+    using namespace mjolnir;
+    LoggerManager::set_default_logger("test_omp_save_load_msgpack.log");
+    using traits_type     = OpenMPSimulatorTraits<realT, UnlimitedBoundary>;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using system_type     = System<traits_type>;
+    using forcefield_type = ForceField<traits_type>;
+    using msgpackobs_type = MsgPackObserver<traits_type>;
+    using boundary_type   = typename system_type::boundary_type;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<realT> uni(-10.0, 10.0);
+    system_type sys(100, boundary_type());
+    forcefield_type ff;
+
+    sys.attribute("pi") = 3.14;
+    sys.attribute("e")  = 2.71;
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)     = uni(mt);
+        sys.rmass(i)    = realT(1.0) / sys.mass(i);
+        sys.position(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.velocity(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.force(i)    = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.name(i)     = std::string("particle") + std::to_string(i);
+        sys.group(i)    = std::string("group")    + std::to_string(i);
+    }
+
+    {
+        msgpackobs_type obs("test_omp_save_load_msgpack_unlimited");
+        obs.initialize(0, 0.1, sys, ff);
+        obs.output(0, 0.1, sys, ff);
+    }
+    const system_type loaded = load_system_from_msgpack<traits_type>("test_omp_save_load_msgpack_unlimited.msg");
+
+    // It should be bitwise-same.
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        BOOST_TEST(sys.mass(i)     == loaded.mass(i)    );
+        BOOST_TEST(sys.rmass(i)    == loaded.rmass(i)   );
+
+        BOOST_TEST(math::X(sys.position(i)) == math::X(loaded.position(i)));
+        BOOST_TEST(math::Y(sys.position(i)) == math::Y(loaded.position(i)));
+        BOOST_TEST(math::Z(sys.position(i)) == math::Z(loaded.position(i)));
+
+        BOOST_TEST(math::X(sys.velocity(i)) == math::X(loaded.velocity(i)));
+        BOOST_TEST(math::Y(sys.velocity(i)) == math::Y(loaded.velocity(i)));
+        BOOST_TEST(math::Z(sys.velocity(i)) == math::Z(loaded.velocity(i)));
+
+        BOOST_TEST(math::X(sys.force(i))    == math::X(loaded.force(i))   );
+        BOOST_TEST(math::Y(sys.force(i))    == math::Y(loaded.force(i))   );
+        BOOST_TEST(math::Z(sys.force(i))    == math::Z(loaded.force(i))   );
+
+        BOOST_TEST(sys.name(i)     == loaded.name(i)    );
+        BOOST_TEST(sys.group(i)    == loaded.group(i)   );
+    }
+    BOOST_TEST(sys.attribute("pi") == loaded.attribute("pi"));
+    BOOST_TEST(sys.attribute("e")  == loaded.attribute("e") );
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_save_load_msgpack_periodic, realT, real_types)
+{
+    using namespace mjolnir;
+    LoggerManager::set_default_logger("test_omp_save_load_msgpack.log");
+    using traits_type     = OpenMPSimulatorTraits<realT, CuboidalPeriodicBoundary>;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using system_type     = System<traits_type>;
+    using forcefield_type = ForceField<traits_type>;
+    using msgpackobs_type = MsgPackObserver<traits_type>;
+    using boundary_type   = typename system_type::boundary_type;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<realT> uni(-10.0, 10.0);
+    system_type sys(100, boundary_type(
+        math::make_coordinate<coordinate_type>(-1.0, -2.0, -3.0),
+        math::make_coordinate<coordinate_type>( 1.0,  2.0,  3.0)));
+
+    forcefield_type ff;
+
+    sys.attribute("pi") = 3.14;
+    sys.attribute("e")  = 2.71;
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)     = uni(mt);
+        sys.rmass(i)    = realT(1.0) / sys.mass(i);
+        sys.position(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.velocity(i) = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.force(i)    = math::make_coordinate<coordinate_type>(uni(mt), uni(mt), uni(mt));
+        sys.name(i)     = std::string("particle") + std::to_string(i);
+        sys.group(i)    = std::string("group")    + std::to_string(i);
+    }
+
+    {
+        msgpackobs_type obs("test_omp_save_load_msgpack_periodic");
+        obs.initialize(0, 0.1, sys, ff);
+        obs.output(0, 0.1, sys, ff);
+    }
+    const system_type loaded = load_system_from_msgpack<traits_type>("test_omp_save_load_msgpack_periodic.msg");
+
+    // It should be bitwise-same.
+
+    BOOST_TEST(math::X(sys.boundary().lower_bound()) == math::X(loaded.boundary().lower_bound()));
+    BOOST_TEST(math::Y(sys.boundary().lower_bound()) == math::Y(loaded.boundary().lower_bound()));
+    BOOST_TEST(math::Z(sys.boundary().lower_bound()) == math::Z(loaded.boundary().lower_bound()));
+
+    BOOST_TEST(math::X(sys.boundary().upper_bound()) == math::X(loaded.boundary().upper_bound()));
+    BOOST_TEST(math::Y(sys.boundary().upper_bound()) == math::Y(loaded.boundary().upper_bound()));
+    BOOST_TEST(math::Z(sys.boundary().upper_bound()) == math::Z(loaded.boundary().upper_bound()));
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        BOOST_TEST(sys.mass(i)     == loaded.mass(i)    );
+        BOOST_TEST(sys.rmass(i)    == loaded.rmass(i)   );
+
+        BOOST_TEST(math::X(sys.position(i)) == math::X(loaded.position(i)));
+        BOOST_TEST(math::Y(sys.position(i)) == math::Y(loaded.position(i)));
+        BOOST_TEST(math::Z(sys.position(i)) == math::Z(loaded.position(i)));
+
+        BOOST_TEST(math::X(sys.velocity(i)) == math::X(loaded.velocity(i)));
+        BOOST_TEST(math::Y(sys.velocity(i)) == math::Y(loaded.velocity(i)));
+        BOOST_TEST(math::Z(sys.velocity(i)) == math::Z(loaded.velocity(i)));
+
+        BOOST_TEST(math::X(sys.force(i))    == math::X(loaded.force(i))   );
+        BOOST_TEST(math::Y(sys.force(i))    == math::Y(loaded.force(i))   );
+        BOOST_TEST(math::Z(sys.force(i))    == math::Z(loaded.force(i))   );
+
+        BOOST_TEST(sys.name(i)     == loaded.name(i)    );
+        BOOST_TEST(sys.group(i)    == loaded.group(i)   );
+    }
+    BOOST_TEST(sys.attribute("pi") == loaded.attribute("pi"));
+    BOOST_TEST(sys.attribute("e")  == loaded.attribute("e") );
+}


### PR DESCRIPTION
Make it easier to start a simulation from the last snapshot of another trajectory.

In the current implementation,
- output `filename.msg`
- by specifying `file_name = "filename.msg"` in `[[systems]]` table, the snapshot will be loaded.