### PR TITLE
regular monthly update

### DIFF
--- a/mjolnir/forcefield/global/DebyeHuckelPotential.hpp
+++ b/mjolnir/forcefield/global/DebyeHuckelPotential.hpp
@@ -61,7 +61,10 @@ class DebyeHuckelPotential
         const std::vector<std::pair<std::size_t, parameter_type>>& parameters,
         const std::map<connection_kind_type, std::size_t>& exclusions,
         ignore_molecule_type ignore_mol, ignore_group_type ignore_grp)
-    : cutoff_ratio_(cutoff_ratio), temperature_(300.0), ion_strength_(0.1),
+    : cutoff_ratio_(cutoff_ratio),
+        // XXX should be updated in the `initialize(sys)` method
+      temperature_ (std::numeric_limits<real_type>::quiet_NaN()),
+      ion_strength_(std::numeric_limits<real_type>::quiet_NaN()),
       exclusion_list_(exclusions, std::move(ignore_mol), std::move(ignore_grp))
     {
         this->parameters_  .reserve(parameters.size());
@@ -76,8 +79,6 @@ class DebyeHuckelPotential
             }
             this->parameters_.at(idx) = idxp.second;
         }
-        // XXX should be updated before use because T and ion conc are default!
-        this->calc_parameters();
     }
     ~DebyeHuckelPotential() = default;
 

--- a/mjolnir/input/read_external_interaction.hpp
+++ b/mjolnir/input/read_external_interaction.hpp
@@ -163,8 +163,7 @@ read_external_position_restraint_interaction(const toml::value& external)
     using real_type       = typename traitsT::real_type;
     using coordinate_type = typename traitsT::coordinate_type;
 
-    const auto& env = external.as_table().count("env") == 1 ?
-                      external.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto potential = toml::find<std::string>(external, "potential");
     if(potential == "Harmonic")
@@ -227,8 +226,7 @@ read_afm_flexible_fitting_interaction(const toml::value& external)
     const auto length_x = toml::find<std::size_t>(external, "length_x");
     const auto length_y = toml::find<std::size_t>(external, "length_y");
 
-    const auto& env = external.as_table().count("env") != 0 ?
-                      external.at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     // read radius and participants
 

--- a/mjolnir/input/read_external_interaction.hpp
+++ b/mjolnir/input/read_external_interaction.hpp
@@ -163,7 +163,7 @@ read_external_position_restraint_interaction(const toml::value& external)
     using real_type       = typename traitsT::real_type;
     using coordinate_type = typename traitsT::coordinate_type;
 
-    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
+    const auto& env = external.contains("env") ? external.at("env") : toml::value{};
 
     const auto potential = toml::find<std::string>(external, "potential");
     if(potential == "Harmonic")
@@ -226,7 +226,7 @@ read_afm_flexible_fitting_interaction(const toml::value& external)
     const auto length_x = toml::find<std::size_t>(external, "length_x");
     const auto length_y = toml::find<std::size_t>(external, "length_y");
 
-    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
+    const auto& env = external.contains("env") ? external.at("env") : toml::value{};
 
     // read radius and participants
 

--- a/mjolnir/input/read_external_potential.hpp
+++ b/mjolnir/input/read_external_potential.hpp
@@ -26,7 +26,7 @@ read_lennard_jones_wall_potential(const toml::value& external)
     using real_type = realT;
     using potential_type = LennardJonesWallPotential<realT>;
 
-    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
+    const auto& env = external.contains("env") ? external.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)
@@ -65,7 +65,7 @@ read_excluded_volume_wall_potential(const toml::value& external)
                      toml::expect<real_type>(external, "epsilon")).unwrap();
     MJOLNIR_LOG_INFO("epsilon = ", eps);
 
-    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
+    const auto& env = external.contains("env") ? external.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)
@@ -107,7 +107,7 @@ read_implicit_membrane_potential(const toml::value& external)
     MJOLNIR_LOG_INFO("magnitude = ", magnitude);
     MJOLNIR_LOG_INFO("bend      = ", bend     );
 
-    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
+    const auto& env = external.contains("env") ? external.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)

--- a/mjolnir/input/read_external_potential.hpp
+++ b/mjolnir/input/read_external_potential.hpp
@@ -26,8 +26,7 @@ read_lennard_jones_wall_potential(const toml::value& external)
     using real_type = realT;
     using potential_type = LennardJonesWallPotential<realT>;
 
-    const auto& env = external.as_table().count("env") == 1 ?
-                      external.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)
@@ -66,8 +65,7 @@ read_excluded_volume_wall_potential(const toml::value& external)
                      toml::expect<real_type>(external, "epsilon")).unwrap();
     MJOLNIR_LOG_INFO("epsilon = ", eps);
 
-    const auto& env = external.as_table().count("env") == 1 ?
-                      external.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)
@@ -109,8 +107,7 @@ read_implicit_membrane_potential(const toml::value& external)
     MJOLNIR_LOG_INFO("magnitude = ", magnitude);
     MJOLNIR_LOG_INFO("bend      = ", bend     );
 
-    const auto& env = external.as_table().count("env") == 1 ?
-                      external.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     real_type cutoff = potential_type::default_cutoff();
     if(external.as_table().count("cutoff") != 0)

--- a/mjolnir/input/read_forcefield.hpp
+++ b/mjolnir/input/read_forcefield.hpp
@@ -21,9 +21,8 @@ read_forcefield(const toml::value& root, const std::size_t N)
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_LOG_FUNCTION();
 
-    const auto input_path = read_input_path(root);
     const auto ff = read_table_from_file(toml::find(root, "forcefields").at(N),
-                                         "forcefields", input_path);
+                                         "forcefields");
     check_keys_available(ff, {"local"_s, "global"_s, "external"_s, "name"_s});
 
     if(ff.as_table().count("name") == 1)
@@ -45,7 +44,7 @@ read_forcefield(const toml::value& root, const std::size_t N)
         {
             MJOLNIR_LOG_NOTICE("reading ", format_nth(i), " [[forcefields.local]]");
             loc.emplace(read_local_interaction<traitsT>(
-                read_table_from_file(locals.at(i), "local", input_path)));
+                read_table_from_file(locals.at(i), "local")));
         }
     }
     if(ff.as_table().count("global") != 0)
@@ -56,7 +55,7 @@ read_forcefield(const toml::value& root, const std::size_t N)
         {
             MJOLNIR_LOG_NOTICE("reading ", format_nth(i), " [[forcefields.global]]");
             glo.emplace(read_global_interaction<traitsT>(
-                read_table_from_file(globals.at(i), "global", input_path)));
+                read_table_from_file(globals.at(i), "global")));
         }
     }
     if(ff.as_table().count("external") != 0)
