### PR TITLE
enable to use env and offset in simulator table

### DIFF
--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -173,52 +173,6 @@ read_ignore_particles_within(const toml::value& global)
     return ignore_particle_within;
 }
 
-template<typename parameterT>
-void check_parameter_overlap(const toml::value& env, const toml::array& setting,
-        std::vector<std::pair<std::size_t, parameterT>>& parameters)
-{
-    if(parameters.empty()) {return ;}
-
-    MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_LOG_FUNCTION();
-    using value_type = std::pair<std::size_t, parameterT>;
-
-    std::sort(parameters.begin(), parameters.end(),
-            [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
-                return lhs.first < rhs.first;
-            });
-    const auto overlap = std::adjacent_find(parameters.begin(), parameters.end(),
-            [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
-                return lhs.first == rhs.first;
-            });
-
-    if(overlap != parameters.end())
-    {
-        const std::size_t overlapped_idx = overlap->first;
-        MJOLNIR_LOG_ERROR("parameter for ", overlapped_idx, " defined twice");
-
-        // find overlapped one
-        const auto overlapped1 = std::find_if(setting.begin(), setting.end(),
-            [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
-            });
-
-        assert(overlapped1 != setting.end());
-
-        const auto overlapped2 = std::find_if(std::next(overlapped1), setting.end(),
-            [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
-            });
-
-        assert(overlapped2 != setting.end());
-
-        throw_exception<std::runtime_error>(toml::format_error(
-            "[error] duplicate parameter definitions",
-            *overlapped1, "this defined twice", *overlapped2, "here"));
-    }
-    return ;
-}
-
 template<typename traitsT>
 ExcludedVolumePotential<traitsT>
 read_excluded_volume_potential(const toml::value& global)

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -66,17 +66,32 @@ read_underdamped_langevin_integrator(const toml::value& simulator)
     const auto& env = simulator.as_table().count("env") == 1 ?
                       simulator.as_table().at("env") : toml::value{};
 
-    std::vector<real_type> gamma(parameters.size());
+    // Temporarily make the vector of idx gamma pair for check duplicated definition
+    // of gamma to index.
+    std::vector<std::pair<std::size_t, real_type>> idx_gammas;
+    idx_gammas.reserve(parameters.size());
     for(const auto& params : parameters)
     {
         const auto offset = find_parameter_or<std::int64_t>(params, env, "offset", 0);
         const auto idx = toml::find<std::size_t>(params, "index") + offset;
         const auto  gm = find_parameter<real_type>(params, env, "gamma", u8"γ");
+
+        idx_gammas.emplace_back(idx, gm);
+    }
+    check_parameter_overlap(env, parameters, idx_gammas);
+
+    std::vector<real_type> gamma(parameters.size());
+    gamma.reserve(parameters.size());
+    for(const auto& idx_gamma : idx_gammas)
+    {
+        const auto idx   = idx_gamma.first;
+        const auto gm = idx_gamma.second;
         if(gamma.size() <= idx){gamma.resize(idx+1);}
         gamma.at(idx) = gm;
 
         MJOLNIR_LOG_INFO("idx = ", idx, ", gamma = ", gm);
     }
+
     return UnderdampedLangevinIntegrator<traitsT>(delta_t, std::move(gamma),
             read_system_motion_remover<traitsT>(simulator));
 }

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -60,16 +60,18 @@ read_underdamped_langevin_integrator(const toml::value& simulator)
 
     const auto& integrator = toml::find(simulator, "integrator");
 
-    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
+    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s, "env"_s});
 
     const auto parameters = toml::find<toml::array  >(integrator, "parameters");
+    const auto& env = simulator.as_table().count("env") == 1 ?
+                      simulator.as_table().at("env") : toml::value{};
 
     std::vector<real_type> gamma(parameters.size());
     for(const auto& params : parameters)
     {
-        const auto idx = toml::find<std::size_t>(params, "index");
-        const auto  gm = toml::expect<real_type>(params, u8"γ").or_other(
-                         toml::expect<real_type>(params, "gamma")).unwrap();
+        const auto offset = find_parameter_or<std::int64_t>(params, env, "offset", 0);
+        const auto idx = toml::find<std::size_t>(params, "index") + offset;
+        const auto  gm = find_parameter<real_type>(params, env, "gamma", u8"γ");
         if(gamma.size() <= idx){gamma.resize(idx+1);}
         gamma.at(idx) = gm;
 
@@ -92,16 +94,18 @@ read_BAOAB_langevin_integrator(const toml::value& simulator)
 
     const auto& integrator = toml::find(simulator, "integrator");
 
-    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
+    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s, "env"_s});
 
     const auto parameters = toml::find<toml::array  >(integrator, "parameters");
