### PR TITLE
fix: input file inclusion

### DIFF
--- a/mjolnir/input/read_input_file.hpp
+++ b/mjolnir/input/read_input_file.hpp
@@ -160,7 +160,7 @@ read_input_file(const std::string& filename)
     read_input_path(root);
 
     MJOLNIR_LOG_NOTICE("expanding include files ...");
-    root = expand_include(root);
+    expand_include(root);
     MJOLNIR_LOG_NOTICE("done.");
 
     // the most of important flags are defined in [simulator], like

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_NAMES
     test_topology
     test_exclusion_list
     test_system_motion_remover
+    test_file_inclusion
 
     test_harmonic_potential
     test_gaussian_potential

--- a/test/core/test_file_inclusion.cpp
+++ b/test/core/test_file_inclusion.cpp
@@ -1,0 +1,48 @@
+#define BOOST_TEST_MODULE "test_file_inclusion"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <mjolnir/input/utility.hpp>
+
+BOOST_AUTO_TEST_CASE(test_file_inclusion_normal)
+{
+    mjolnir::LoggerManager::set_default_logger("test_file_inclusion.log");
+    toml::value includes = toml::table{
+        {"include", "included.toml"}
+    };
+    toml::value included = toml::table{
+        {"foo", 3.14}, {"bar", 42}
+    };
+    {
+        std::ofstream ofs("included.toml");
+        ofs << included;
+    }
+
+    mjolnir::expand_include(includes);
+
+    BOOST_TEST(toml::find<double>(includes, "foo") == std::stod("3.14"));
+    BOOST_TEST(toml::find<int   >(includes, "bar") == 42);
+}
+BOOST_AUTO_TEST_CASE(test_file_inclusion_array_of_tables)
+{
+    mjolnir::LoggerManager::set_default_logger("test_file_inclusion.log");
+    toml::value includes = toml::array{
+        toml::table{{"include", "included.toml"}}
+    };
+    toml::value included = toml::table{
+        {"foo", 3.14}, {"bar", 42}
+    };
+    {
+        std::ofstream ofs("included.toml");
+        ofs << included;
+    }
+
+    mjolnir::expand_include(includes);
+
+    BOOST_TEST(toml::find<double>(includes.at(0), "foo") == std::stod("3.14"));
+    BOOST_TEST(toml::find<int   >(includes.at(0), "bar") == 42);
+}


### PR DESCRIPTION
- enable to expand an include file inside an array of tables.
- avoid unexpected recursive inclusion when including the following file

```toml
# include.toml
[foo]
include = "include.toml"
```