@@ -67,7 +66,7 @@ read_forcefield(const toml::value& root, const std::size_t N)
         {
             MJOLNIR_LOG_NOTICE("reading ", format_nth(i), " [[forcefields.external]]");
             ext.emplace(read_external_interaction<traitsT>(
-                read_table_from_file(externals.at(i), "external", input_path)));
+                read_table_from_file(externals.at(i), "external")));
         }
     }
     return ForceField<traitsT>(std::move(loc), std::move(glo), std::move(ext));

--- a/mjolnir/input/read_global_interaction.hpp
+++ b/mjolnir/input/read_global_interaction.hpp
@@ -144,8 +144,7 @@ read_global_3spn2_base_base_interaction(const toml::value& global)
     // ------------------------------------------------------------------------
     // read parameters
 
-    const auto& env    = global.as_table().count("env") == 1 ?
-                         global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
@@ -298,8 +297,7 @@ read_pdns_interaction(const toml::value& global)
     const real_type cutoff = toml::find_or<real_type>(global, "cutoff",
             potential_type::default_cutoff());
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
@@ -403,8 +401,7 @@ read_pwmcos_interaction(const toml::value& global)
     const real_type cutoff = toml::find_or<real_type>(global, "cutoff",
             potential_type::default_cutoff());
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -21,6 +21,9 @@ namespace mjolnir
 // global potential
 // ============================================================================
 
+//
+// reads `ignore.molecule`. If not provided, return the default value.
+//
 inline IgnoreMolecule<typename Topology::molecule_id_type>
 read_ignored_molecule(const toml::value& global)
 {
@@ -82,6 +85,9 @@ read_ignored_molecule(const toml::value& global)
     }
 }
 
+//
+// reads `ignore.group`. If not provided, return the default value.
+//
 inline IgnoreGroup<typename Topology::group_id_type>
 read_ignored_group(const toml::value& global)
 {
@@ -150,6 +156,9 @@ read_ignored_group(const toml::value& global)
     return IgnoreGroup<group_id_type>(ignores);
 }
 
+//
+// reads `ignore.particles_within`. If not provided, return the default value.
+//
 inline std::map<std::string, std::size_t>
 read_ignore_particles_within(const toml::value& global)
 {
@@ -173,6 +182,15 @@ read_ignore_particles_within(const toml::value& global)
     return ignore_particle_within;
 }
 
+//
+// checks index overlap in the `parameters` array. If any, show the warning.
+// After reading the parameters, call this.
+// ```toml
+// parameters = [
+//     {index = 10, radius = 2.0},
+//     {index = 10, radius = 2.0}, # <- overlap! parameter value is ambiguous.
+// ]
+// ```
 template<typename parameterT>
 void check_parameter_overlap(const toml::value& env, const toml::array& setting,
         std::vector<std::pair<std::size_t, parameterT>>& parameters)