+    const auto& env = simulator.as_table().count("env") == 1?
+                      simulator.as_table().count("env") : toml::value{};
 
     std::vector<real_type> gamma(parameters.size());
     for(const auto& params : parameters)
     {
-        const auto idx = toml::find<std::size_t>(params, "index");
-        const auto  gm = toml::expect<real_type>(params, u8"γ").or_other(
-                         toml::expect<real_type>(params, "gamma")).unwrap();
+        const auto offset = find_parameter_or<std::int64_t>(params, env, "offset", 0);
+        const auto idx = find_parameter<std::size_t>(params, env, "index") + offset;
+        const auto  gm = find_parameter<real_type>(params, env, "gamma", u8"γ");
         if(gamma.size() <= idx) {gamma.resize(idx+1);}
         gamma.at(idx) = gm;
 

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -29,7 +29,7 @@ read_molecular_dynamics_simulator(
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
         "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s, "delta_t"_s,
-        "integrator"_s});
+        "integrator"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -86,8 +86,8 @@ read_simulated_annealing_simulator(
     using real_type   = typename traitsT::real_type;
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
-            "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s,
-            "delta_t"_s, "integrator"_s, "schedule"_s, "each_step"_s});
+            "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s, "delta_t"_s,
+            "integrator"_s, "schedule"_s, "each_step"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -163,7 +163,7 @@ read_switching_forcefield_simulator(
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
             "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s,
-            "delta_t"_s, "integrator"_s, "schedule"_s});
+            "delta_t"_s, "integrator"_s, "schedule"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -234,7 +234,7 @@ read_energy_calculation_simulator(
     using coordinate_type = typename traitsT::coordinate_type;
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
-            "file"_s, "parallelism"_s});
+            "file"_s, "parallelism"_s, "env"_s});
 
     // ------------------------------------------------------------------------
     // construct observers manually ...

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -188,14 +188,18 @@ void check_parameter_overlap(const toml::value& env, const toml::array& setting,
         // find overlapped one
         const auto overlapped1 = std::find_if(setting.begin(), setting.end(),
             [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
+                const auto ofs = find_parameter_or<std::int64_t>(v, env, "offset", 0);
+                const auto idx = find_parameter<std::size_t>(v, env, "index") + ofs;
+                return idx == overlapped_idx;
             });
 
         assert(overlapped1 != setting.end());
 
         const auto overlapped2 = std::find_if(std::next(overlapped1), setting.end(),
             [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
+                const auto ofs = find_parameter_or<std::int64_t>(v, env, "offset", 0);
+                const auto idx = find_parameter<std::size_t>(v, env, "index") + ofs;
+                return idx == overlapped_idx;
             });
 
         assert(overlapped2 != setting.end());

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -157,6 +157,55 @@ T find_parameter_or(const toml::value& params, const toml::value& env,
     }
     return toml::get_or(p, opt);
 }
+
+// This check the index in parameters vector doesn't appear twice.
+//     If the index appear twice, it raise the error represent the line of
+// input file define the index.
+template<typename parameterT>
+void check_parameter_overlap(const toml::value& env, const toml::array& setting,
+        std::vector<std::pair<std::size_t, parameterT>>& parameters)
+{
+    if(parameters.empty()) {return ;}
+
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    MJOLNIR_LOG_FUNCTION();
+    using value_type = std::pair<std::size_t, parameterT>;
+
+    std::sort(parameters.begin(), parameters.end(),
+            [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
+                return lhs.first < rhs.first;
+            });
+    const auto overlap = std::adjacent_find(parameters.begin(), parameters.end(),
+            [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
+                return lhs.first == rhs.first;
+            });
+
+    if(overlap != parameters.end())
+    {
+        const std::size_t overlapped_idx = overlap->first;
+        MJOLNIR_LOG_ERROR("parameter for ", overlapped_idx, " defined twice");
+
+        // find overlapped one
+        const auto overlapped1 = std::find_if(setting.begin(), setting.end(),
+            [overlapped_idx, &env](const toml::value& v) -> bool {
+                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
+            });
+
+        assert(overlapped1 != setting.end());
+
+        const auto overlapped2 = std::find_if(std::next(overlapped1), setting.end(),
+            [overlapped_idx, &env](const toml::value& v) -> bool {
+                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
+            });
+
+        assert(overlapped2 != setting.end());
+
+        throw_exception<std::runtime_error>(toml::format_error(
+            "[error] duplicate parameter definitions",
+            *overlapped1, "this defined twice", *overlapped2, "here"));
+    }
+    return ;
+}
 } // mjolnir
 
 namespace toml


### PR DESCRIPTION
The list of the changed point is below.
1. add offset to each read integrator function.
2. add env to each read integrator function.
3. avoid raising warning from check_key_available.
4. check the duplicated definition of gamma to the same index in read_underdamped_langevin_integrator function.

Using offset for parameter definition, the possibility of mistakes about index increases, so I implemented the fourth point. However, how to implement this is not trivial to me.
 Now, UnderdampedLangevimIntegrator uses the real type vector to store the gamma and I have no idea to check duplicated definition based on this without another container. One option to implement a method is changing gamma container to another type of container, but this change is too large.
    I implemented it using a temporal vector, for the moment, of course, this makes overhead. So if there is a better way for this, I'll remove this commit from this PR and try that.