### PR TITLE
doc: fix potential parameter argument in ExcludedVolumeWall

### DIFF
--- a/book/ja/refs/ExcludedVolumeWallPotential.md
+++ b/book/ja/refs/ExcludedVolumeWallPotential.md
@@ -18,7 +18,7 @@ shape.axis     = "+X"
 shape.position = 0.0
 shape.margin   = 0.5
 
-potential   = "ExcludedVolume"
+potential   = "ExcludedVolumeWall"
 epsilon     = 0.1
 parameters  = [
     {index = 0, radius = 1.0},


### PR DESCRIPTION
In ExcludedVolumeWallPotential reference, the argument of the potential parameter is "ExcludedVolume" but Mjolnir raise an error "[error] mjolnir::read_external_distance_interaction: invalid potential".