@@ -185,8 +203,9 @@ void check_parameter_overlap(const toml::value& env, const toml::array& setting,
 
     std::sort(parameters.begin(), parameters.end(),
             [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
-                return lhs.first < rhs.first;
+                return lhs.first < rhs.first; // check only its index.
             });
+
     const auto overlap = std::adjacent_find(parameters.begin(), parameters.end(),
             [](const value_type& lhs, const value_type& rhs) noexcept -> bool {
                 return lhs.first == rhs.first;
@@ -197,23 +216,25 @@ void check_parameter_overlap(const toml::value& env, const toml::array& setting,
         const std::size_t overlapped_idx = overlap->first;
         MJOLNIR_LOG_ERROR("parameter for ", overlapped_idx, " defined twice");
 
-        // find overlapped one
-        const auto overlapped1 = std::find_if(setting.begin(), setting.end(),
+        // define a functor to find the toml::value by its index.
+        // read the index in parameter and compare it with the `overlapped_idx`.
+        const auto find_by_index =
             [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
-            });
+                return find_parameter<std::size_t>(v, env, "index") +
+                    find_parameter_or<std::size_t>(v, env, "offset", 0) ==
+                    overlapped_idx;
+            };
 
+        const auto overlapped1 = std::find_if(
+                setting.begin(), setting.end(), find_by_idx);
         assert(overlapped1 != setting.end());
 
-        const auto overlapped2 = std::find_if(std::next(overlapped1), setting.end(),
-            [overlapped_idx, &env](const toml::value& v) -> bool {
-                return find_parameter<std::size_t>(v, env, "index") == overlapped_idx;
-            });
-
+        const auto overlapped2 = std::find_if(
+                std::next(overlapped1), setting.end(), find_by_idx);
         assert(overlapped2 != setting.end());
 
         throw_exception<std::runtime_error>(toml::format_error(
-            "[error] duplicate parameter definitions",
+            "check_parameter_overlap: duplicate parameter definitions",
             *overlapped1, "this defined twice", *overlapped2, "here"));
     }
     return ;
@@ -229,8 +250,7 @@ read_excluded_volume_potential(const toml::value& global)
     using real_type      = typename potential_type::real_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const real_type eps = toml::find<real_type>(global, "epsilon");
     MJOLNIR_LOG_INFO("epsilon = ", eps);
@@ -271,8 +291,7 @@ read_inverse_power_potential(const toml::value& global)
     using integer_type   = typename potential_type::integer_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const real_type eps = toml::find<real_type>(global, "epsilon");
     MJOLNIR_LOG_INFO("epsilon = ", eps);
@@ -315,8 +334,7 @@ read_hard_core_excluded_volume_potential(const toml::value& global)
     using real_type      = typename potential_type::real_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const real_type eps = toml::find<real_type>(global, "epsilon");
     MJOLNIR_LOG_INFO("epsilon = ", eps);
@@ -362,8 +380,7 @@ read_lennard_jones_potential(const toml::value& global)
     using real_type      = typename potential_type::real_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const real_type cutoff = toml::find_or<real_type>(global, "cutoff",
             potential_type::default_cutoff());
@@ -402,8 +419,7 @@ read_uniform_lennard_jones_potential(const toml::value& global)
     using real_type      = typename potential_type::real_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto sigma   = toml::expect<real_type>(global, u8"σ").or_other(
                          toml::expect<real_type>(global, "sigma")).unwrap();
@@ -450,8 +466,7 @@ read_debye_huckel_potential(const toml::value& global)
     using real_type      = typename potential_type::real_type;
     using parameter_type = typename potential_type::parameter_type;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const real_type cutoff = toml::find_or<real_type>(global, "cutoff",
             potential_type::default_cutoff());
@@ -490,8 +505,7 @@ read_3spn2_excluded_volume_potential(const toml::value& global)
     using parameter_type = typename potential_type::parameter_type;
     using bead_kind      = parameter_3SPN2::bead_kind;
 
-    const auto& env = global.as_table().count("env") == 1 ?
-                      global.as_table().at("env") : toml::value{};
+    const auto& env = global.contains("env") ? global.at("env") : toml::value{};
 
     const auto& ps = toml::find<toml::array>(global, "parameters");
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -226,11 +226,11 @@ void check_parameter_overlap(const toml::value& env, const toml::array& setting,
             };
 
         const auto overlapped1 = std::find_if(
-                setting.begin(), setting.end(), find_by_idx);
+                setting.begin(), setting.end(), find_by_index);
         assert(overlapped1 != setting.end());
 
         const auto overlapped2 = std::find_if(
-                std::next(overlapped1), setting.end(), find_by_idx);
+                std::next(overlapped1), setting.end(), find_by_index);
         assert(overlapped2 != setting.end());
 
         throw_exception<std::runtime_error>(toml::format_error(

--- a/mjolnir/input/read_input_file.hpp
+++ b/mjolnir/input/read_input_file.hpp
@@ -132,7 +132,7 @@ read_input_file(const std::string& filename)
 {
     // here, logger name is not given yet. output status directory on console.
     std::cerr << "-- reading and parsing toml file `" << filename << "` ... ";
-    const auto root = toml::parse(filename);
+    auto root = toml::parse(filename);
     std::cerr << " successfully parsed." << std::endl;
 
     // initializing logger by using output_path and output_prefix ...
@@ -158,6 +158,10 @@ read_input_file(const std::string& filename)
 
     // load the input path in the [files] table and set it globally
     read_input_path(root);
+
+    MJOLNIR_LOG_NOTICE("expanding include files ...");
+    root = expand_include(root);
+    MJOLNIR_LOG_NOTICE("done.");
 
     // the most of important flags are defined in [simulator], like
     // `precision = "float"`, `boundary_type = "Unlimited"`.

--- a/mjolnir/input/read_input_file.hpp
+++ b/mjolnir/input/read_input_file.hpp
@@ -156,14 +156,16 @@ read_input_file(const std::string& filename)
     check_keys_available(root, {"files"_s, "units"_s, "simulator"_s,
                                 "systems"_s, "forcefields"_s});
 
+    // load the input path in the [files] table and set it globally
+    read_input_path(root);
+
     // the most of important flags are defined in [simulator], like
     // `precision = "float"`, `boundary_type = "Unlimited"`.
     // Those values should be read before others.
-    // Thus first read [simulator] here and pass it to the latter functions.
+    const auto simulator = read_table_from_file(
+            toml::find(root, "simulator"), "simulator");
 
-    const auto& simulator = toml::find(root, "simulator");
-    return read_precision(root, read_table_from_file(
-                simulator, "simulator", read_input_path(root)));
+    return read_precision(root, simulator);
 }
 
 #ifdef MJOLNIR_SEPARATE_BUILD

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -59,21 +59,41 @@ read_underdamped_langevin_integrator(const toml::value& simulator)
 
     const auto& integrator = toml::find(simulator, "integrator");
 
-    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
+    check_keys_available(integrator,
+            {"type"_s, "seed"_s, "parameters"_s, "remove"_s, "env"_s});
 
     const auto parameters = toml::find<toml::array>(integrator, "parameters");
 
-    std::vector<real_type> gamma(parameters.size());
+    const auto& env = integrator.contains("env") ?
+                      integrator.at("env") : toml::value{};
+
+    // Temporarily make a vector of idx gamma pair to check index duplication.
+    std::vector<std::pair<std::size_t, real_type>> idx_gammas;
+    idx_gammas.reserve(parameters.size());
     for(const auto& params : parameters)
     {
-        const auto idx = toml::find<std::size_t>(params, "index");
-        const auto  gm = toml::expect<real_type>(params, u8"γ").or_other(
-                         toml::expect<real_type>(params, "gamma")).unwrap();
-        if(gamma.size() <= idx){gamma.resize(idx+1);}
+        const auto offset = find_parameter_or<std::int64_t>(params, env, "offset", 0);
+        const auto idx    = toml::find<std::size_t>(params, "index") + offset;
+        const auto gm     = find_parameter<real_type>(params, env, "gamma", u8"γ");
+
+        idx_gammas.emplace_back(idx, gm);
+    }
+    check_parameter_overlap(env, parameters, idx_gammas);
+
+    std::vector<real_type> gamma(parameters.size());
+    for(const auto& idx_gamma : idx_gammas)
+    {
+        const auto idx = idx_gamma.first;
+        const auto gm  = idx_gamma.second;
+        if(gamma.size() <= idx)
+        {
+            gamma.resize(idx+1, real_type(0.0));
+        }
         gamma.at(idx) = gm;
 
         MJOLNIR_LOG_INFO("idx = ", idx, ", gamma = ", gm);
     }
+
     return UnderdampedLangevinIntegrator<traitsT>(delta_t, std::move(gamma),
             read_system_motion_remover<traitsT>(simulator));
 }
@@ -91,17 +111,36 @@ read_BAOAB_langevin_integrator(const toml::value& simulator)
 
     const auto& integrator = toml::find(simulator, "integrator");
 
-    check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
+    check_keys_available(integrator,
+            {"type"_s, "seed"_s, "parameters"_s, "remove"_s, "env"_s});
 
     const auto parameters = toml::find<toml::array>(integrator, "parameters");
 
-    std::vector<real_type> gamma(parameters.size());
+    const auto& env = integrator.contains("env") ?
+                      integrator.count("env") : toml::value{};
+
+    // Temporarily make a vector of idx gamma pair to check index duplication.
+    std::vector<std::pair<std::size_t, real_type>> idx_gammas;
+    idx_gammas.reserve(parameters.size());
     for(const auto& params : parameters)
     {
-        const auto idx = toml::find<std::size_t>(params, "index");
-        const auto  gm = toml::expect<real_type>(params, u8"γ").or_other(
-                         toml::expect<real_type>(params, "gamma")).unwrap();
-        if(gamma.size() <= idx) {gamma.resize(idx+1);}
+        const auto offset = find_parameter_or<std::int64_t>(params, env, "offset", 0);
+        const auto idx    = toml::find<std::size_t>(params, "index") + offset;
+        const auto gm     = find_parameter<real_type>(params, env, "gamma", u8"γ");
+
+        idx_gammas.emplace_back(idx, gm);
+    }
+    check_parameter_overlap(env, parameters, idx_gammas);
+
+    std::vector<real_type> gamma(parameters.size());
+    for(const auto& idx_gamma : idx_gammas)
+    {
+        const auto idx = idx_gamma.first;
+        const auto  gm = idx_gamma.second;
+        if(gamma.size() <= idx)
+        {
+            gamma.resize(idx+1, real_type(0.0));
+        }
         gamma.at(idx) = gm;
 
         MJOLNIR_LOG_INFO("idx = ", idx, ", gamma = ", gm);

--- a/mjolnir/input/read_integrator.hpp
+++ b/mjolnir/input/read_integrator.hpp
@@ -31,7 +31,6 @@ read_system_motion_remover(const toml::value& simulator)
     return SystemMotionRemover<traitsT>(translation, rotation, rescale);
 }
 
-
 template<typename traitsT>
 VelocityVerletIntegrator<traitsT>
 read_velocity_verlet_integrator(const toml::value& simulator)
@@ -62,7 +61,7 @@ read_underdamped_langevin_integrator(const toml::value& simulator)
 
     check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
 
-    const auto parameters = toml::find<toml::array  >(integrator, "parameters");
+    const auto parameters = toml::find<toml::array>(integrator, "parameters");
 
     std::vector<real_type> gamma(parameters.size());
     for(const auto& params : parameters)
@@ -94,7 +93,7 @@ read_BAOAB_langevin_integrator(const toml::value& simulator)
 
     check_keys_available(integrator, {"type"_s, "seed"_s, "parameters"_s, "remove"_s});
 
-    const auto parameters = toml::find<toml::array  >(integrator, "parameters");
+    const auto parameters = toml::find<toml::array>(integrator, "parameters");
 
     std::vector<real_type> gamma(parameters.size());
     for(const auto& params : parameters)
@@ -146,7 +145,7 @@ struct read_integrator_impl<BAOABLangevinIntegrator<traitsT>>
 template<typename integratorT>
 integratorT read_integrator(const toml::value& sim)
 {
-    if(sim.as_table().count("integrator") == 0)
+    if(!sim.contains("integrator"))
     {
         throw_exception<std::runtime_error>(toml::format_error("[error] "
             "mjolnir::read_integrator: No integrator defined: ", sim, "here", {

--- a/mjolnir/input/read_local_interaction.hpp
+++ b/mjolnir/input/read_local_interaction.hpp
@@ -394,8 +394,7 @@ read_3spn2_base_stacking_interaction(const std::string& kind, const toml::value&
     const auto& params = toml::find<toml::array>(local, "parameters");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
-    const auto& env = local.as_table().count("env") == 1 ?
-                      local.as_table().at("env") : toml::value{};
+    const auto& env = local.contains("env") ? local.at("env") : toml::value{};
     // parameters = [
     //     {strand = 0, nucleotide =  0,          S =   0, B =   1, Base = "A"},
     //     {strand = 0, nucleotide =  1, P =   2, S =   3, B =   4, Base = "T"},
@@ -487,8 +486,7 @@ read_directional_contact_potentials(const toml::value& local)
     const auto& params = toml::find(local, "parameters").as_array();
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
-    const auto& env = local.as_table().count("env") == 1 ?
-                      local.as_table().at("env") : toml::value{};
+    const auto& env = local.contains("env") ? local.at("env") : toml::value{};
 
     std::vector<indices_potentials_tuple_type> retval;
     retval.reserve(params.size());
@@ -623,8 +621,6 @@ read_directional_contact_interaction(const std::string& kind,
     }
 }
 
-
-
 // ----------------------------------------------------------------------------
 // general read_local_interaction function
 // ----------------------------------------------------------------------------
@@ -729,7 +725,6 @@ extern template std::unique_ptr<LocalInteractionBase<SimulatorTraits<float,  Unl
 extern template std::unique_ptr<LocalInteractionBase<SimulatorTraits<double, CuboidalPeriodicBoundary>>> read_3spn2_base_stacking_interaction(const std::string& kind, const toml::value& local);
 extern template std::unique_ptr<LocalInteractionBase<SimulatorTraits<float,  CuboidalPeriodicBoundary>>> read_3spn2_base_stacking_interaction(const std::string& kind, const toml::value& local);
 #endif
-
 
 } // mjolnir
 #endif// MJOLNIR_READ_LOCAL_INTERACTION

--- a/mjolnir/input/read_local_interaction.hpp
+++ b/mjolnir/input/read_local_interaction.hpp
@@ -168,159 +168,6 @@ read_contact_interaction(const std::string& kind, const toml::value& local)
             }));
     }
 }
-
-template<typename realT,
-         typename angle1T, typename angle2T, typename contactT>
-std::vector<std::tuple<std::array<std::size_t, 4>, angle1T, angle2T, contactT>>
-read_directional_contact_potentials(const toml::value& local)
-{
-    MJOLNIR_GET_DEFAULT_LOGGER();
-    MJOLNIR_LOG_FUNCTION();
-    MJOLNIR_LOG_INFO("as 4-body interaction");
-
-    using indices_type = std::array<std::size_t, 4>;
-    using indices_potentials_tuple_type =
-        std::tuple<indices_type, angle1T, angle2T, contactT>;
-
-    const auto& params = toml::find(local, "parameters").as_array();
-    MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
-
-    const auto& env = local.as_table().count("env") == 1 ?
-                      local.as_table().at("env") : toml::value{};
-
-    std::vector<indices_potentials_tuple_type> retval;
-    retval.reserve(params.size());
-    for(const auto& item : params)
-    {
-        const auto indices = find_parameter<indices_type>(item, env, "indices");
-        MJOLNIR_LOG_INFO_NO_LF("idxs = ", indices, ", ");
-
-        const auto angle1  = find_parameter<toml::value>(item, env, "angle1");
-        const auto angle2  = find_parameter<toml::value>(item, env, "angle2");
-        const auto contact = find_parameter<toml::value>(item, env, "contact");
-
-        retval.push_back(std::make_tuple(indices,
-            detail::read_local_potential_impl<angle1T>::invoke(angle1, env),
-            detail::read_local_potential_impl<angle2T>::invoke(angle2, env),
-            detail::read_local_potential_impl<contactT>::invoke(contact, env)));
-    }
-    return retval;
-}
-
-// This is reading contact part of read_directional_contact_interaction function.
-template<typename traitsT, typename ... PotentialTs>
-typename std::enable_if<sizeof...(PotentialTs) == 2,
-    std::unique_ptr<LocalInteractionBase<traitsT>>>::type
-read_directional_contact_interaction(const std::string& kind,
-        const toml::value& local, std::vector<std::string>)
-{
-    MJOLNIR_GET_DEFAULT_LOGGER();
-    using real_type = typename traitsT::real_type;
-
-    const real_type margin = toml::find_or<real_type>(local, "margin", 0.5);
-
-    const auto contact_potential =
-        toml::find<std::string>(local, "potentials", "contact");
-
-    if(contact_potential == "GoContact")
-    {
-        MJOLNIR_LOG_NOTICE("-- contact potential function is 10-12 Go contact.");
-        using contact_potentialT = GoContactPotential<real_type>;
-
-        return make_unique<DirectionalContactInteraction<
-            traitsT, PotentialTs..., contact_potentialT>>(kind,
-              read_directional_contact_potentials<
-                  real_type, PotentialTs..., contact_potentialT
-              >(local), margin);
-    }
-    else if(contact_potential == "Gaussian")
-    {
-        MJOLNIR_LOG_NOTICE("-- contact potential function is Gaussian.");
-        using contact_potentialT = GaussianPotential<real_type>;
-
-        return make_unique<DirectionalContactInteraction<
-                traitsT, PotentialTs..., contact_potentialT>>(kind,
-              read_directional_contact_potentials<
-                  real_type, PotentialTs..., contact_potentialT
-              >(local), margin);
-    }
-    else if(contact_potential == "Uniform")
-    {
-        MJOLNIR_LOG_NOTICE("-- contact potential function is Uniform potential");
-        using contact_potentialT = UniformPotential<real_type>;
-
-        return make_unique<DirectionalContactInteraction<
-                traitsT, PotentialTs..., contact_potentialT>>(kind,
-              read_directional_contact_potentials<
-                  real_type, PotentialTs..., contact_potentialT
-              >(local), margin);
-    }
-    else
-    {
-        throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_directional_contact_interaction: invalid contact potential",
-            toml::find(local, "potentials", "contact"), "here", {
-            "expected value is one of the following.",
-            "- \"GoContact\": r^12 - r^10 type native contact potential",
-            "- \"Gaussian\" : well-known gaussian potential"
-            }));
-    }
-}
-
-// This is reading angle parts of read_directional_contact_interaction function.
-template<typename traitsT, typename ... PotentialTs>
-typename std::enable_if<sizeof...(PotentialTs) < 2,
-    std::unique_ptr<LocalInteractionBase<traitsT>>>::type
-read_directional_contact_interaction(const std::string& kind,
-        const toml::value& local, std::vector<std::string> angle_keys)
-{
-    MJOLNIR_GET_DEFAULT_LOGGER();
-    using real_type = typename traitsT::real_type;
-
-    const auto angle_key = angle_keys.back();
-    const auto angle_potential =
-        toml::find<std::string>(local, "potentials", angle_key);
-
-    angle_keys.pop_back();
-    if(angle_potential == "Cosine")
-    {
-        MJOLNIR_LOG_NOTICE("-- angle potential function is Cosine potential");
-        using angle_potential_T = CosinePotential<real_type>;
-
-        return read_directional_contact_interaction<
-            traitsT, PotentialTs..., angle_potential_T
-            >(kind, local, std::move(angle_keys));
-    }
-    else if(angle_potential == "Gaussian")
-    {
-        MJOLNIR_LOG_NOTICE("-- angle potential function is Gaussian");
-        using angle_potential_T = GaussianPotential<real_type>;
-
-        return read_directional_contact_interaction<
-            traitsT, PotentialTs..., angle_potential_T
-            >(kind, local, std::move(angle_keys));
-    }
-    else if(angle_potential == "Uniform")
-    {
-        MJOLNIR_LOG_NOTICE("-- angle potential function is Uniform potential");
-        using angle_potential_T = UniformPotential<real_type>;
-
-        return read_directional_contact_interaction<
-            traitsT, PotentialTs..., angle_potential_T
-            >(kind, local, std::move(angle_keys));
-    }
-    else
-    {
-        throw_exception<std::runtime_error>(toml::format_error("[error] "
-            "mjolnir::read_bond_length_interaction: invalid angle potential",
-            toml::find(local, "potentials", angle_key), "here", {
-            "expected value is one of the following.",
-            "- \"Cosine\"   : 1 + Cosine(x) potential",
-            "- \"Gaussian\" : well-known gaussian potential"
-            }));
-    }
-}
-
 template<typename traitsT>
 std::unique_ptr<LocalInteractionBase<traitsT>>
 read_bond_angle_interaction(const std::string& kind, const toml::value& local)
@@ -622,6 +469,161 @@ read_3spn2_base_stacking_interaction(const std::string& kind, const toml::value&
     return make_unique<ThreeSPN2BaseStackingInteraction<traitsT>>(kind,
             std::move(parameters), std::move(potential), std::move(nuc_idxs));
 }
+
+
+template<typename realT,
+         typename angle1T, typename angle2T, typename contactT>
+std::vector<std::tuple<std::array<std::size_t, 4>, angle1T, angle2T, contactT>>
+read_directional_contact_potentials(const toml::value& local)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    MJOLNIR_LOG_FUNCTION();
+    MJOLNIR_LOG_INFO("as 4-body interaction");
+
+    using indices_type = std::array<std::size_t, 4>;
+    using indices_potentials_tuple_type =
+        std::tuple<indices_type, angle1T, angle2T, contactT>;
+
+    const auto& params = toml::find(local, "parameters").as_array();
+    MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
+
+    const auto& env = local.as_table().count("env") == 1 ?
+                      local.as_table().at("env") : toml::value{};
+
+    std::vector<indices_potentials_tuple_type> retval;
+    retval.reserve(params.size());
+    for(const auto& item : params)
+    {
+        const auto indices = find_parameter<indices_type>(item, env, "indices");
+        MJOLNIR_LOG_INFO_NO_LF("idxs = ", indices, ", ");
+
+        const auto angle1  = find_parameter<toml::value>(item, env, "angle1");
+        const auto angle2  = find_parameter<toml::value>(item, env, "angle2");
+        const auto contact = find_parameter<toml::value>(item, env, "contact");
+
+        retval.push_back(std::make_tuple(indices,
+            detail::read_local_potential_impl<angle1T>::invoke(angle1, env),
+            detail::read_local_potential_impl<angle2T>::invoke(angle2, env),
+            detail::read_local_potential_impl<contactT>::invoke(contact, env)));
+    }
+    return retval;
+}
+
+// This is reading contact part of read_directional_contact_interaction function.
+template<typename traitsT, typename ... PotentialTs>
+typename std::enable_if<sizeof...(PotentialTs) == 2,
+    std::unique_ptr<LocalInteractionBase<traitsT>>>::type
+read_directional_contact_interaction(const std::string& kind,
+        const toml::value& local, std::vector<std::string>)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    using real_type = typename traitsT::real_type;
+
+    const real_type margin = toml::find_or<real_type>(local, "margin", 0.5);
+
+    const auto contact_potential =
+        toml::find<std::string>(local, "potentials", "contact");
+
+    if(contact_potential == "GoContact")
+    {
+        MJOLNIR_LOG_NOTICE("-- contact potential function is 10-12 Go contact.");
+        using contact_potentialT = GoContactPotential<real_type>;
+
+        return make_unique<DirectionalContactInteraction<
+            traitsT, PotentialTs..., contact_potentialT>>(kind,
+              read_directional_contact_potentials<
+                  real_type, PotentialTs..., contact_potentialT
+              >(local), margin);
+    }
+    else if(contact_potential == "Gaussian")
+    {
+        MJOLNIR_LOG_NOTICE("-- contact potential function is Gaussian.");
+        using contact_potentialT = GaussianPotential<real_type>;
+
+        return make_unique<DirectionalContactInteraction<
+                traitsT, PotentialTs..., contact_potentialT>>(kind,
+              read_directional_contact_potentials<
+                  real_type, PotentialTs..., contact_potentialT
+              >(local), margin);
+    }
+    else if(contact_potential == "Uniform")
+    {
+        MJOLNIR_LOG_NOTICE("-- contact potential function is Uniform potential");
+        using contact_potentialT = UniformPotential<real_type>;
+
+        return make_unique<DirectionalContactInteraction<
+                traitsT, PotentialTs..., contact_potentialT>>(kind,
+              read_directional_contact_potentials<
+                  real_type, PotentialTs..., contact_potentialT
+              >(local), margin);
+    }
+    else
+    {
+        throw_exception<std::runtime_error>(toml::format_error("[error] "
+            "mjolnir::read_directional_contact_interaction: invalid contact potential",
+            toml::find(local, "potentials", "contact"), "here", {
+            "expected value is one of the following.",
+            "- \"GoContact\": r^12 - r^10 type native contact potential",
+            "- \"Gaussian\" : well-known gaussian potential"
+            }));
+    }
+}
+
+// This is reading angle parts of read_directional_contact_interaction function.
+template<typename traitsT, typename ... PotentialTs>
+typename std::enable_if<sizeof...(PotentialTs) < 2,
+    std::unique_ptr<LocalInteractionBase<traitsT>>>::type
+read_directional_contact_interaction(const std::string& kind,
+        const toml::value& local, std::vector<std::string> angle_keys)
+{
+    MJOLNIR_GET_DEFAULT_LOGGER();
+    using real_type = typename traitsT::real_type;
+
+    const auto angle_key = angle_keys.back();
+    const auto angle_potential =
+        toml::find<std::string>(local, "potentials", angle_key);
+
+    angle_keys.pop_back();
+    if(angle_potential == "Cosine")
+    {
+        MJOLNIR_LOG_NOTICE("-- angle potential function is Cosine potential");
+        using angle_potential_T = CosinePotential<real_type>;
+
+        return read_directional_contact_interaction<
+            traitsT, PotentialTs..., angle_potential_T
+            >(kind, local, std::move(angle_keys));
+    }
+    else if(angle_potential == "Gaussian")
+    {
+        MJOLNIR_LOG_NOTICE("-- angle potential function is Gaussian");
+        using angle_potential_T = GaussianPotential<real_type>;
+
+        return read_directional_contact_interaction<
+            traitsT, PotentialTs..., angle_potential_T
+            >(kind, local, std::move(angle_keys));
+    }
+    else if(angle_potential == "Uniform")
+    {
+        MJOLNIR_LOG_NOTICE("-- angle potential function is Uniform potential");
+        using angle_potential_T = UniformPotential<real_type>;
+
+        return read_directional_contact_interaction<
+            traitsT, PotentialTs..., angle_potential_T
+            >(kind, local, std::move(angle_keys));
+    }
+    else
+    {
+        throw_exception<std::runtime_error>(toml::format_error("[error] "
+            "mjolnir::read_bond_length_interaction: invalid angle potential",
+            toml::find(local, "potentials", angle_key), "here", {
+            "expected value is one of the following.",
+            "- \"Cosine\"   : 1 + Cosine(x) potential",
+            "- \"Gaussian\" : well-known gaussian potential"
+            }));
+    }
+}
+
+
 
 // ----------------------------------------------------------------------------
 // general read_local_interaction function

--- a/mjolnir/input/read_local_potential.hpp
+++ b/mjolnir/input/read_local_potential.hpp
@@ -403,8 +403,7 @@ read_local_potential(const toml::value& local)
     const auto& params = toml::find<toml::array>(local, "parameters");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
-    const auto& env = local.as_table().count("env") == 1 ?
-                      local.as_table().at("env") : toml::value{};
+    const auto& env = local.contains("env") ? local.at("env") : toml::value{};
 
     std::vector<indices_potential_pair_t> retval;
     retval.reserve(params.size());
@@ -443,8 +442,7 @@ read_local_potentials(const toml::value& local,
     const auto& params = toml::find<toml::array>(local, "parameters");
     MJOLNIR_LOG_NOTICE("-- ", params.size(), " interactions are found.");
 
-    const auto& env = local.as_table().count("env") == 1 ?
-                      local.as_table().at("env") : toml::value{};
+    const auto& env = local.contains("env") ? local.at("env") : toml::value{};
 
     std::vector<indices_potential_pair_type> retval;
     retval.reserve(params.size());

--- a/mjolnir/input/read_observer.hpp
+++ b/mjolnir/input/read_observer.hpp
@@ -71,18 +71,16 @@ read_observer(const toml::value& root)
 
     const auto& output = toml::find(root, "files", "output");
 
-    const auto progress_bar_enabled = toml::expect<bool>(output, "progress_bar")
-                                                        .unwrap_or(true);
-
     const auto output_path   = read_output_path(root);
     const auto output_prefix = toml::find<std::string>(output, "prefix");
     MJOLNIR_LOG_NOTICE("output file prefix is `", output_path, output_prefix, '`');
 
     const std::string file_prefix = output_path + output_prefix;
 
-    // ------------------------------------------------------------------------
+    const auto progress_bar_activated =
+        toml::find_or<bool>(output, "progress_bar", true);
 
-    ObserverContainer<traitsT> observers(progress_bar_enabled);
+    ObserverContainer<traitsT> observers(progress_bar_activated);
 
     const auto& format = toml::find(output, "format");
 
@@ -92,8 +90,7 @@ read_observer(const toml::value& root)
     }
     else if(format.is_array())
     {
-        const auto fmts = toml::get<toml::array>(format);
-        for(const auto& fmt : fmts)
+        for(const auto& fmt : format.as_array())
         {
             add_observer(observers, fmt, file_prefix);
         }

--- a/mjolnir/input/read_path.hpp
+++ b/mjolnir/input/read_path.hpp
@@ -6,6 +6,20 @@
 namespace mjolnir
 {
 
+// input path is used everywhere.
+// It would be useful to be able to retrieve the input path at anytime, anywhere.
+//
+// Using global variable is generally not a good idea, but passing input_path to
+// all the functions is also complicated. Passing the root object of the file
+// can be another option, but it makes reader functions longer.
+//
+// So, here, we make only input_path global.
+inline std::string& get_input_path()
+{
+    static std::string input = "";
+    return input;
+}
+
 // this function may be called from other read_* functions.
 template<typename C, template<typename...> class T, template<typename...> class A>
 std::string read_input_path(const toml::basic_value<C, T, A>& root)
@@ -15,16 +29,26 @@ std::string read_input_path(const toml::basic_value<C, T, A>& root)
 
     const auto& files = toml::find(root, "files");
 
-    std::string input_path("./");
+    auto& input_path = get_input_path();
+    if(!input_path.empty())
+    {
+        MJOLNIR_LOG_WARN("input_path (", input_path, ") is overwritten!");
+    }
+
+    input_path = "./";
     if(files.contains("input"))
     {
         const auto& input = toml::find(files, "input");
         if(input.contains("path"))
         {
             input_path = toml::find<std::string>(input, "path");
-            if(input_path.back() != '/') {input_path += '/';}
+            if(input_path.back() != '/')
+            {
+                input_path += '/';
+            }
         }
     }
+    MJOLNIR_LOG_NOTICE("input_path is ", input_path);
     return input_path;
 }
 

--- a/mjolnir/input/read_path.hpp
+++ b/mjolnir/input/read_path.hpp
@@ -6,7 +6,7 @@
 namespace mjolnir
 {
 
-// this function may be callen from other read_* functions.
+// this function may be called from other read_* functions.
 template<typename C, template<typename...> class T, template<typename...> class A>
 std::string read_input_path(const toml::basic_value<C, T, A>& root)
 {
@@ -16,10 +16,10 @@ std::string read_input_path(const toml::basic_value<C, T, A>& root)
     const auto& files = toml::find(root, "files");
 
     std::string input_path("./");
-    if(files.as_table().count("input") == 1)
+    if(files.contains("input"))
     {
         const auto& input = toml::find(files, "input");
-        if(input.as_table().count("path") == 1)
+        if(input.contains("path"))
         {
             input_path = toml::find<std::string>(input, "path");
             if(input_path.back() != '/') {input_path += '/';}
@@ -38,10 +38,10 @@ std::string read_output_path(const toml::basic_value<C, T, A>& root)
     const auto& files = toml::find(root, "files");
 
     std::string output_path("./");
-    if(files.as_table().count("output") == 1)
+    if(files.contains("output"))
     {
         const auto& output = toml::find(files, "output");
-        if(output.as_table().count("path") == 1)
+        if(output.contains("path"))
         {
             output_path = toml::find<std::string>(output, "path");
             if(output_path.back() != '/') {output_path += '/';}

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -29,7 +29,7 @@ read_molecular_dynamics_simulator(
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
         "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s, "delta_t"_s,
-        "integrator"_s});
+        "integrator"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -86,8 +86,8 @@ read_simulated_annealing_simulator(
     using real_type   = typename traitsT::real_type;
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
-            "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s,
-            "delta_t"_s, "integrator"_s, "schedule"_s, "each_step"_s});
+            "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s, "delta_t"_s,
+            "integrator"_s, "schedule"_s, "each_step"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -163,7 +163,7 @@ read_switching_forcefield_simulator(
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
             "parallelism"_s, "seed"_s, "total_step"_s, "save_step"_s,
-            "delta_t"_s, "integrator"_s, "schedule"_s});
+            "delta_t"_s, "integrator"_s, "schedule"_s, "env"_s});
 
     const auto tstep = toml::find<std::size_t>(simulator, "total_step");
     const auto sstep = toml::find<std::size_t>(simulator, "save_step");
@@ -234,7 +234,7 @@ read_energy_calculation_simulator(
     using coordinate_type = typename traitsT::coordinate_type;
 
     check_keys_available(simulator, {"type"_s, "boundary_type"_s, "precision"_s,
-            "file"_s, "parallelism"_s});
+            "file"_s, "parallelism"_s, "env"_s});
 
     // ------------------------------------------------------------------------
     // construct observers manually ...

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -302,8 +302,7 @@ read_energy_calculation_simulator(
     }
 
     MJOLNIR_LOG_NOTICE("reading a system ...");
-    const auto system = read_table_from_file(systems.at(0), "systems",
-                                             read_input_path(root));
+    const auto system = read_table_from_file(systems.at(0), "systems");
 
     const auto& boundary = toml::find(system, "boundary_shape");
     const auto& particles = toml::find(system, "particles").as_array();

--- a/mjolnir/input/read_system.hpp
+++ b/mjolnir/input/read_system.hpp
@@ -91,8 +91,6 @@ read_system(const toml::value& root, const std::size_t N)
 
     MJOLNIR_LOG_NOTICE("reading ", format_nth(N), " system ...");
 
-    const auto input_path = read_input_path(root);
-
     // check [[systems]] has `file_name = "checkpoint.msg"`.
     // If `file_name` has `.msg` file, load system status from the file.
     if(systems.at(N).contains("file_name"))
@@ -107,13 +105,16 @@ read_system(const toml::value& root, const std::size_t N)
         const auto& fname = toml::find<std::string>(systems, N, "file_name");
         if(file_extension_is(fname, ".msg"))
         {
-            MJOLNIR_LOG_NOTICE("msgpack file specified. "
-                               "load system status from .msg file.");
+            const auto& input_path = get_input_path();
+
+            MJOLNIR_LOG_NOTICE("msgpack file specified. load system status from ",
+                               input_path, fname);
+
             return load_system_from_msgpack<traitsT>(input_path + fname);
         }
     }
 
-    const auto system = read_table_from_file(systems.at(N), "systems", input_path);
+    const auto system = read_table_from_file(systems.at(N), "systems");
 
     check_keys_available(system, {"boundary_shape"_s, "attributes"_s, "particles"_s});
 

--- a/mjolnir/input/read_table_from_file.cpp
+++ b/mjolnir/input/read_table_from_file.cpp
@@ -8,5 +8,5 @@ namespace mjolnir
 {
 template toml::basic_value<toml::discard_comments, std::unordered_map, std::vector>
 read_table_from_file(const toml::basic_value<toml::discard_comments, std::unordered_map, std::vector>& root,
-                     const std::string& name, const std::string& input_path);
+                     const std::string& name);
 } // mjolnir

--- a/mjolnir/input/read_table_from_file.hpp
+++ b/mjolnir/input/read_table_from_file.hpp
@@ -34,7 +34,7 @@ namespace mjolnir
 template<typename C, template<typename...> class T, template<typename...> class A>
 toml::basic_value<C, T, A>
 read_table_from_file(const toml::basic_value<C, T, A>& target,
-                     const std::string& table_name, const std::string& input_path)
+                     const std::string& table_name)
 {
     MJOLNIR_GET_DEFAULT_LOGGER();
     MJOLNIR_LOG_FUNCTION();
@@ -50,6 +50,8 @@ read_table_from_file(const toml::basic_value<C, T, A>& target,
                          "ignored.");
         check_keys_available(target, {"file_name"_s});
     }
+
+    const std::string& input_path = get_input_path();
 
     // file_name is provided. we need to read it.
     const auto file_name = input_path + toml::find<std::string>(target, "file_name");
@@ -91,7 +93,7 @@ read_table_from_file(const toml::basic_value<C, T, A>& target,
 #ifdef MJOLNIR_SEPARATE_BUILD
 extern template toml::basic_value<toml::discard_comments, std::unordered_map, std::vector>
 read_table_from_file(const toml::basic_value<toml::discard_comments, std::unordered_map, std::vector>& root,
-                     const std::string& table_name, const std::string& input_path);
+                     const std::string& table_name);
 #endif
 
 } // mjolnir

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -179,7 +179,7 @@ T find_parameter_or(const toml::value& params, const toml::value& env,
     return toml::get_or(p, opt);
 }
 
-void merge_toml_tables(toml::value& table, const toml::value& other)
+inline void merge_toml_tables(toml::value& table, const toml::value& other)
 {
     using ::mjolnir::literals::string_literals::operator"" _s;
     assert(table.is_table());

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -45,6 +45,25 @@ inline bool check_keys_available(const toml::value& table,
     return all_available;
 }
 
+//
+// if the file extension is the same as expected, return true.
+// `expected` should contain the dot. e.g. expected = ".xyz"
+//
+inline bool file_extension_is(const std::string& filename,
+                              const std::string& expected)
+{
+    if(filename.size() < expected.size())
+    {
+        return false;
+    }
+    const auto last_dot = filename.find_last_of('.');
+    if(last_dot == std::string::npos)
+    {
+        return false;
+    }
+    return filename.substr(last_dot) == expected;
+}
+
 // find_parameter is a utility function to support the following functionality.
 //
 // ```toml
@@ -156,25 +175,6 @@ T find_parameter_or(const toml::value& params, const toml::value& env,
         return toml::find_or(env, p.as_string(), opt);
     }
     return toml::get_or(p, opt);
-}
-
-//
-// if the file extension is the same as expected, return true.
-// `expected` should contain the dot. e.g. expected = ".xyz"
-//
-inline bool file_extension_is(const std::string& filename,
-                              const std::string& expected)
-{
-    if(filename.size() < expected.size())
-    {
-        return false;
-    }
-    const auto last_dot = filename.find_last_of('.');
-    if(last_dot == std::string::npos)
-    {
-        return false;
-    }
-    return filename.substr(last_dot) == expected;
 }
 
 } // mjolnir

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -169,7 +169,7 @@ inline bool file_extension_is(const std::string& filename,
     {
         return false;
     }
-    const last_dot = filename.find_last_of('.');
+    const auto last_dot = filename.find_last_of('.');
     if(last_dot == std::string::npos)
     {
         return false;

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -29,6 +29,7 @@ inline bool check_keys_available(const toml::value& table,
     bool all_available = true;
     for(const auto& kv : table.as_table())
     {
+        if(kv.first == "include") {continue;}
         if(list.end() == std::find(list.begin(), list.end(), kv.first))
         {
             std::ostringstream oss;

--- a/mjolnir/input/utility.hpp
+++ b/mjolnir/input/utility.hpp
@@ -157,6 +157,26 @@ T find_parameter_or(const toml::value& params, const toml::value& env,
     }
     return toml::get_or(p, opt);
 }
+
+//
+// if the file extension is the same as expected, return true.
+// `expected` should contain the dot. e.g. expected = ".xyz"
+//
+inline bool file_extension_is(const std::string& filename,
+                              const std::string& expected)
+{
+    if(filename.size() < expected.size())
+    {
+        return false;
+    }
+    const last_dot = filename.find_last_of('.');
+    if(last_dot == std::string::npos)
+    {
+        return false;
+    }
+    return filename.substr(last_dot) == expected;
+}
+
 } // mjolnir
 
 namespace toml

--- a/test/core/test_debye_huckel_potential.cpp
+++ b/test/core/test_debye_huckel_potential.cpp
@@ -21,6 +21,9 @@ BOOST_AUTO_TEST_CASE(DH_double)
     using molecule_id_type = mjolnir::Topology::molecule_id_type;
     using group_id_type    = mjolnir::Topology::group_id_type;
 
+    using boundary_type = traits_type::boundary_type;
+    using system_type   = mjolnir::System<traits_type>;
+
     // to make the value realistic, we need to modify the unit system.
     using phys_type = mjolnir::physics::constants<real_type>;
     using unit_type = mjolnir::unit::constants<real_type>;
@@ -41,6 +44,13 @@ BOOST_AUTO_TEST_CASE(DH_double)
     constexpr std::size_t N = 10000;
     constexpr real_type   h = 1e-6;
 
+    system_type sys(0, boundary_type{});
+    sys.attribute("temperature")    = 300.0; // [K]
+    sys.attribute("ionic_strength") =   0.1; // [M]
+
+    mjolnir::Topology top(0);
+    top.construct_molecules();
+
     const real_type charge = 1.0;
     mjolnir::DebyeHuckelPotential<traits_type> dh(
         mjolnir::DebyeHuckelPotential<traits_type>::default_cutoff(),
@@ -48,6 +58,8 @@ BOOST_AUTO_TEST_CASE(DH_double)
         mjolnir::IgnoreMolecule<molecule_id_type>("Nothing"),
         mjolnir::IgnoreGroup   <group_id_type   >({})
         );
+
+    dh.initialize(sys, top);
 
     const real_type x_min = 0.5 * dh.debye_length();
     const real_type x_max = dh.max_cutoff_length();
@@ -72,6 +84,9 @@ BOOST_AUTO_TEST_CASE(DH_float)
     using molecule_id_type = mjolnir::Topology::molecule_id_type;
     using group_id_type    = mjolnir::Topology::group_id_type;
 
+    using boundary_type = traits_type::boundary_type;
+    using system_type   = mjolnir::System<traits_type>;
+
     using phys_type = mjolnir::physics::constants<real_type>;
     using unit_type = mjolnir::unit::constants<real_type>;
 
@@ -91,6 +106,13 @@ BOOST_AUTO_TEST_CASE(DH_float)
     constexpr static std::size_t N = 1000;
     constexpr static real_type   h = 1e-2;
 
+    system_type sys(0, boundary_type{});
+    sys.attribute("temperature")    = 300.0; // [K]
+    sys.attribute("ionic_strength") =   0.1; // [M]
+
+    mjolnir::Topology top(0);
+    top.construct_molecules();
+
     const real_type charge = 1.0;
     mjolnir::DebyeHuckelPotential<traits_type> dh(
         mjolnir::DebyeHuckelPotential<traits_type>::default_cutoff(),
@@ -98,6 +120,8 @@ BOOST_AUTO_TEST_CASE(DH_float)
         mjolnir::IgnoreMolecule<molecule_id_type>("Nothing"),
         mjolnir::IgnoreGroup   <group_id_type   >({})
         );
+
+    dh.initialize(sys, top);
 
     const real_type x_min = 0.5 * dh.debye_length();
     const real_type x_max = dh.max_cutoff_length();


### PR DESCRIPTION
- enable to use offset and env in `[simulator]` table (@yutakasi634 )
- check parameter duplication in `[simulator]` (@yutakasi634 )
- enable to include toml files in a input file

The included files will be expanded only once. Recursive inclusion does not work.
```toml
include = "some_table.toml"
[another_table]
include = ["parameter1.toml", "parameter2.toml"]
```