### PR TITLE
add `calc_force_and_energy` method

### DIFF
--- a/mjolnir/core/ExternalForceField.hpp
+++ b/mjolnir/core/ExternalForceField.hpp
@@ -113,6 +113,17 @@ class ExternalForceField
         }
         return energy;
     }
+    real_type calc_force_and_energy(system_type& sys) const noexcept
+    {
+        // TODO speedup
+        real_type energy = 0.0;
+        for(const auto& item : this->interactions_)
+        {
+            item->calc_force(sys);
+            energy += item->calc_energy(sys);
+        }
+        return energy;
+    }
 
     // basically, it is called only once at the begenning of a simulation.
     // this function do a lot of stuff, such as memory allocation, but it does

--- a/mjolnir/core/ExternalForceField.hpp
+++ b/mjolnir/core/ExternalForceField.hpp
@@ -115,12 +115,10 @@ class ExternalForceField
     }
     real_type calc_force_and_energy(system_type& sys) const noexcept
     {
-        // TODO speedup
         real_type energy = 0.0;
         for(const auto& item : this->interactions_)
         {
-            item->calc_force(sys);
-            energy += item->calc_energy(sys);
+            energy += item->calc_force_and_energy(sys);
         }
         return energy;
     }

--- a/mjolnir/core/ExternalForceInteractionBase.hpp
+++ b/mjolnir/core/ExternalForceInteractionBase.hpp
@@ -24,8 +24,9 @@ class ExternalForceInteractionBase
     virtual void reduce_margin(const real_type, const system_type&) = 0;
     virtual void  scale_margin(const real_type, const system_type&) = 0;
 
-    virtual void      calc_force (system_type&)       const noexcept = 0;
-    virtual real_type calc_energy(const system_type&) const noexcept = 0;
+    virtual void      calc_force (system_type&)           const noexcept = 0;
+    virtual real_type calc_energy(const system_type&)     const noexcept = 0;
+    virtual real_type calc_force_and_energy(system_type&) const noexcept = 0;
 
     virtual ExternalForceInteractionBase* clone() const = 0;
 

--- a/mjolnir/core/GlobalForceField.hpp
+++ b/mjolnir/core/GlobalForceField.hpp
@@ -120,12 +120,10 @@ class GlobalForceField
     }
     real_type calc_force_and_energy(system_type& sys) const noexcept
     {
-        // TODO speedup
         real_type energy = 0.;
         for(const auto& item : this->interactions_)
         {
-            item->calc_force(sys);
-            energy += item->calc_energy(sys);
+            energy += item->calc_force_and_energy(sys);
         }
         return energy;
     }

--- a/mjolnir/core/GlobalForceField.hpp
+++ b/mjolnir/core/GlobalForceField.hpp
@@ -118,6 +118,17 @@ class GlobalForceField
         }
         return energy;
     }
+    real_type calc_force_and_energy(system_type& sys) const noexcept
+    {
+        // TODO speedup
+        real_type energy = 0.;
+        for(const auto& item : this->interactions_)
+        {
+            item->calc_force(sys);
+            energy += item->calc_energy(sys);
+        }
+        return energy;
+    }
 
     // basically, it is called only once at the begenning of a simulation.
     // this function do a lot of stuff, such as memory allocation, but it does

--- a/mjolnir/core/GlobalInteractionBase.hpp
+++ b/mjolnir/core/GlobalInteractionBase.hpp
@@ -25,8 +25,9 @@ class GlobalInteractionBase
     virtual void reduce_margin(const real_type, const system_type&) = 0;
     virtual void  scale_margin(const real_type, const system_type&) = 0;
 
-    virtual void      calc_force (system_type&)       const noexcept = 0;
-    virtual real_type calc_energy(const system_type&) const noexcept = 0;
+    virtual void      calc_force (system_type&)           const noexcept = 0;
+    virtual real_type calc_energy(const system_type&)     const noexcept = 0;
+    virtual real_type calc_force_and_energy(system_type&) const noexcept = 0;
 
     virtual GlobalInteractionBase* clone() const = 0;
 

--- a/mjolnir/core/LocalForceField.hpp
+++ b/mjolnir/core/LocalForceField.hpp
@@ -122,6 +122,15 @@ class LocalForceField
         }
         return energy;
     }
+    real_type calc_force_and_energy(system_type& sys) const noexcept
+    {
+        real_type energy = 0.0;
+        for(const auto& item : this->interactions_)
+        {
+            energy += item->calc_force_and_energy(sys);
+        }
+        return energy;
+    }
 
     // basically, it is called only once at the begenning of a simulation.
     // this function do a lot of stuff, such as memory allocation, but it does

--- a/mjolnir/core/LocalInteractionBase.hpp
+++ b/mjolnir/core/LocalInteractionBase.hpp
@@ -28,8 +28,9 @@ class LocalInteractionBase
     virtual void reduce_margin(const real_type, const system_type&) = 0;
     virtual void  scale_margin(const real_type, const system_type&) = 0;
 
-    virtual void      calc_force (system_type&)       const noexcept = 0;
-    virtual real_type calc_energy(const system_type&) const noexcept = 0;
+    virtual void      calc_force (system_type&)           const noexcept = 0;
+    virtual real_type calc_energy(const system_type&)     const noexcept = 0;
+    virtual real_type calc_force_and_energy(system_type&) const noexcept = 0;
 
     virtual LocalInteractionBase* clone() const = 0;
 

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -76,8 +76,9 @@ class ThreeSPN2BaseBaseInteraction final : public GlobalInteractionBase<traitsT>
         return;
     }
 
-    void      calc_force (system_type& sys)       const noexcept override;
-    real_type calc_energy(const system_type& sys) const noexcept override;
+    void      calc_force (system_type& sys)           const noexcept override;
+    real_type calc_energy(const system_type& sys)     const noexcept override;
+    real_type calc_force_and_energy(system_type& sys) const noexcept override;
 
     std::string name() const override {return "3SPN2BaseBase";}
 
@@ -789,6 +790,449 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_energy(
     }
     return E_BP + E_CS;
 }
+
+template<typename traitsT>
+typename ThreeSPN2BaseBaseInteraction<traitsT>::real_type
+ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
+        system_type& sys) const noexcept
+{
+    constexpr auto pi        = math::constants<real_type>::pi();
+    constexpr auto two_pi    = math::constants<real_type>::two_pi();
+    constexpr auto tolerance = math::abs_tolerance<real_type>();
+
+    const auto leading_participants = this->potential_.leading_participants();
+    real_type energy = 0;
+    for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
+    {
+        const auto   Bi = leading_participants[idx];
+        const auto& rBi = sys.position(Bi);
+        for(const auto& ptnr : this->partition_.partners(Bi))
+        {
+            const auto  Bj   = ptnr.index;
+            const auto& para = ptnr.parameter();
+            const auto& rBj  = sys.position(Bj);
+            const auto  bp_kind = para.bp_kind;
+
+            const auto Bij = sys.adjust_direction(rBj - rBi); // Bi -> Bj
+            const auto lBij_sq = math::length_sq(Bij);
+            if(lBij_sq > potential_.cutoff_sq())
+            {
+                continue;
+            }
+
+            // ================================================================
+            // base pairing
+            //
+            //  Si o         o Sj
+            //      \-.   ,-/
+            //    Bi o =(= o Bj
+            //
+            // U_rep(rij) + 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+
+            const auto rlBij = math::rsqrt(lBij_sq); // 1 / |Bij|
+            const auto lBij  = lBij_sq * rlBij;      // |Bij|
+
+            const auto Bij_reg =  rlBij * Bij;
+            const auto Bji_reg = -rlBij * Bij;
+
+            // ----------------------------------------------------------------
+            // calculate the the repulsive part, which does not depend on angle.
+            //
+            //  U_rep = e_ij(1 - exp(-a_ij(rij - r0_ij)))^2   ... r < r0
+            //          0                                     ... otherwise
+            // dU_rep = 2 a e exp(-a(r-r0)) (1-exp(-a(r-r0))) ... r < r0
+            //        = 0                                     ... otherwise
+            //
+            {
+                energy += potential_.U_rep(bp_kind, lBij);
+                const auto dU_rep = potential_.dU_rep(bp_kind, lBij);
+                if(dU_rep != real_type(0))
+                {
+                    // remember that F = -dU.
+                    sys.force(Bi) -= dU_rep * Bji_reg;
+                    sys.force(Bj) -= dU_rep * Bij_reg;
+                }
+            }
+
+            // ----------------------------------------------------------------
+            // calc theta1 and 2 to calculate the attractive part,
+            //  = 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+            //
+            //   theta1   theta2
+            //       |     |
+            //  Si o v     v o Sj
+            //      \-.   ,-/
+            //    Bi o =(= o Bj
+
+            const auto   Si = para.Si;
+            const auto   Sj = para.Sj;
+            const auto& rSi = sys.position(Si);
+            const auto& rSj = sys.position(Sj);
+
+            const auto SBi = sys.adjust_direction(rBi - rSi); // Si -> Bi
+            const auto SBj = sys.adjust_direction(rBj - rSj); // Sj -> Bj
+
+            const auto lSBi_sq = math::length_sq(SBi); // |SBi|^2
+            const auto lSBj_sq = math::length_sq(SBj); // |SBj|^2
+            const auto rlSBi   = math::rsqrt(lSBi_sq); // 1 / |SBi|
+            const auto rlSBj   = math::rsqrt(lSBj_sq); // 1 / |SBj|
+            const auto BSi_reg = -rlSBi * SBi;
+            const auto BSj_reg = -rlSBj * SBj;
+
+            const auto dot_SBiBj  = -math::dot_product(SBi, Bij);
+            const auto dot_SBjBi  =  math::dot_product(SBj, Bij);
+            const auto cos_theta1 = dot_SBiBj * rlSBi * rlBij;
+            const auto cos_theta2 = dot_SBjBi * rlSBj * rlBij;
+            const auto theta1 = std::acos(math::clamp<real_type>(cos_theta1, -1, 1));
+            const auto theta2 = std::acos(math::clamp<real_type>(cos_theta2, -1, 1));
+
+            // ----------------------------------------------------------------
+            // calc angle-dependent terms and advance if both are nonzero
+            //
+            // 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+
+            const auto theta1_0 = potential_.theta1_0(bp_kind);
+            const auto theta2_0 = potential_.theta2_0(bp_kind);
+            const auto f1 = potential_.f(bp_kind, theta1, theta1_0);
+            const auto f2 = potential_.f(bp_kind, theta2, theta2_0);
+
+            if(f1 != real_type(0.0) && f2 != real_type(0.0))
+            {
+                // calculate dihedral, phi
+                //
+                //  Si o         o Sj
+                //      \       /
+                //    Bi o =(= o Bj
+                //         phi
+
+                const auto df1 = potential_.df(bp_kind, theta1, theta1_0);
+                const auto df2 = potential_.df(bp_kind, theta2, theta2_0);
+
+                const auto m = math::cross_product(-SBi, Bij);
+                const auto n = math::cross_product( Bij, SBj);
+                const auto m_lsq = math::length_sq(m);
+                const auto n_lsq = math::length_sq(n);
+
+                const auto dot_phi = math::dot_product(m, n) *
+                                     math::rsqrt(m_lsq * n_lsq);
+                const auto cos_phi = math::clamp<real_type>(dot_phi, -1, 1);
+
+                const auto phi = std::copysign(std::acos(cos_phi),
+                                               -math::dot_product(SBi, n));
+
+                auto dphi = phi - this->potential_.phi_0(bp_kind);
+                if(dphi < -pi) {dphi += two_pi;}
+                if(pi <= dphi) {dphi -= two_pi;}
+                const auto cos_dphi = std::cos(dphi);
+                const auto sin_dphi = std::sin(dphi);
+
+                const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
+
+                energy += 0.5 * (1 + cos_dphi) * f1 * f2 * U_dU_attr.first;
+
+                // ------------------------------------------------------------
+                // calculate attractive force
+                //
+                // d/dr [1/2 (1 + cos(dphi)) f(dtheta1) f(dtheta2) U_attr(Bij)]
+                // = ( -sin(dphi))/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
+                // + (1+cos(dphi))/2 df/dtheta1 f(dtheta2) U_attr(Bij) dtheta1/dr
+                // + (1+cos(dphi))/2 f(dtheta1) df/dtheta2 U_attr(Bij) dtheta2/dr
+                // + (1+cos(dphi))/2 f(dtheta1) f(dtheta2) dU_attr/dr  dBij/dr
+
+                if(cos_dphi != real_type(-1.0))
+                {
+                    // --------------------------------------------------------
+                    // calc dihedral term
+                    // -sin(dphi)/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
+                    if(sin_dphi != real_type(0.0))
+                    {
+                        // remember that F = -dU. Here `coef` = -dU.
+                        const auto coef = real_type(0.5) * sin_dphi *
+                                          f1 * f2 * U_dU_attr.first;
+
+                        const auto rlBij_sq = rlBij * rlBij; // 1 / |Bij|^2
+                        const auto fSi = ( coef * lBij / m_lsq) * m;
+                        const auto fSj = (-coef * lBij / n_lsq) * n;
+
+                        const auto coef_Bi = dot_SBiBj * rlBij_sq;
+                        const auto coef_Bj = dot_SBjBi * rlBij_sq;
+
+                        sys.force(Si) += fSi;
+                        sys.force(Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                        sys.force(Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                        sys.force(Sj) += fSj;
+                    }
+
+                    const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
+
+                    // --------------------------------------------------------
+                    // calc theta1 term
+                    // (1+cos(dphi))/2 df/dtheta1 f(dtheta2) U_attr(Bij) dtheta1/dr
+                    if(df1 != real_type(0.0))
+                    {
+                        // remember that F = -dU. Here `coef` = -dU.
+                        const auto coef = -dihd_term * df1 * f2 * U_dU_attr.first;
+
+                        const auto sin_theta1 = std::sin(theta1);
+                        const auto coef_rsin  = (sin_theta1 > tolerance) ?
+                                   (coef / sin_theta1) : (coef / tolerance);
+
+                        const auto fSi = (coef_rsin * rlSBi) *
+                                         (cos_theta1 * BSi_reg - Bij_reg);
+                        const auto fBj = (coef_rsin * rlBij) *
+                                         (cos_theta1 * Bij_reg - BSi_reg);
+                        sys.force(Si) += fSi;
+                        sys.force(Bi) -= (fSi + fBj);
+                        sys.force(Bj) += fBj;
+                    }
+                    // --------------------------------------------------------
+                    // calc theta2 term
+                    // (1+cos(dphi))/2 f(dtheta1) df/dtheta2 U_attr(Bij) dtheta2/dr
+                    if(df2 != real_type(0.0))
+                    {
+                        // remember that F = -dU. Here `coef` = -dU.
+                        const auto coef = -dihd_term * f1 * df2 * U_dU_attr.first;
+
+                        const auto sin_theta2 = std::sin(theta2);
+                        const auto coef_rsin  = (sin_theta2 > tolerance) ?
+                                   (coef / sin_theta2) : (coef / tolerance);
+
+                        const auto fBi = (coef_rsin * rlBij) *
+                                         (cos_theta2 * Bji_reg - BSj_reg);
+                        const auto fSj = (coef_rsin * rlSBj) *
+                                         (cos_theta2 * BSj_reg - Bji_reg);
+                        sys.force(Bi) += fBi;
+                        sys.force(Bj) -= (fBi + fSj);
+                        sys.force(Sj) += fSj;
+                    }
+                    // --------------------------------------------------------
+                    // calc distance
+                    // + 1/2 (1+cos(dphi)) f(dtheta1) f(dtheta2) dU_attr/dr  dBij/dr
+                    if(U_dU_attr.second != real_type(0.0))
+                    {
+                        // remember that F = -dU. Here `coef` = -dU.
+                        const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
+                        sys.force(Bi) += coef * Bji_reg;
+                        sys.force(Bj) += coef * Bij_reg;
+                    }
+                }
+            }
+
+            // ================================================================
+            // cross stacking
+            // f(theta_3) f(theta_CS) U_attr(epsilon, alpha, rij)
+            //
+            //       Si   Bi   Bj   Sj
+            //  5'    o -- o===o -- o     3'
+            //  ^    /      \ /      \    |
+            //  | P o        X        o P |
+            //  |    \      / \      /    v
+            //  3'    o -- o===o -- o     5'
+            //       Bj_next   Bj_next
+            //
+            // d/dr Vcs =
+            //    df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3  /dr
+            //  + f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS /dr
+            //  + f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+            //
+
+            const auto Bi_next        = para.Bi_next;
+            const auto Bj_next        = para.Bj_next;
+            const bool Bi_next_exists = (Bi_next != potential_type::invalid());
+            const bool Bj_next_exists = (Bj_next != potential_type::invalid());
+
+            if(!Bi_next_exists && !Bj_next_exists)
+            {
+                continue; // if both interacting pair do not exist, do nothing.
+            }
+
+            // ----------------------------------------------------------------
+            // calc common part, theta3 and dtheta3/dr.
+
+            const auto cos_theta3 = math::dot_product(BSi_reg, BSj_reg);
+            const auto theta3     = std::acos(math::clamp<real_type>(cos_theta3, -1, 1));
+            const auto theta3_0   = potential_.theta3_0(bp_kind);
+            const auto f3         = potential_.f(bp_kind, theta3, theta3_0);
+            if(f3 == real_type(0))
+            {
+                // f(theta) == 0 means df(theta) is also zero.
+                // so here, both cross-stacking becomes zero. skip them.
+                continue;
+            }
+            const auto df3 = potential_.df(bp_kind, theta3, theta3_0);
+
+            // ----------------------------------------------------------------
+            // force directions for dtheta3/dr
+
+            // here, theta3 is a return value of acos, so it is in [0, pi].
+            // and inside it, sin(theta3) should be larger than 0.
+            const auto sin_theta3  = std::sin(theta3);
+            const auto rsin_theta3 = sin_theta3 > tolerance ?
+                real_type(1) / sin_theta3 : real_type(1) / tolerance;
+
+            const auto fBi_theta3 = rsin_theta3 * rlSBi * (BSj_reg - cos_theta3 * BSi_reg);
+            const auto fBj_theta3 = rsin_theta3 * rlSBj * (BSi_reg - cos_theta3 * BSj_reg);
+            const auto fSi_theta3 = real_type(-1) * fBi_theta3;
+            const auto fSj_theta3 = real_type(-1) * fBj_theta3;
+
+            // adjacent of Base j exists. its not the edge of the strand.
+            if(Bj_next_exists)
+            {
+                // ------------------------------------------------------------
+                // 5' cross stacking (the case if `Bi` is in sense strand)
+                //
+                //       Si   Bi   Bj   Sj
+                //  5'    o--> o===o <--o     3'
+                //  ^    /   `--\        \    |
+                //  | P o   tCS  \        o P |
+                //  |    \        \      /    v
+                //  3'    o -- o===o -- o     5'
+                //           Bi3   Bj5
+                //
+                // Hereafter, we use the notation illustrated above (excepting
+                // the index `Bj_next` that corresponds to Bj5).
+
+                const auto cs_kind = para.cs_i_kind;
+
+                const auto& rBj5     = sys.position(Bj_next);
+                const auto  Bj5i     = sys.adjust_direction(rBi - rBj5);
+                const auto  lBj5i_sq = math::length_sq(Bj5i); // |Bj5i|^2
+                const auto  rlBj5i   = math::rsqrt(lBj5i_sq);  // 1 / |Bj5i|
+
+                const auto dot_theta_CS = math::dot_product(SBi, Bj5i);
+                const auto cos_theta_CS = dot_theta_CS * rlSBi * rlBj5i;
+                const auto theta_CS     =
+                    std::acos(math::clamp<real_type>(cos_theta_CS, -1, 1));
+                const auto theta_CS_0   = potential_.thetaCS_0(cs_kind);
+
+                const auto fCS  = potential_.f(cs_kind, theta_CS, theta_CS_0);
+                // if f == 0, df is also zero. if fCS == 0, no force there
+                if(fCS != real_type(0))
+                {
+                    const auto dfCS  = potential_.df(cs_kind, theta_CS, theta_CS_0);
+
+                    const auto lBj5i = lBj5i_sq * rlBj5i;
+                    const auto U_dU_attr = potential_.U_dU_attr(cs_kind, lBj5i);
+                    const auto Bj5i_reg  = rlBj5i * Bj5i;
+
+                    energy += f3 * fCS * U_dU_attr.first;
+
+                    // --------------------------------------------------------
+                    // df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3 /dr
+                    if(df3 != real_type(0))
+                    {
+                        const auto coef = -df3 * fCS * U_dU_attr.first;
+                        sys.force(Si) += coef * fSi_theta3;
+                        sys.force(Sj) += coef * fSj_theta3;
+                        sys.force(Bi) += coef * fBi_theta3;
+                        sys.force(Bj) += coef * fBj_theta3;
+                    }
+                    // --------------------------------------------------------
+                    // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
+                    if(dfCS != real_type(0))
+                    {
+                        const auto coef         = -f3 * dfCS * U_dU_attr.first;
+                        const auto sin_theta_CS = std::sin(theta_CS);
+                        const auto coef_rsin    = (sin_theta_CS > tolerance) ?
+                                   (coef / sin_theta_CS) : (coef / tolerance);
+
+                        const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
+                        const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
+
+                        sys.force(Si)      += fSi;
+                        sys.force(Bi)      -= (fSi + fBj5);
+                        sys.force(Bj_next) += fBj5;
+                    }
+                    // --------------------------------------------------------
+                    // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+                    if(U_dU_attr.second != real_type(0.0))
+                    {
+                        const auto coef = -f3 * fCS * U_dU_attr.second;
+                        sys.force(Bi)      += coef * Bj5i_reg;
+                        sys.force(Bj_next) -= coef * Bj5i_reg;
+                    }
+                }
+            }
+            if(Bi_next_exists)
+            {
+                // ------------------------------------------------------------
+                // 3' cross stacking (the case `Bi` is in a sense strand)
+                //
+                //       Si   Bi   Bj   Sj
+                //  5'    o--> o===o <--o     3'
+                //  ^    /        /--'   \    |
+                //  | P o        /  tCS   o P |
+                //  |    \      /        /    v
+                //  3'    o -- o===o -- o     5'
+                //           Bi3   Bj5
+                //
+                // Hereafter, we use the notation illustrated above (excepting
+                // the index `Bi_next` that corresponds to Bi3).
+
+                const auto cs_kind = para.cs_j_kind;
+
+                const auto& rBi3     = sys.position(Bi_next);
+                const auto  Bi3j     = sys.adjust_direction(rBj - rBi3);
+                const auto  lBi3j_sq = math::length_sq(Bi3j); // |Bi3j|^2
+                const auto  rlBi3j   = math::rsqrt(lBi3j_sq);  // 1 / |Bi3j|
+
+                const auto dot_theta_CS = math::dot_product(SBj, Bi3j);
+                const auto cos_theta_CS = dot_theta_CS * rlSBj * rlBi3j;
+                const auto theta_CS     =
+                    std::acos(math::clamp<real_type>(cos_theta_CS, -1, 1));
+                const auto theta_CS_0   = potential_.thetaCS_0(cs_kind);
+
+                const auto fCS = potential_.f(cs_kind, theta_CS, theta_CS_0);
+                // if f == 0, df is also zero. if fCS == 0, no force there
+                if(fCS != real_type(0))
+                {
+                    const auto dfCS  = potential_.df(cs_kind, theta_CS, theta_CS_0);
+                    const auto lBi3j = lBi3j_sq * rlBi3j;
+                    const auto U_dU_attr = potential_.U_dU_attr(cs_kind, lBi3j);
+                    const auto Bi3j_reg  = rlBi3j * Bi3j;
+
+                    energy += f3 * fCS * U_dU_attr.first;
+
+                    // --------------------------------------------------------
+                    // df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3 /dr
+                    if(df3 != real_type(0))
+                    {
+                        const auto coef = -df3 * fCS * U_dU_attr.first;
+                        sys.force(Si) += coef * fSi_theta3;
+                        sys.force(Sj) += coef * fSj_theta3;
+                        sys.force(Bi) += coef * fBi_theta3;
+                        sys.force(Bj) += coef * fBj_theta3;
+                    }
+                    // --------------------------------------------------------
+                    // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
+                    if(dfCS != real_type(0))
+                    {
+                        const auto coef         = -f3 * dfCS * U_dU_attr.first;
+                        const auto sin_theta_CS = std::sin(theta_CS);
+                        const auto coef_rsin    = (sin_theta_CS > tolerance) ?
+                                   (coef / sin_theta_CS) : (coef / tolerance);
+
+                        const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
+                        const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
+                        sys.force(Sj)      += fSj;
+                        sys.force(Bj)      -= (fSj + fBi3);
+                        sys.force(Bi_next) += fBi3;
+                    }
+                    // --------------------------------------------------------
+                    // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+                    if(U_dU_attr.second != real_type(0.0))
+                    {
+                        const auto coef = -f3 * fCS * U_dU_attr.second;
+                        sys.force(Bj)      += coef * Bi3j_reg;
+                        sys.force(Bi_next) -= coef * Bi3j_reg;
+                    }
+                }
+            }
+        }
+    }
+    return energy;
+}
+
 } // mjolnir
 
 #ifdef MJOLNIR_SEPARATE_BUILD

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
@@ -85,8 +85,9 @@ class ThreeSPN2BaseStackingInteraction final : public LocalInteractionBase<trait
     void reduce_margin(const real_type, const system_type&) override {return;}
     void  scale_margin(const real_type, const system_type&) override {return;}
 
-    void      calc_force (system_type&)       const noexcept override;
-    real_type calc_energy(const system_type&) const noexcept override;
+    void      calc_force (system_type&)           const noexcept override;
+    real_type calc_energy(const system_type&)     const noexcept override;
+    real_type calc_force_and_energy(system_type&) const noexcept override;
 
     std::string name() const override {return "3SPN2BaseStacking"_s;}
 
@@ -346,6 +347,126 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_energy(
         E += U_attr * f_theta;
     }
     return E;
+}
+
+template<typename traitsT>
+typename ThreeSPN2BaseStackingInteraction<traitsT>::real_type
+ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
+        system_type& sys) const noexcept
+{
+    constexpr auto tolerance = math::abs_tolerance<real_type>();
+    real_type energy = 0;
+    for(const auto& idxp : this->parameters_)
+    {
+        // ====================================================================
+        // Base Stacking
+        // U_BS = U_rep(rij) + f(theta) U_attr(rij)
+        //
+        //        SBi
+        //     Si --> Bi
+        //    /     `-^
+        //   Pj theta | rij
+        //    \       |
+        //     Sj --- Bj
+        //
+        // dU_BS/dr = dU_rep(rij)/dr + df(theta) U_attr(rij) dtheta/dr
+        //                           + f(theta) dU_attr(rij) drij/dr
+
+        const std::size_t Si = idxp.first[0];
+        const std::size_t Bi = idxp.first[1];
+        const std::size_t Bj = idxp.first[2];
+        const auto   bs_kind = idxp.second;
+
+        const auto& rBi = sys.position(Bi);
+        const auto& rBj = sys.position(Bj);
+        const auto& rSi = sys.position(Si);
+
+        const auto Bji = sys.adjust_direction(rBi - rBj); // Bj -> Bi
+        const auto SBi = sys.adjust_direction(rBi - rSi); // Si -> Bi
+
+        const auto lBji_sq = math::length_sq(Bji); // |Bji|^2
+        const auto rlBji   = math::rsqrt(lBji_sq); // 1 / |Bji|
+        const auto lBji    = lBji_sq * rlBji;      // |Bji|
+        const auto Bji_reg = Bji * rlBji;          // Bji / |Bji|
+
+        // ====================================================================
+        // calc repulsive part, which does not depend on angle term.
+
+        const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
+        if(dU_rep != real_type(0.0))
+        {
+            sys.force(Bi) -= dU_rep * Bji_reg;
+            sys.force(Bj) += dU_rep * Bji_reg;
+        }
+        energy += potential_.U_rep(bs_kind, lBji);
+
+        // --------------------------------------------------------------------
+        // calc theta
+        //
+        //        SBi
+        //     Si --> Bi
+        //    /     `-^
+        //   Pj theta | rij
+        //    \       |
+        //     Sj --- Bj
+
+        const auto lSBi_sq = math::length_sq(SBi);
+        const auto rlSBi   = math::rsqrt(lSBi_sq);
+        const auto SBi_reg = SBi * rlSBi;
+
+        const auto cos_theta = math::dot_product(SBi_reg, Bji_reg);
+        const auto theta = std::acos(math::clamp<real_type>(cos_theta, -1, 1));
+
+        // ====================================================================
+        // calc attractive part
+        //
+        // dU_BS^attr/dr = df(theta) U_attr(rij) dtheta/dr
+        //               + f(theta) dU_attr(rij) drij/dr
+
+        const auto theta_0 = potential_.theta_0(bs_kind);
+        const auto f_theta = potential_.f(theta, theta_0);
+        if(f_theta == real_type(0.0))
+        {
+            // purely repulsive.
+            continue;
+        }
+        const auto df_theta  = potential_.df(theta, theta_0);
+        const auto U_dU_attr = potential_.U_dU_attr(bs_kind, lBji);
+
+        energy += U_dU_attr.first * f_theta;
+
+        // --------------------------------------------------------------------
+        // calc the first term in the attractive part
+        // = df(theta) U_attr(rij) dtheta/dr
+        //
+        if(df_theta != real_type(0.0))
+        {
+            const auto coef = -df_theta * U_dU_attr.first;
+
+            const auto sin_theta = std::sin(theta);
+            const auto coef_rsin = (sin_theta > tolerance) ?
+                                   coef / sin_theta : coef / tolerance;
+
+            const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
+            const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
+
+            sys.force(Si) +=  fSi;
+            sys.force(Bi) -= (fSi + fBj);
+            sys.force(Bj) +=        fBj;
+        }
+
+        // --------------------------------------------------------------------
+        // calc the second term in the attractive part
+        // = f(theta) dU_attr(rij) drij/dr
+
+        if(U_dU_attr.second != real_type(0.0))
+        {
+            const auto coef = f_theta * U_dU_attr.second;
+            sys.force(Bi) -= coef * Bji_reg;
+            sys.force(Bj) += coef * Bji_reg;
+        }
+    }
+    return energy;
 }
 
 } // mjolnir

--- a/mjolnir/forcefield/MultipleBasin/MultipleBasin3BasinUnit.hpp
+++ b/mjolnir/forcefield/MultipleBasin/MultipleBasin3BasinUnit.hpp
@@ -15,10 +15,6 @@ namespace mjolnir
 
 // 3-basin MultipleBasin forcefield.
 //
-// TODO: to speedup this forcefield...
-// - add `calc_force_and_energy` member function to interactions
-//   - it is technically easy. but it requires a huge effort.
-//
 // V_MB is a solution of the following equation.
 //
 // (V1 + dV1  delta12  delta13 ) (c1)        (c1)
@@ -145,25 +141,20 @@ class MultipleBasin3BasinUnit final: public MultipleBasinUnitBase<traitsT>
         // force_buffer is zero-cleared (at the end of this function),
         // so the forces in the system will be zero-cleared after this.
         sys.preprocess_forces();
-        this->calc_force_basin1(sys);
+        const auto V_1 = this->calc_force_and_energy_basin1(sys) + dV1_;
         sys.postprocess_forces();
 
         swap(this->force_buffer1_, sys.forces());
 
         sys.preprocess_forces();
-        this->calc_force_basin2(sys);
+        const auto V_2 = this->calc_force_and_energy_basin2(sys) + dV2_;
         sys.postprocess_forces();
 
         swap(this->force_buffer2_, sys.forces());
 
         sys.preprocess_forces();
-        this->calc_force_basin3(sys);
+        const auto V_3 = this->calc_force_and_energy_basin3(sys) + dV3_;
         sys.postprocess_forces();
-
-        // TODO add calc_force_and_energy() to `Interaction`s.
-        const auto V_1 = this->calc_energy_basin1(sys) + this->dV1_;
-        const auto V_2 = this->calc_energy_basin2(sys) + this->dV2_;
-        const auto V_3 = this->calc_energy_basin3(sys) + this->dV3_;
 
         const auto V_MB = this->calc_V_MB(V_1, V_2, V_3);
 
@@ -355,26 +346,29 @@ class MultipleBasin3BasinUnit final: public MultipleBasinUnitBase<traitsT>
     // -----------------------------------------------------------------------
     // calc_force/energy, dump/list_energy for each basin
 
-    void calc_force_basin1(system_type& sys) const
+    real_type calc_force_and_energy_basin1(system_type& sys) const
     {
-        std::get<0>(basin1_).calc_force(sys);
-        std::get<1>(basin1_).calc_force(sys);
-        std::get<2>(basin1_).calc_force(sys);
-        return;
+        real_type energy = 0;
+        energy += std::get<0>(basin1_).calc_force_and_energy(sys);
+        energy += std::get<1>(basin1_).calc_force_and_energy(sys);
+        energy += std::get<2>(basin1_).calc_force_and_energy(sys);
+        return energy;
     }
-    void calc_force_basin2(system_type& sys) const
+    real_type calc_force_and_energy_basin2(system_type& sys) const
     {
-        std::get<0>(basin2_).calc_force(sys);
-        std::get<1>(basin2_).calc_force(sys);
-        std::get<2>(basin2_).calc_force(sys);
-        return;
+        real_type energy = 0;
+        energy += std::get<0>(basin2_).calc_force_and_energy(sys);
+        energy += std::get<1>(basin2_).calc_force_and_energy(sys);
+        energy += std::get<2>(basin2_).calc_force_and_energy(sys);
+        return energy;
     }
-    void calc_force_basin3(system_type& sys) const
+    real_type calc_force_and_energy_basin3(system_type& sys) const
     {
-        std::get<0>(basin3_).calc_force(sys);
-        std::get<1>(basin3_).calc_force(sys);
-        std::get<2>(basin3_).calc_force(sys);
-        return;
+        real_type energy = 0;
+        energy += std::get<0>(basin3_).calc_force_and_energy(sys);
+        energy += std::get<1>(basin3_).calc_force_and_energy(sys);
+        energy += std::get<2>(basin3_).calc_force_and_energy(sys);
+        return energy;
     }
 
     real_type calc_energy_basin1(const system_type& sys) const

--- a/mjolnir/forcefield/PDNS/ProteinDNANonSpecificInteraction.hpp
+++ b/mjolnir/forcefield/PDNS/ProteinDNANonSpecificInteraction.hpp
@@ -78,8 +78,9 @@ class ProteinDNANonSpecificInteraction final : public GlobalInteractionBase<trai
         return ;
     }
 
-    void      calc_force (system_type& sys)       const noexcept override;
-    real_type calc_energy(const system_type& sys) const noexcept override;
+    void      calc_force (system_type& sys)           const noexcept override;
+    real_type calc_energy(const system_type& sys)     const noexcept override;
+    real_type calc_force_and_energy(system_type& sys) const noexcept override;
 
     std::string name() const override {return "PDNSInteraction";}
 
@@ -334,6 +335,162 @@ ProteinDNANonSpecificInteraction<traitsT>::calc_energy(
     }
     return E;
 }
+
+template<typename traitsT>
+typename ProteinDNANonSpecificInteraction<traitsT>::real_type
+ProteinDNANonSpecificInteraction<traitsT>::calc_force_and_energy(
+        system_type& sys) const noexcept
+{
+    MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+    MJOLNIR_LOG_FUNCTION_DEBUG();
+
+    constexpr auto tolerance = math::abs_tolerance<real_type>();
+    // XXX Note: P is ambiguous because both Protein and Phosphate has `P`.
+    // But this interaction is named as P-D ns, so here it uses `P` for protein
+    // and `D` for DNA.
+
+    real_type energy = 0;
+    for(std::size_t i=0; i < this->potential_.contacts().size(); ++i)
+    {
+        const auto& para = potential_.contacts()[i];
+
+        const auto  P  = para.P;
+        const auto& rP = sys.position(P);
+        for(const auto& ptnr : this->partition_.partners(P))
+        {
+            const auto  D  = ptnr.index;          // DNA phosphate
+            const auto  S3 = ptnr.parameter().S3; // 3' Sugar
+            const auto& rD = sys.position(D);
+
+            MJOLNIR_LOG_DEBUG("protein = ", P, ", DNA = ", D, ", r0 = ", para.r0);
+
+            //  PC          S5'    |
+            //    o         o--o B | theta is an angle formed by the vector
+            //    A\ P   D /       | from the neighboring amino acid residue at
+            // vP | o --> o        | the N-term side to the amino acid residue
+            //    |/     `-\       | at the C-term side (vP in the figure) and
+            //    o    phi  o--o B | the vector from Protein to DNA (phosphate).
+            //  PN           S3'   |
+
+            // ----------------------------------------------------------------
+            // calculates the distance part
+
+            const auto rPD    = sys.adjust_direction(rD - rP); // PRO -> DNA
+            const auto lPD_sq = math::length_sq(rPD);
+            if(para.r_cut_sq < lPD_sq)
+            {
+                continue;
+            }
+            const auto rlPD   = math::rsqrt(lPD_sq);
+            const auto  lPD   = lPD_sq * rlPD;
+            const auto f_df   = potential_.f_df(para.r0, lPD);
+
+            MJOLNIR_LOG_DEBUG("f = ", f_df.first, ", df = ", f_df.second);
+
+            // ----------------------------------------------------------------
+            // calculates the angle part (theta)
+
+            const auto& rPC   = sys.position(para.PC);
+            const auto& rPN   = sys.position(para.PN);
+            const auto rPNC   = sys.adjust_direction(rPC - rPN); // PN -> PC
+            const auto rlPNC  = math::rlength(rPNC);
+            const auto dotPNC = math::dot_product(rPNC, rPD);
+            const auto cosPNC = dotPNC * rlPD * rlPNC;
+            const auto theta  = std::acos(math::clamp<real_type>(cosPNC,-1,1));
+
+            const auto g_dg_theta = potential_.g_dg(para.theta0, theta);
+
+            MJOLNIR_LOG_DEBUG("g(theta) = ", g_dg_theta.first,
+                             ", dg(theta) = ", g_dg_theta.second);
+
+            // ----------------------------------------------------------------
+            // calculates the angle part (phi)
+
+            const auto& rS3   = sys.position(S3);
+            const auto rS3D   = sys.adjust_direction(rD - rS3); // S3' -> D
+            const auto rlS3D  = math::rlength(rS3D);
+            const auto dotS3D = math::dot_product(rPD, rS3D);
+            const auto cosS3D = dotS3D * rlS3D * rlPD;
+            const auto phi    = std::acos(math::clamp<real_type>(cosS3D,-1,1));
+
+            const auto g_dg_phi = potential_.g_dg(para.phi0, phi);
+
+            MJOLNIR_LOG_DEBUG("g(phi) = ", g_dg_phi.first,
+                             ", dg(phi) = ", g_dg_phi.second);
+
+            // ----------------------------------------------------------------
+            // calculate force
+            //
+            //   d/dr [kf(r)  g(theta)  g(phi)]
+            // =    k [df(r)  g(theta)  g(phi) dr/dr     +
+            //          f(r) dg(theta)  g(phi) dtheta/dr +
+            //          f(r)  g(theta) dg(phi) dphi/dr   ]
+            const auto k = para.k;
+
+            energy += k * f_df.first * g_dg_theta.first * g_dg_phi.first;
+
+            // df(r) g(theta) g(phi)
+            if(g_dg_theta.first  != 0 && g_dg_phi.first  != 0)
+            {
+                MJOLNIR_LOG_DEBUG("calculating distance force");
+
+                const auto coef = rlPD * k *
+                    f_df.second * g_dg_theta.first * g_dg_phi.first;
+                const auto F = -coef * rPD;
+
+                sys.force(P) -= F;
+                sys.force(D) += F;
+            }
+
+            // f(r) dg(theta) g(phi)
+            if(g_dg_theta.second != 0 && g_dg_phi.first  != 0)
+            {
+                MJOLNIR_LOG_DEBUG("calculating theta force");
+
+                const auto deriv =
+                    k * f_df.first * g_dg_theta.second * g_dg_phi.first;
+
+                const auto sin_theta = std::sin(theta);
+                const auto coef_sin  = deriv / std::max(sin_theta, tolerance);
+
+                const auto rPD_reg  = rlPD  * rPD;
+                const auto rPNC_reg = rlPNC * rPNC;
+
+                const auto F_P  = -coef_sin * rlPD  * (rPNC_reg - cosPNC * rPD_reg );
+                const auto F_PN = -coef_sin * rlPNC * (rPD_reg  - cosPNC * rPNC_reg);
+
+                sys.force(D)       -= F_P;
+                sys.force(P)       += F_P;
+                sys.force(para.PN) += F_PN;
+                sys.force(para.PC) -= F_PN;
+            }
+
+            // f(r) dg(theta) g(phi)
+            if(g_dg_theta.first  != 0 && g_dg_phi.second != 0)
+            {
+                MJOLNIR_LOG_DEBUG("calculating phi force");
+
+                const auto deriv =
+                    k * f_df.first * g_dg_theta.first * g_dg_phi.second;
+
+                const auto sin_phi  = std::sin(phi);
+                const auto coef_sin = deriv / std::max(sin_phi, tolerance);
+
+                const auto rPD_reg  = rlPD  * rPD;
+                const auto rS3D_reg = rlS3D * rS3D;
+
+                const auto F_P = -coef_sin * rlPD  * (rS3D_reg - cosS3D * rPD_reg);
+                const auto F_S = -coef_sin * rlS3D * (rPD_reg  - cosS3D * rS3D_reg);
+
+                sys.force(P)  += F_P;
+                sys.force(D)  -= F_P + F_S;
+                sys.force(S3) += F_S;
+            }
+        }
+    }
+    return energy;
+}
+
 
 } // mjolnir
 

--- a/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
+++ b/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
@@ -77,8 +77,9 @@ class PWMcosInteraction final : public GlobalInteractionBase<traitsT>
         return ;
     }
 
-    void      calc_force (system_type& sys)       const noexcept override;
-    real_type calc_energy(const system_type& sys) const noexcept override;
+    void      calc_force (system_type& sys)           const noexcept override;
+    real_type calc_energy(const system_type& sys)     const noexcept override;
+    real_type calc_force_and_energy(system_type& sys) const noexcept override;
 
     std::string name() const override {return "PWMcosInteraction";}
 
@@ -412,6 +413,233 @@ PWMcosInteraction<traitsT>::calc_energy(const system_type& sys) const noexcept
     }
     return E;
 }
+
+template<typename traitsT>
+typename PWMcosInteraction<traitsT>::real_type
+PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexcept
+{
+    MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+    MJOLNIR_LOG_FUNCTION_DEBUG();
+    //   DNA        protein    |
+    //        i-1              | r is the length of vector `v0`.
+    //     S--B       C        | angle1 is an angle formed by v0 and v1.
+    //    /   |        \       | angle2 is an angle formed by v0 and v2.
+    //   P    | v2      C j-1  | angle3 is an angle formed by v0 and v3.
+    //    \   |        /A      |
+    //  v1 S<-+-Bi--> Cj| v3   | v0: Bi -> Cj
+    //    /   |    v0  \|      | v1: Bi -> Si
+    //   P    |         C j+1  | v2: Bi-1 -> Bi+1
+    //    \   v v2     /       | v3: Cj+1 -> Cj-1
+    //     S--B       C        |
+    //        i+1              |
+    //
+    // d/dq e(b) f(r) g(theta1) g(theta2) g(theta3)
+    // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3) +
+    //   e(b) f(r) dg/dtheta1 dtheta1/dq g(theta2) g(theta3) +
+    //   e(b) f(r) g(theta1) dg/dtheta2 dtheta2/dq g(theta3) +
+    //   e(b) f(r) g(theta1) g(theta2) dg/dtheta3 dtheta3/dq
+
+    constexpr auto abs_tol = math::abs_tolerance<real_type>();
+
+    const auto energy_unit  = potential_.energy_unit();  // overall coefficient
+    const auto energy_shift = potential_.energy_shift(); // overall energy shift
+
+    real_type energy = 0;
+    for(std::size_t i=0; i < this->potential_.contacts().size(); ++i)
+    {
+        const auto& para = potential_.contacts()[i];
+        const auto& PWM  = para.PWM;
+
+        const auto  Ca  = para.Ca;  // C-alpha (not a calcium!)
+        const auto& rCa = sys.position(Ca);
+
+        const auto  CaN = para.CaN; // N-term Ca (Cj-1)
+        const auto  CaC = para.CaC; // C-term Ca (Cj+1)
+
+        MJOLNIR_LOG_DEBUG("Calpha = ", Ca);
+        for(const auto& ptnr : this->partition_.partners(Ca))
+        {
+            const auto  B  = ptnr.index;          // DNA Base
+            const auto  S  = ptnr.parameter().S;  // corresponding Sugar
+            const auto  B5 = ptnr.parameter().B5; // Base (Bi-1)
+            const auto  B3 = ptnr.parameter().B3; // Base (Bi+1)
+            MJOLNIR_LOG_DEBUG("Base = ", B);
+
+            const auto& rB     = sys.position(B);
+            const auto rBCa    = sys.adjust_direction(rCa - rB); // Bi -> Cj
+            const auto lBCa_sq = math::length_sq(rBCa);
+
+            if(para.r_cut_sq < lBCa_sq) {continue;}
+            MJOLNIR_LOG_DEBUG("within the cutoff");
+
+            // ----------------------------------------------------------------
+            // calculates the distance term (f(r))
+
+            const auto rlBCa = math::rsqrt(lBCa_sq);
+            const auto  lBCa = lBCa_sq * rlBCa;
+            const auto  f_df = potential_.f_df(para.r0, lBCa);
+
+            // ----------------------------------------------------------------
+            // calculates the theta1 term
+
+            const auto& rS    = sys.position(S);
+            const auto  rBS   = sys.adjust_direction(rS - rB); // Bi -> Si
+            const auto rlBS   = math::rlength(rBS);
+            const auto dot1   = math::dot_product(rBS, rBCa);
+            const auto cos1   = dot1 * rlBS * rlBCa;
+            const auto theta1 = std::acos(math::clamp<real_type>(cos1,-1,1));
+            const auto g_dg_1 = potential_.g_dg(para.theta1_0, theta1);
+
+            if(g_dg_1.first == 0 && g_dg_1.second == 0)
+            {
+                MJOLNIR_LOG_DEBUG("theta1 - theta1_0 > 2phi");
+                continue;
+            }
+
+            // ----------------------------------------------------------------
+            // calculates the theta2 term
+
+            const auto& rB3   = sys.position(B3);
+            const auto& rB5   = sys.position(B5);                // (B5) -> (B3)
+            const auto  rB53  = sys.adjust_direction(rB3 - rB5); // Bi-1 -> Bi+1
+            const auto rlB53  = math::rlength(rB53);
+            const auto dot2   = math::dot_product(rB53, rBCa);
+            const auto cos2   = dot2 * rlB53 * rlBCa;
+            const auto theta2 = std::acos(math::clamp<real_type>(cos2,-1,1));
+            const auto g_dg_2 = potential_.g_dg(para.theta2_0, theta2);
+
+            if(g_dg_2.first == 0 && g_dg_2.second == 0)
+            {
+                MJOLNIR_LOG_DEBUG("theta2 - theta2_0 > 2phi");
+                continue;
+            }
+
+            // ----------------------------------------------------------------
+            // calculates the theta3 term
+
+            const auto& rCaN  = sys.position(CaN);
+            const auto& rCaC  = sys.position(CaC);               //(CaC) -> (CaN)
+            const auto  rCCN  = sys.adjust_direction(rCaN-rCaC); // Cj+1 -> Cj-1
+            const auto rlCCN  = math::rlength(rCCN);
+            const auto dot3   = math::dot_product(rCCN, rBCa);
+            const auto cos3   = dot3 * rlCCN * rlBCa;
+            const auto theta3 = std::acos(math::clamp<real_type>(cos3,-1,1));
+            const auto g_dg_3 = potential_.g_dg(para.theta3_0, theta3);
+
+            if(g_dg_3.first == 0 && g_dg_3.second == 0)
+            {
+                MJOLNIR_LOG_DEBUG("theta3 - theta3_0 > 2phi");
+                continue;
+            }
+
+            // ================================================================
+            // calculates the force direction
+
+            const auto Bk    = static_cast<std::size_t>(ptnr.parameter().base);
+            const auto e_pwm = PWM[Bk];
+
+            const auto coef  = para.gamma   * energy_unit;
+            const auto shift = para.epsilon + energy_shift;
+
+            const auto factor = coef * (e_pwm + shift);
+
+            energy += factor * f_df.first *
+                      g_dg_1.first * g_dg_2.first * g_dg_3.first;
+
+            auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+
+            // ----------------------------------------------------------------
+            // calculate direction term
+            // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3)
+
+            if(g_dg_1.first != 0 && g_dg_2.first != 0 && g_dg_3.first != 0)
+            {
+                const auto magnitude = factor *
+                    f_df.second * g_dg_1.first * g_dg_2.first * g_dg_3.first;
+
+                F_Ca -= (magnitude * rlBCa) * rBCa;
+                F_B  += (magnitude * rlBCa) * rBCa;
+            }
+
+            // ----------------------------------------------------------------
+            // calculate angle1 term
+            // = e(b) f(r) dg/dtheta1 dtheta1/dq g(theta2) g(theta3)
+
+            if(g_dg_1.second != 0 && g_dg_2.first != 0 && g_dg_3.first != 0)
+            {
+                const auto magnitude = factor *
+                    f_df.first * g_dg_1.second * g_dg_2.first * g_dg_3.first;
+
+                const auto sin_theta = std::sin(theta1);
+                const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                const auto Fi = (coef_rsin * rlBCa) *
+                                ((cos1 * rlBCa) * rBCa - rlBS  * rBS );
+                const auto Fk = (coef_rsin * rlBS ) *
+                                ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
+
+                F_Ca         -= Fi;
+                F_B          += (Fi + Fk);
+                sys.force(S) -= Fk;
+            }
+
+            // ----------------------------------------------------------------
+            // calculate angle2 term
+            // = e(b) f(r) g(theta1) dg/dtheta2 dtheta2/dq g(theta3)
+
+            if(g_dg_1.first != 0 && g_dg_2.second != 0 && g_dg_3.first != 0)
+            {
+                const auto magnitude = factor *
+                    f_df.first * g_dg_1.first * g_dg_2.second * g_dg_3.first;
+
+                const auto sin_theta = std::sin(theta2);
+                const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                const auto Fi = (coef_rsin * rlBCa) *
+                                ((cos2 * rlBCa) * rBCa - rlB53 * rB53);
+                const auto Fk = (coef_rsin * rlB53) *
+                                ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
+
+                F_Ca          -= Fi;
+                F_B           += Fi;
+                sys.force(B5) += Fk;
+                sys.force(B3) -= Fk;
+            }
+
+            // ----------------------------------------------------------------
+            // calculate angle3 term
+            // = e(b) f(r) g(theta1) g(theta2) dg/dtheta3 dtheta3/dq
+
+            if(g_dg_1.first != 0 && g_dg_2.first != 0 && g_dg_3.second != 0)
+            {
+                const auto magnitude = factor *
+                    f_df.first * g_dg_1.first * g_dg_2.first * g_dg_3.second;
+
+                const auto sin_theta = std::sin(theta3);
+                const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                const auto Fi = (coef_rsin * rlBCa) *
+                                ((cos3 * rlBCa) * rBCa - rlCCN * rCCN);
+                const auto Fk = (coef_rsin * rlCCN) *
+                                ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
+
+                F_Ca           -= Fi;
+                F_B            += Fi;
+                sys.force(CaC) += Fk;
+                sys.force(CaN) -= Fk;
+            }
+
+            // ----------------------------------------------------------------
+            // collect force on Ca and B
+
+            sys.force(Ca) += F_Ca;
+            sys.force(B ) += F_B ;
+        }
+    }
+    return energy;
+}
+
 
 } // mjolnir
 

--- a/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
@@ -153,6 +153,52 @@ class GlobalPairInteraction<
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+        MJOLNIR_LOG_FUNCTION_DEBUG();
+
+        const auto coef_at_cutoff  = potential_.coef_at_cutoff();
+        const auto cutoff_ratio    = potential_.cutoff_ratio();
+        const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
+        const auto epsilon         = potential_.epsilon();
+        const auto epsilon12       = 12 * epsilon;
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
+        {
+            const auto i = leading_participants[idx];
+            for(const auto& ptnr : this->partition_.partners(i))
+            {
+                const auto  j     = ptnr.index;
+                const auto& param = ptnr.parameter(); // sum of radius
+
+                const coordinate_type rij =
+                    sys.adjust_direction(sys.position(j) - sys.position(i));
+                const real_type l_sq = math::length_sq(rij);
+
+                const real_type sigma_sq = param * param;
+                if(sigma_sq * cutoff_ratio_sq < l_sq) {continue;}
+
+                MJOLNIR_LOG_DEBUG("calculating force between ", i, " and ", j);
+
+                const real_type rcp_l_sq = real_type(1) / l_sq;
+                const real_type s2l2     = sigma_sq * rcp_l_sq;
+                const real_type s6l6     = s2l2 * s2l2 * s2l2;
+
+                energy += epsilon * (s6l6 * s6l6 - coef_at_cutoff);
+
+                const coordinate_type f = rij *
+                    (-epsilon12 * s6l6 * s6l6 * rcp_l_sq);
+
+                sys.force(i) += f;
+                sys.force(j) -= f;
+            }
+        }
+        return energy;
+    }
+
     std::string name() const override {return "GlobalPairExcludedVolume";}
 
     base_type* clone() const override

--- a/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
@@ -73,7 +73,6 @@ class GlobalPairInteraction<
         return;
     }
 
-
     void calc_force(system_type& sys) const noexcept override
     {
         const auto  cutoff_ratio    = potential_.cutoff_ratio();
@@ -147,6 +146,49 @@ class GlobalPairInteraction<
         }
         return E;
     }
+
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        const auto cutoff_ratio    = potential_.cutoff_ratio();
+        const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
+        const auto coef_at_cutoff  = potential_.coef_at_cutoff();
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+        for(std::size_t idx=0; idx<leading_participants.size(); ++idx)
+        {
+            const auto i = leading_participants[idx];
+
+            for(const auto& ptnr : this->partition_.partners(i))
+            {
+                const auto  j     = ptnr.index;
+                const auto& param = ptnr.parameter();
+
+                const coordinate_type rij =
+                    sys.adjust_direction(sys.position(j) - sys.position(i));
+                const real_type l_sq = math::length_sq(rij);
+
+                const real_type sigma_sq = param.first * param.first;
+                if(sigma_sq * cutoff_ratio_sq < l_sq) {continue;}
+
+                const real_type epsilon = param.second;
+
+                const real_type rcp_l_sq = 1 / l_sq;
+                const real_type s2l2 = sigma_sq * rcp_l_sq;
+                const real_type s6l6 = s2l2 * s2l2 * s2l2;
+
+                energy += 4 * epsilon * (s6l6 * s6l6 - s6l6 - coef_at_cutoff);
+
+                const coordinate_type f = rij *
+                    (24 * epsilon * (s6l6 - 2 * s6l6 * s6l6) * rcp_l_sq);
+
+                sys.force(i) += f;
+                sys.force(j) -= f;
+            }
+        }
+        return energy;
+    }
+
 
     std::string name() const override {return "GlobalPairLennardJones";}
 

--- a/mjolnir/forcefield/local/BondAngleInteraction.hpp
+++ b/mjolnir/forcefield/local/BondAngleInteraction.hpp
@@ -49,8 +49,54 @@ class BondAngleInteraction final : public LocalInteractionBase<traitsT>
     BondAngleInteraction& operator=(BondAngleInteraction&&)      = default;
     ~BondAngleInteraction() override {}
 
-    void      calc_force (system_type&)        const noexcept override;
-    real_type calc_energy(const system_type& ) const noexcept override;
+    void      calc_force (system_type&)           const noexcept override;
+    real_type calc_energy(const system_type&)     const noexcept override;
+
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        constexpr auto abs_tol = math::abs_tolerance<real_type>();
+
+        real_type energy = 0;
+        for(const auto& idxp : this->potentials_)
+        {
+            const auto& idxs = idxp.first;
+            const auto& pot  = idxp.second;
+
+            const auto& p0 = sys.position(idxs[0]);
+            const auto& p1 = sys.position(idxs[1]);
+            const auto& p2 = sys.position(idxs[2]);
+
+            const auto r_ij         = sys.adjust_direction(p0 - p1);
+            const auto inv_len_r_ij = math::rlength(r_ij);
+            const auto r_ij_reg     = r_ij * inv_len_r_ij;
+
+            const auto r_kj         = sys.adjust_direction(p2 - p1);
+            const auto inv_len_r_kj = math::rlength(r_kj);
+            const auto r_kj_reg     = r_kj * inv_len_r_kj;
+
+            const auto dot_ijk   = math::dot_product(r_ij_reg, r_kj_reg);
+            const auto cos_theta = math::clamp<real_type>(dot_ijk, -1, 1);
+
+            // acos returns a value in [0, pi]
+            const auto theta = std::acos(cos_theta);
+            const auto coef  = -pot.derivative(theta);
+            energy += pot.potential(theta);
+
+            // sin(x) >= 0 if x is in [0, pi].
+            const auto sin_theta    = std::sin(theta);
+            const auto coef_inv_sin = coef / std::max(sin_theta, abs_tol);
+
+            const auto Fi = (coef_inv_sin * inv_len_r_ij) *
+                            (cos_theta * r_ij_reg - r_kj_reg);
+            const auto Fk = (coef_inv_sin * inv_len_r_kj) *
+                            (cos_theta * r_kj_reg - r_ij_reg);
+
+            sys.force(idxs[0]) += Fi;
+            sys.force(idxs[1]) -= (Fi + Fk);
+            sys.force(idxs[2]) += Fk;
+        }
+        return energy;
+    }
 
     void initialize(const system_type& sys) override
     {

--- a/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
@@ -60,21 +60,13 @@ class BondLengthInteraction<
                 continue;
             }
 
-            const real_type rd2   = real_type(1) / len2;
-            const real_type rd6   = rd2 * rd2 * rd2;
-            const real_type rd12  = rd6 * rd6;
-            const real_type rd14  = rd12 * rd2;
+            const real_type r2     = real_type(1) / len2;
+            const real_type v0r_2  = pot.v0() * pot.v0() * r2;
+            const real_type v0r_6  = v0r_2 * v0r_2 * v0r_2;
+            const real_type v0r_10 = v0r_6 * v0r_2 * v0r_2;
+            const real_type v0r_12 = v0r_10 * v0r_2;
 
-            const real_type v0    = pot.v0();
-            const real_type v0_3  = v0   * v0   * v0;
-            const real_type v0_9  = v0_3 * v0_3 * v0_3;
-            const real_type v0_10 = v0_9 * v0;
-            const real_type v0_12 = v0_9 * v0_3;
-
-            //   60k * [(r0/r)^10  - (r0/r)^12] / r * (dr / r)
-            // = 60k * [r0^10/r^12 - r0^12/r^14]    *  dr
-
-            const auto coef = -60 * pot.k() * (v0_10 * rd12 - v0_12 * rd14);
+            const auto coef = -60 * pot.k() * r2 * (v0r_10 - v0r_12);
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
@@ -90,6 +82,39 @@ class BondLengthInteraction<
                     sys.position(idxp.first[1]) - sys.position(idxp.first[0]))));
         }
         return E;
+    }
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        real_type energy = 0;
+        for(const auto& idxp : this->potentials_)
+        {
+            const std::size_t idx0 = idxp.first[0];
+            const std::size_t idx1 = idxp.first[1];
+            const auto&       pot  = idxp.second;
+
+            const auto dpos =
+                sys.adjust_direction(sys.position(idx1) - sys.position(idx0));
+
+            const real_type len2 = math::length_sq(dpos);
+            if(pot.cutoff() * pot.cutoff() <= len2)
+            {
+                continue;
+            }
+
+            const real_type r2     = real_type(1) / len2;
+            const real_type v0r_2  = pot.v0() * pot.v0() * r2;
+            const real_type v0r_6  = v0r_2 * v0r_2 * v0r_2;
+            const real_type v0r_10 = v0r_6 * v0r_2 * v0r_2;
+            const real_type v0r_12 = v0r_10 * v0r_2;
+
+            energy += pot.k() * (5 * v0r_12 - 6 * v0r_10);
+
+            const auto coef = -60 * pot.k() * r2 * (v0r_10 - v0r_12);
+            const auto f    = coef * dpos;
+            sys.force(idx0) -= f;
+            sys.force(idx1) += f;
+        }
+        return energy;
     }
 
     void initialize(const system_type& sys) override

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -46,8 +46,9 @@ class DirectionalContactInteraction final : public LocalInteractionBase<traitsT>
     {}
     ~DirectionalContactInteraction() override{}
 
-    void      calc_force (system_type&)       const noexcept override;
-    real_type calc_energy(const system_type&) const noexcept override;
+    void      calc_force (system_type&)           const noexcept override;
+    real_type calc_energy(const system_type&)     const noexcept override;
+    real_type calc_force_and_energy(system_type&) const noexcept override;
 
     void initialize(const system_type& sys) override
     {
@@ -387,6 +388,153 @@ DirectionalContactInteraction<
     }
     return E;
 }
+
+template<typename traitsT,           typename angle1_potentialT,
+         typename angle2_potentialT, typename contact_potentialT>
+typename DirectionalContactInteraction<traitsT, angle1_potentialT,
+         angle2_potentialT, contact_potentialT>::real_type
+DirectionalContactInteraction<
+    traitsT, angle1_potentialT, angle2_potentialT, contact_potentialT
+    >::calc_force_and_energy(system_type& sys) const noexcept
+{
+    MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+    MJOLNIR_LOG_FUNCTION_DEBUG();
+
+    real_type energy = 0;
+    for(const std::size_t active_contact : this->active_contacts_)
+    {
+        const auto& idxp = this->potentials_[active_contact];
+
+        const auto& angle1_pot  = std::get<1>(idxp);
+        const auto& angle2_pot  = std::get<2>(idxp);
+        const auto& contact_pot = std::get<3>(idxp);
+
+        const std::size_t      Ci  = std::get<0>(idxp)[0];
+        const std::size_t      Pi  = std::get<0>(idxp)[1];
+        const std::size_t      Pj  = std::get<0>(idxp)[2];
+        const std::size_t      Cj  = std::get<0>(idxp)[3];
+        const coordinate_type& rCi = sys.position(Ci);
+        const coordinate_type& rPi = sys.position(Pi);
+        const coordinate_type& rPj = sys.position(Pj);
+        const coordinate_type& rCj = sys.position(Cj);
+
+        // =========================================================
+        // contact schema
+        //
+        //     theta1 theta2
+        //       |      |
+        //  Ci o v      v o Cj
+        //     \-.      ,-/
+        //   Pi o- - - - o Pj
+        //        |Pij|
+        //
+        // U_dir = U_angle1(theta1) * U_angle2(theta2) * U_contact(|Pij|)
+
+        const auto  Pij = sys.adjust_direction(rPj - rPi); // Pi -> Pj
+        const auto lPij = math::length(Pij);
+        if(lPij > contact_pot.cutoff())
+        {
+            continue;
+        }
+
+        constexpr auto abs_tol = math::abs_tolerance<real_type>();
+
+        // ==========================================================
+        // dU_angle1(theta1) / dr
+        const auto PiCi         = sys.adjust_direction(rCi - rPi);
+        const auto inv_len_PiCi = math::rlength(PiCi);
+        const auto PiCi_reg     = PiCi * inv_len_PiCi;
+
+        const auto inv_len_Pij  = real_type(1.0) / lPij;
+        const auto Pij_reg      = Pij * inv_len_Pij;
+
+        const auto PiCi_dot_Pij = math::dot_product(PiCi_reg, Pij_reg);
+        const auto cos_theta1   = math::clamp<real_type>(PiCi_dot_Pij, -1, 1);
+        const auto theta1       = std::acos(cos_theta1);
+        const auto angle1_coef  = angle1_pot.derivative(theta1);
+
+        const auto sin_theta1          = std::sin(theta1);
+        const auto angle1_coef_inv_sin = angle1_coef / std::max(sin_theta1, abs_tol);
+
+        const auto dU_angle1_drCi = (angle1_coef_inv_sin * inv_len_PiCi) *
+                                    (cos_theta1 * PiCi_reg - Pij_reg);
+        const auto dU_angle1_drPj = (angle1_coef_inv_sin * inv_len_Pij)  *
+                                    (cos_theta1 * Pij_reg  - PiCi_reg);
+
+        const auto dU_angle1_drPi = -(dU_angle1_drCi + dU_angle1_drPj);
+
+        MJOLNIR_LOG_DEBUG("dU_angle1 / drCi = {", dU_angle1_drCi, "}");
+        MJOLNIR_LOG_DEBUG("dU_angle1 / drPj = {", dU_angle1_drPj, "}");
+        MJOLNIR_LOG_DEBUG("dU_angle1 / drPi = {", dU_angle1_drPi, "}");
+
+        // dU_angle2(theta2) / dr
+        const auto PjCj         = sys.adjust_direction(rCj - rPj);
+        const auto inv_len_PjCj = math::rlength(PjCj);
+        const auto PjCj_reg     = PjCj * inv_len_PjCj;
+
+        const auto Pji_reg      = -Pij_reg;
+        const auto PjCj_dot_Pji = math::dot_product(PjCj_reg, Pji_reg);
+        const auto cos_theta2   = math::clamp<real_type>(PjCj_dot_Pji, -1, 1);
+        const auto theta2       = std::acos(cos_theta2);
+        const auto angle2_coef  = angle2_pot.derivative(theta2);
+
+        const auto sin_theta2          = std::sin(theta2);
+        const auto angle2_coef_inv_sin = angle2_coef / std::max(sin_theta2, abs_tol);
+
+        const auto dU_angle2_drCj = (angle2_coef_inv_sin * inv_len_PjCj) *
+                                    (cos_theta2 * PjCj_reg - Pji_reg);
+        const auto dU_angle2_drPi = (angle2_coef_inv_sin * inv_len_Pij)  *
+                                    (cos_theta2 * Pji_reg  - PjCj_reg);
+
+        const auto dU_angle2_drPj = -(dU_angle2_drCj + dU_angle2_drPi);
+
+        MJOLNIR_LOG_DEBUG("dU_angle2 / drCj = {", dU_angle2_drCj, "}");
+        MJOLNIR_LOG_DEBUG("dU_angle2 / drPi = {", dU_angle2_drPi, "}");
+        MJOLNIR_LOG_DEBUG("dU_angle2 / drPj = {", dU_angle2_drPj, "}");
+
+        // dU_con(|Pij|) / dr
+        const auto contact_coef = contact_pot.derivative(lPij);
+        const auto dU_con_drPj  = contact_coef * Pij_reg;
+        const auto dU_con_drPi  = -dU_con_drPj;
+
+        MJOLNIR_LOG_DEBUG("dU_con / drPi = {", dU_con_drPi, "}");
+        MJOLNIR_LOG_DEBUG("dU_con / drPj = {", dU_con_drPj, "}");
+
+        const real_type U_angle1          =  angle1_pot.potential(theta1);
+        const real_type U_angle2          =  angle2_pot.potential(theta2);
+        const real_type U_con             = contact_pot.potential(lPij);
+        const real_type U_angle1_U_con    = U_angle1 * U_con;
+        const real_type U_angle2_U_con    = U_angle2 * U_con;
+        const real_type U_angle1_U_angle2 = U_angle1 * U_angle2;
+
+        MJOLNIR_LOG_DEBUG("U_angle1 = ", U_angle1);
+        MJOLNIR_LOG_DEBUG("U_angle2 = ", U_angle2);
+        MJOLNIR_LOG_DEBUG("U_con    = ", U_con);
+
+        const auto dU_dir_drCi = dU_angle1_drCi * U_angle2_U_con;
+        const auto dU_dir_drPi = dU_angle1_drPi * U_angle2_U_con +
+                                 dU_angle2_drPi * U_angle1_U_con +
+                                 U_angle1_U_angle2 * dU_con_drPi;
+        const auto dU_dir_drPj = dU_angle1_drPj * U_angle2_U_con +
+                                 dU_angle2_drPj * U_angle1_U_con +
+                                 U_angle1_U_angle2 * dU_con_drPj;
+        const auto dU_dir_drCj = dU_angle2_drCj * U_angle1_U_con;
+
+        MJOLNIR_LOG_DEBUG("dU_dir / drCi = {", dU_dir_drCi, "}");
+        MJOLNIR_LOG_DEBUG("dU_dir / drPi = {", dU_dir_drPi, "}");
+        MJOLNIR_LOG_DEBUG("dU_dir / drPj = {", dU_dir_drPj, "}");
+        MJOLNIR_LOG_DEBUG("dU_dir / drCj = {", dU_dir_drCj, "}");
+
+        sys.force(Ci) -= dU_dir_drCi;
+        sys.force(Pi) -= dU_dir_drPi;
+        sys.force(Pj) -= dU_dir_drPj;
+        sys.force(Cj) -= dU_dir_drCj;
+
+        energy += U_angle1 * U_angle2 * U_con;
+    }
+    return energy;
+}
+
 
 } // mjolnir
 

--- a/mjolnir/forcefield/local/DummyInteraction.hpp
+++ b/mjolnir/forcefield/local/DummyInteraction.hpp
@@ -38,8 +38,9 @@ class DummyInteraction final : public LocalInteractionBase<traitsT>
     {}
     ~DummyInteraction() override {}
 
-    void      calc_force (system_type&)       const noexcept override {return;}
-    real_type calc_energy(const system_type&) const noexcept override {return 0;}
+    void      calc_force (system_type&)           const noexcept override {return;}
+    real_type calc_energy(const system_type&)     const noexcept override {return 0;}
+    real_type calc_force_and_energy(system_type&) const noexcept override {return 0;}
 
     void initialize(const system_type&) override
     {

--- a/mjolnir/omp/BondLengthInteraction.hpp
+++ b/mjolnir/omp/BondLengthInteraction.hpp
@@ -79,6 +79,33 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        real_type E = 0.;
+#pragma omp parallel for reduction(+:E)
+        for(std::size_t i=0; i<this->potentials.size(); ++i)
+        {
+            const auto& idxp = this->potentials[i];
+
+            const std::size_t idx0 = idxp.first[0];
+            const std::size_t idx1 = idxp.first[1];
+
+            const auto dpos =
+                sys.adjust_direction(sys.position(idx1) - sys.position(idx0));
+
+            const real_type len2 = math::length_sq(dpos); // l^2
+            const real_type rlen = math::rsqrt(len2);     // 1/l
+            const real_type  len = len2 * rlen;
+            const real_type force = -1 * idxp.second.derivative(len);
+            E += idxp.second.potential(len);
+
+            const coordinate_type f = dpos * (force * rlen);
+            sys.force_thread(omp_get_thread_num(), idx0) -= f;
+            sys.force_thread(omp_get_thread_num(), idx1) += f;
+        }
+        return E;
+    }
+
     void initialize(const system_type& sys) override
     {
         MJOLNIR_GET_DEFAULT_LOGGER();

--- a/mjolnir/omp/ContactInteraction.hpp
+++ b/mjolnir/omp/ContactInteraction.hpp
@@ -87,6 +87,33 @@ class ContactInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        real_type E = 0.0;
+#pragma omp parallel for reduction(+:E)
+        for(std::size_t i=0; i<active_contacts_.size(); ++i)
+        {
+            const auto& idxp = this->potentials[active_contacts_[i]];
+
+            const std::size_t idx0 = idxp.first[0];
+            const std::size_t idx1 = idxp.first[1];
+
+            const auto dpos =
+                sys.adjust_direction(sys.position(idx1) - sys.position(idx0));
+
+            const real_type len2 = math::length_sq(dpos); // l^2
+            const real_type rlen = math::rsqrt(len2);     // 1/l
+            const real_type len  = len2 * rlen;
+            const real_type force = -1 * idxp.second.derivative(len);
+            E += idxp.second.potential(len);
+
+            const coordinate_type f = dpos * (force * rlen);
+            sys.force_thread(omp_get_thread_num(), idx0) -= f;
+            sys.force_thread(omp_get_thread_num(), idx1) += f;
+        }
+        return E;
+    }
+
     void initialize(const system_type& sys) override
     {
         MJOLNIR_GET_DEFAULT_LOGGER();

--- a/mjolnir/omp/DihedralAngleInteraction.hpp
+++ b/mjolnir/omp/DihedralAngleInteraction.hpp
@@ -133,6 +133,65 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        real_type E = 0.0;
+#pragma omp parallel for reduction(+:E)
+        for(std::size_t i=0; i<this->potentials.size(); ++i)
+        {
+            const auto& idxp = this->potentials[i];
+            const std::size_t idx0 = idxp.first[0];
+            const std::size_t idx1 = idxp.first[1];
+            const std::size_t idx2 = idxp.first[2];
+            const std::size_t idx3 = idxp.first[3];
+
+            const auto& r_i = sys.position(idx0);
+            const auto& r_j = sys.position(idx1);
+            const auto& r_k = sys.position(idx2);
+            const auto& r_l = sys.position(idx3);
+
+            const coordinate_type r_ij = sys.adjust_direction(r_i - r_j);
+            const coordinate_type r_kj = sys.adjust_direction(r_k - r_j);
+            const coordinate_type r_lk = sys.adjust_direction(r_l - r_k);
+            const coordinate_type r_kl = real_type(-1.0) * r_lk;
+
+            const real_type r_kj_lensq  = math::length_sq(r_kj);
+            const real_type r_kj_rlen   = math::rsqrt(r_kj_lensq);
+            const real_type r_kj_rlensq = r_kj_rlen * r_kj_rlen;
+            const real_type r_kj_len    = r_kj_rlen * r_kj_lensq;
+
+            const coordinate_type m = math::cross_product(r_ij, r_kj);
+            const coordinate_type n = math::cross_product(r_kj, r_kl);
+            const real_type m_lensq = math::length_sq(m);
+            const real_type n_lensq = math::length_sq(n);
+
+            const real_type dot_mn  = math::dot_product(m, n) *
+                                      math::rsqrt(m_lensq * n_lensq);
+            const real_type cos_phi = math::clamp<real_type>(dot_mn, -1, 1);
+            const real_type phi     =
+                std::copysign(std::acos(cos_phi), math::dot_product(r_ij, n));
+
+            // -dV / dphi
+            const real_type coef = -(idxp.second.derivative(phi));
+            E += idxp.second.potential(phi);
+
+            const coordinate_type Fi = ( coef * r_kj_len / m_lensq) * m;
+            const coordinate_type Fl = (-coef * r_kj_len / n_lensq) * n;
+
+            const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
+            const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
+
+            const auto thread_id = omp_get_thread_num();
+
+            sys.force_thread(thread_id, idx0) += Fi;
+            sys.force_thread(thread_id, idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+            sys.force_thread(thread_id, idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+            sys.force_thread(thread_id, idx3) += Fl;
+        }
+        return E;
+    }
+
+
     void initialize(const system_type& sys) override
     {
         MJOLNIR_GET_DEFAULT_LOGGER();

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -152,6 +152,55 @@ class GlobalPairInteraction<
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+        MJOLNIR_LOG_FUNCTION_DEBUG();
+
+        const auto coef_at_cutoff  = potential_.coef_at_cutoff();
+        const auto cutoff_ratio    = potential_.cutoff_ratio();
+        const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
+        const auto epsilon         = potential_.epsilon();
+        const auto epsilon12       = 12 * epsilon;
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+#pragma omp parallel for reduction(+:energy)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
+        {
+            const auto i = leading_participants[idx];
+            for(const auto& ptnr : this->partition_.partners(i))
+            {
+                const auto  j     = ptnr.index;
+                const auto& param = ptnr.parameter(); // sum of radius
+
+                const coordinate_type rij =
+                    sys.adjust_direction(sys.position(j) - sys.position(i));
+                const real_type l_sq = math::length_sq(rij);
+
+                const real_type sigma_sq = param * param;
+                if(sigma_sq * cutoff_ratio_sq < l_sq) {continue;}
+
+                MJOLNIR_LOG_DEBUG("calculating force between ", i, " and ", j);
+
+                const real_type rcp_l_sq = real_type(1) / l_sq;
+                const real_type s2l2     = sigma_sq * rcp_l_sq;
+                const real_type s6l6     = s2l2 * s2l2 * s2l2;
+
+                energy += epsilon * (s6l6 * s6l6 - coef_at_cutoff);
+
+                const coordinate_type f = rij *
+                    (-epsilon12 * s6l6 * s6l6 * rcp_l_sq);
+
+                const std::size_t thread_id = omp_get_thread_num();
+                sys.force_thread(thread_id, i) += f;
+                sys.force_thread(thread_id, j) -= f;
+            }
+        }
+        return energy;
+    }
+
+
     std::string name() const override {return "GlobalPairExcludedVolume";}
 
     base_type* clone() const override

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -145,6 +145,50 @@ class GlobalPairInteraction<
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        const auto cutoff_ratio    = potential_.cutoff_ratio();
+        const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
+        const auto coef_at_cutoff  = potential_.coef_at_cutoff();
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+#pragma omp parallel for reduction(+:energy)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
+        {
+            const auto i = leading_participants[idx];
+            for(const auto& ptnr : this->partition_.partners(i))
+            {
+                const auto  j     = ptnr.index;
+                const auto& param = ptnr.parameter();
+
+                const coordinate_type rij =
+                    sys.adjust_direction(sys.position(j) - sys.position(i));
+                const real_type l_sq = math::length_sq(rij);
+
+                const real_type sigma_sq = param.first * param.first;
+                if(sigma_sq * cutoff_ratio_sq < l_sq) {continue;}
+
+                const real_type epsilon = param.second;
+
+                const real_type rcp_l_sq = 1 / l_sq;
+                const real_type s2l2 = sigma_sq * rcp_l_sq;
+                const real_type s6l6 = s2l2 * s2l2 * s2l2;
+
+                energy += 4 * epsilon * (s6l6 * s6l6 - s6l6 - coef_at_cutoff);
+
+                const coordinate_type f = rij *
+                    (24 * epsilon * (s6l6 - 2 * s6l6 * s6l6) * rcp_l_sq);
+
+                const std::size_t thread_id = omp_get_thread_num();
+                sys.force_thread(thread_id, i) += f;
+                sys.force_thread(thread_id, j) -= f;
+            }
+        }
+        return energy;
+    }
+
+
     std::string name() const override {return "GlobalPairLennardJones";}
 
     base_type* clone() const override

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -145,6 +145,49 @@ class GlobalPairInteraction<
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        const auto coef_at_cutoff  = potential_.coef_at_cutoff();
+        const auto cutoff_ratio    = potential_.cutoff_ratio();
+        const auto cutoff_ratio_sq = cutoff_ratio * cutoff_ratio;
+        const auto sigma           = this->potential_.sigma();
+        const auto sigma_sq        = sigma * sigma;
+        const auto r_cutoff_sq     = cutoff_ratio_sq * sigma_sq;
+        const auto epsilon         = this->potential_.epsilon();
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+#pragma omp parallel for reduction(+:energy)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
+        {
+            const auto i = leading_participants[idx];
+            for(const auto& ptnr : this->partition_.partners(i))
+            {
+                const auto j = ptnr.index;
+
+                const coordinate_type rij =
+                    sys.adjust_direction(sys.position(j) - sys.position(i));
+                const real_type l_sq = math::length_sq(rij);
+
+                if(r_cutoff_sq < l_sq) {continue;}
+
+                const real_type rcp_l_sq = 1 / l_sq;
+                const real_type s2l2 = sigma_sq * rcp_l_sq;
+                const real_type s6l6 = s2l2 * s2l2 * s2l2;
+
+                energy += 4 * epsilon * (s6l6 * s6l6 - s6l6 - coef_at_cutoff);
+
+                const coordinate_type f = rij *
+                    (24 * epsilon * (s6l6 - 2 * s6l6 * s6l6) * rcp_l_sq);
+
+                const std::size_t thread_id = omp_get_thread_num();
+                sys.force_thread(thread_id, i) += f;
+                sys.force_thread(thread_id, j) -= f;
+            }
+        }
+        return energy;
+    }
+
     std::string name() const override {return "GlobalPairUniformLennardJones";}
 
     base_type* clone() const override

--- a/mjolnir/omp/GoContactInteraction.hpp
+++ b/mjolnir/omp/GoContactInteraction.hpp
@@ -69,21 +69,13 @@ class ContactInteraction<
                 continue;
             }
 
-            const real_type rd2   = real_type(1) / len2;
-            const real_type rd6   = rd2 * rd2 * rd2;
-            const real_type rd12  = rd6 * rd6;
-            const real_type rd14  = rd12 * rd2;
+            const real_type r2     = real_type(1) / len2;
+            const real_type v0r_2  = pot.v0() * pot.v0() * r2;
+            const real_type v0r_6  = v0r_2 * v0r_2 * v0r_2;
+            const real_type v0r_10 = v0r_6 * v0r_2 * v0r_2;
+            const real_type v0r_12 = v0r_10 * v0r_2;
 
-            const real_type v0    = pot.v0();
-            const real_type v0_3  = v0   * v0   * v0;
-            const real_type v0_9  = v0_3 * v0_3 * v0_3;
-            const real_type v0_10 = v0_9 * v0;
-            const real_type v0_12 = v0_9 * v0_3;
-
-            //   60k * [(r0/r)^10  - (r0/r)^12] / r * (dr / r)
-            // = 60k * [r0^10/r^12 - r0^12/r^14]    *  dr
-
-            const auto coef = -60 * pot.k() * (v0_10 * rd12 - v0_12 * rd14);
+            const auto coef = -60 * pot.k() * r2 * (v0r_10 - v0r_12);
             const auto f    = coef * dpos;
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
@@ -102,6 +94,45 @@ class ContactInteraction<
             const auto& idxp = this->potentials_[active_contact];
             E += idxp.second.potential(math::length(sys.adjust_direction(
                     sys.position(idxp.first[1]) - sys.position(idxp.first[0]))));
+        }
+        return E;
+    }
+
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        real_type E = 0.0;
+#pragma omp parallel for reduction(+:E)
+        for(std::size_t i=0; i<this->active_contacts_.size(); ++i)
+        {
+            const std::size_t active_contact = active_contacts_[i];
+            const auto& idxp = this->potentials_[active_contact];
+
+            const std::size_t idx0 = idxp.first[0];
+            const std::size_t idx1 = idxp.first[1];
+            const auto&       pot  = idxp.second;
+
+            const auto dpos =
+                sys.adjust_direction(sys.position(idx1) - sys.position(idx0));
+
+            const real_type len2  = math::length_sq(dpos);
+            if(pot.cutoff() * pot.cutoff() <= len2)
+            {
+                continue;
+            }
+
+            const real_type r2     = real_type(1) / len2;
+            const real_type v0r_2  = pot.v0() * pot.v0() * r2;
+            const real_type v0r_6  = v0r_2 * v0r_2 * v0r_2;
+            const real_type v0r_10 = v0r_6 * v0r_2 * v0r_2;
+            const real_type v0r_12 = v0r_10 * v0r_2;
+
+            E += pot.k() * (5 * v0r_12 - 6 * v0r_10);
+
+            const auto coef = -60 * pot.k() * r2 * (v0r_10 - v0r_12);
+            const auto f    = coef * dpos;
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
         }
         return E;
     }

--- a/mjolnir/omp/PWMcosInteraction.hpp
+++ b/mjolnir/omp/PWMcosInteraction.hpp
@@ -392,6 +392,233 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER_DEBUG();
+        MJOLNIR_LOG_FUNCTION_DEBUG();
+        //   DNA        protein    |
+        //        i-1              | r is the length of vector `v0`.
+        //     S--B       C        | angle1 is an angle formed by v0 and v1.
+        //    /   |        \       | angle2 is an angle formed by v0 and v2.
+        //   P    | v2      C j-1  | angle3 is an angle formed by v0 and v3.
+        //    \   |        /A      |
+        //  v1 S<-+-Bi--> Cj| v3   | v0: Bi -> Cj
+        //    /   |    v0  \|      | v1: Bi -> Si
+        //   P    |         C j+1  | v2: Bi-1 -> Bi+1
+        //    \   v v2     /       | v3: Cj+1 -> Cj-1
+        //     S--B       C        |
+        //        i+1              |
+        //
+        // d/dq e(b) f(r) g(theta1) g(theta2) g(theta3)
+        // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3) +
+        //   e(b) f(r) dg/dtheta1 dtheta1/dq g(theta2) g(theta3) +
+        //   e(b) f(r) g(theta1) dg/dtheta2 dtheta2/dq g(theta3) +
+        //   e(b) f(r) g(theta1) g(theta2) dg/dtheta3 dtheta3/dq
+
+        constexpr auto abs_tol = math::abs_tolerance<real_type>();
+
+        const auto energy_unit  = potential_.energy_unit();  // overall coefficient
+        const auto energy_shift = potential_.energy_shift(); // overall energy shift
+
+        real_type energy = 0;
+#pragma omp parallel for reduction(+:energy)
+        for(std::size_t i=0; i < this->potential_.contacts().size(); ++i)
+        {
+            const auto thread_id = omp_get_thread_num();
+
+            const auto& para = potential_.contacts()[i];
+            const auto& PWM  = para.PWM;
+
+            const auto  Ca  = para.Ca;  // C-alpha (not a calcium!)
+            const auto& rCa = sys.position(Ca);
+
+            const auto  CaN = para.CaN; // N-term Ca (Cj-1)
+            const auto  CaC = para.CaC; // C-term Ca (Cj+1)
+
+            MJOLNIR_LOG_DEBUG("Calpha = ", Ca);
+            for(const auto& ptnr : this->partition_.partners(Ca))
+            {
+                const auto  B  = ptnr.index;          // DNA Base
+                const auto  S  = ptnr.parameter().S;  // corresponding Sugar
+                const auto  B5 = ptnr.parameter().B5; // Base (Bi-1)
+                const auto  B3 = ptnr.parameter().B3; // Base (Bi+1)
+                MJOLNIR_LOG_DEBUG("Base = ", B);
+
+                const auto& rB     = sys.position(B);
+                const auto rBCa    = sys.adjust_direction(rCa - rB); // Bi -> Cj
+                const auto lBCa_sq = math::length_sq(rBCa);
+
+                if(para.r_cut_sq < lBCa_sq) {continue;}
+                MJOLNIR_LOG_DEBUG("within the cutoff");
+
+                // ----------------------------------------------------------------
+                // calculates the distance term (f(r))
+
+                const auto rlBCa = math::rsqrt(lBCa_sq);
+                const auto  lBCa = lBCa_sq * rlBCa;
+                const auto  f_df = potential_.f_df(para.r0, lBCa);
+
+                // ----------------------------------------------------------------
+                // calculates the theta1 term
+
+                const auto& rS    = sys.position(S);
+                const auto  rBS   = sys.adjust_direction(rS - rB); // Bi -> Si
+                const auto rlBS   = math::rlength(rBS);
+                const auto dot1   = math::dot_product(rBS, rBCa);
+                const auto cos1   = dot1 * rlBS * rlBCa;
+                const auto theta1 = std::acos(math::clamp<real_type>(cos1,-1,1));
+                const auto g_dg_1 = potential_.g_dg(para.theta1_0, theta1);
+
+                if(g_dg_1.first == 0 && g_dg_1.second == 0)
+                {
+                    MJOLNIR_LOG_DEBUG("theta1 - theta1_0 > 2phi");
+                    continue;
+                }
+
+                // ----------------------------------------------------------------
+                // calculates the theta2 term
+
+                const auto& rB3   = sys.position(B3);
+                const auto& rB5   = sys.position(B5);                // (B5) -> (B3)
+                const auto  rB53  = sys.adjust_direction(rB3 - rB5); // Bi-1 -> Bi+1
+                const auto rlB53  = math::rlength(rB53);
+                const auto dot2   = math::dot_product(rB53, rBCa);
+                const auto cos2   = dot2 * rlB53 * rlBCa;
+                const auto theta2 = std::acos(math::clamp<real_type>(cos2,-1,1));
+                const auto g_dg_2 = potential_.g_dg(para.theta2_0, theta2);
+
+                if(g_dg_2.first == 0 && g_dg_2.second == 0)
+                {
+                    MJOLNIR_LOG_DEBUG("theta2 - theta2_0 > 2phi");
+                    continue;
+                }
+
+                // ----------------------------------------------------------------
+                // calculates the theta3 term
+
+                const auto& rCaN  = sys.position(CaN);
+                const auto& rCaC  = sys.position(CaC);               //(CaC) -> (CaN)
+                const auto  rCCN  = sys.adjust_direction(rCaN-rCaC); // Cj+1 -> Cj-1
+                const auto rlCCN  = math::rlength(rCCN);
+                const auto dot3   = math::dot_product(rCCN, rBCa);
+                const auto cos3   = dot3 * rlCCN * rlBCa;
+                const auto theta3 = std::acos(math::clamp<real_type>(cos3,-1,1));
+                const auto g_dg_3 = potential_.g_dg(para.theta3_0, theta3);
+
+                if(g_dg_3.first == 0 && g_dg_3.second == 0)
+                {
+                    MJOLNIR_LOG_DEBUG("theta3 - theta3_0 > 2phi");
+                    continue;
+                }
+
+                // ================================================================
+                // calculates the force direction
+
+                const auto Bk    = static_cast<std::size_t>(ptnr.parameter().base);
+                const auto e_pwm = PWM[Bk];
+
+                const auto coef  = para.gamma   * energy_unit;
+                const auto shift = para.epsilon + energy_shift;
+
+                const auto factor = coef * (e_pwm + shift);
+                energy += factor * f_df.first * g_dg_1.first *
+                          g_dg_2.first * g_dg_3.first;
+
+                auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
+                auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+
+                // ----------------------------------------------------------------
+                // calculate direction term
+                // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3)
+
+                if(g_dg_1.first != 0 && g_dg_2.first != 0 && g_dg_3.first != 0)
+                {
+                    const auto magnitude = factor *
+                        f_df.second * g_dg_1.first * g_dg_2.first * g_dg_3.first;
+
+                    F_Ca -= (magnitude * rlBCa) * rBCa;
+                    F_B  += (magnitude * rlBCa) * rBCa;
+                }
+
+                // ----------------------------------------------------------------
+                // calculate angle1 term
+                // = e(b) f(r) dg/dtheta1 dtheta1/dq g(theta2) g(theta3)
+
+                if(g_dg_1.second != 0 && g_dg_2.first != 0 && g_dg_3.first != 0)
+                {
+                    const auto magnitude = factor *
+                        f_df.first * g_dg_1.second * g_dg_2.first * g_dg_3.first;
+
+                    const auto sin_theta = std::sin(theta1);
+                    const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                    const auto Fi = (coef_rsin * rlBCa) *
+                                    ((cos1 * rlBCa) * rBCa - rlBS  * rBS );
+                    const auto Fk = (coef_rsin * rlBS ) *
+                                    ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
+
+                    F_Ca         -= Fi;
+                    F_B          += (Fi + Fk);
+                    sys.force_thread(thread_id, S) -= Fk;
+                }
+
+                // ----------------------------------------------------------------
+                // calculate angle2 term
+                // = e(b) f(r) g(theta1) dg/dtheta2 dtheta2/dq g(theta3)
+
+                if(g_dg_1.first != 0 && g_dg_2.second != 0 && g_dg_3.first != 0)
+                {
+                    const auto magnitude = factor *
+                        f_df.first * g_dg_1.first * g_dg_2.second * g_dg_3.first;
+
+                    const auto sin_theta = std::sin(theta2);
+                    const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                    const auto Fi = (coef_rsin * rlBCa) *
+                                    ((cos2 * rlBCa) * rBCa - rlB53 * rB53);
+                    const auto Fk = (coef_rsin * rlB53) *
+                                    ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
+
+                    F_Ca          -= Fi;
+                    F_B           += Fi;
+                    sys.force_thread(thread_id, B5) += Fk;
+                    sys.force_thread(thread_id, B3) -= Fk;
+                }
+
+                // ----------------------------------------------------------------
+                // calculate angle3 term
+                // = e(b) f(r) g(theta1) g(theta2) dg/dtheta3 dtheta3/dq
+
+                if(g_dg_1.first != 0 && g_dg_2.first != 0 && g_dg_3.second != 0)
+                {
+                    const auto magnitude = factor *
+                        f_df.first * g_dg_1.first * g_dg_2.first * g_dg_3.second;
+
+                    const auto sin_theta = std::sin(theta3);
+                    const auto coef_rsin = magnitude / std::max(sin_theta, abs_tol);
+
+                    const auto Fi = (coef_rsin * rlBCa) *
+                                    ((cos3 * rlBCa) * rBCa - rlCCN * rCCN);
+                    const auto Fk = (coef_rsin * rlCCN) *
+                                    ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
+
+                    F_Ca           -= Fi;
+                    F_B            += Fi;
+                    sys.force_thread(thread_id, CaC) += Fk;
+                    sys.force_thread(thread_id, CaN) -= Fk;
+                }
+
+                // ----------------------------------------------------------------
+                // collect force on Ca and B
+
+                sys.force_thread(thread_id, Ca) += F_Ca;
+                sys.force_thread(thread_id, B ) += F_B ;
+            }
+        }
+        return energy;
+    }
+
+
     std::string name() const override {return "PWMcosInteraction";}
 
     potential_type const& potential() const noexcept {return potential_;}

--- a/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
@@ -763,6 +763,444 @@ class ThreeSPN2BaseBaseInteraction<
         return E;
     }
 
+    real_type calc_force_and_energy(system_type& sys) const noexcept override
+    {
+        constexpr auto pi        = math::constants<real_type>::pi();
+        constexpr auto two_pi    = math::constants<real_type>::two_pi();
+        constexpr auto tolerance = math::abs_tolerance<real_type>();
+
+        real_type energy = 0;
+        const auto leading_participants = this->potential_.leading_participants();
+#pragma omp parallel for reduction(+:energy)
+        for(std::size_t idx=0; idx < leading_participants.size(); ++idx)
+        {
+            const std::size_t thread_id = omp_get_thread_num();
+
+            const auto   Bi = leading_participants[idx];
+            const auto& rBi = sys.position(Bi);
+            for(const auto& ptnr : this->partition_.partners(Bi))
+            {
+                const auto  Bj   = ptnr.index;
+                const auto& para = ptnr.parameter();
+                const auto& rBj  = sys.position(Bj);
+                const auto  bp_kind = para.bp_kind;
+
+                const auto Bij = sys.adjust_direction(rBj - rBi); // Bi -> Bj
+                const auto lBij_sq = math::length_sq(Bij);
+                if(lBij_sq > potential_.cutoff_sq())
+                {
+                    continue;
+                }
+
+                // ================================================================
+                // base pairing
+                //
+                //  Si o         o Sj
+                //      \-.   ,-/
+                //    Bi o =(= o Bj
+                //
+                // U_rep(rij) + 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+
+                const auto rlBij = math::rsqrt(lBij_sq); // 1 / |Bij|
+                const auto lBij  = lBij_sq * rlBij;      // |Bij|
+
+                const auto Bij_reg =  rlBij * Bij;
+                const auto Bji_reg = -rlBij * Bij;
+
+                // ----------------------------------------------------------------
+                // calculate the the repulsive part, which does not depend on angle.
+                //
+                // dU_rep = 2 a e exp(-a(r-r0)) (1-exp(-a(r-r0))) ... r  <  r0
+                //        = 0                                     ... r0 <= r
+                //
+                {
+                    energy += potential_.U_rep(bp_kind, lBij);
+                    const auto dU_rep = potential_.dU_rep(bp_kind, lBij);
+                    if(dU_rep != real_type(0))
+                    {
+                        // remember that F = -dU.
+                        sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
+                        sys.force_thread(thread_id, Bj) -= dU_rep * Bij_reg;
+                    }
+                }
+
+                // ----------------------------------------------------------------
+                // calc theta1 and 2 to calculate the attractive part,
+                //  = 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+                //
+                //   theta1   theta2
+                //       |     |
+                //  Si o v     v o Sj
+                //      \-.   ,-/
+                //    Bi o =(= o Bj
+
+                const auto   Si = para.Si;
+                const auto   Sj = para.Sj;
+                const auto& rSi = sys.position(Si);
+                const auto& rSj = sys.position(Sj);
+
+                const auto SBi = sys.adjust_direction(rBi - rSi); // Si -> Bi
+                const auto SBj = sys.adjust_direction(rBj - rSj); // Sj -> Bj
+
+                const auto lSBi_sq = math::length_sq(SBi); // |SBi|^2
+                const auto lSBj_sq = math::length_sq(SBj); // |SBj|^2
+                const auto rlSBi   = math::rsqrt(lSBi_sq); // 1 / |SBi|
+                const auto rlSBj   = math::rsqrt(lSBj_sq); // 1 / |SBj|
+                const auto BSi_reg = -rlSBi * SBi;
+                const auto BSj_reg = -rlSBj * SBj;
+
+                const auto dot_SBiBj  = -math::dot_product(SBi, Bij);
+                const auto dot_SBjBi  =  math::dot_product(SBj, Bij);
+                const auto cos_theta1 = dot_SBiBj * rlSBi * rlBij;
+                const auto cos_theta2 = dot_SBjBi * rlSBj * rlBij;
+                const auto theta1 = std::acos(math::clamp<real_type>(cos_theta1, -1, 1));
+                const auto theta2 = std::acos(math::clamp<real_type>(cos_theta2, -1, 1));
+
+                // ----------------------------------------------------------------
+                // calc angle-dependent terms and advance if both are nonzero
+                //
+                // 1/2(1+cos(dphi)) f(dtheta1) f(dtheta2) U_attr(rij)
+
+                const auto theta1_0 = potential_.theta1_0(bp_kind);
+                const auto theta2_0 = potential_.theta2_0(bp_kind);
+                const auto f1 = potential_.f(bp_kind, theta1, theta1_0);
+                const auto f2 = potential_.f(bp_kind, theta2, theta2_0);
+
+                if(f1 != real_type(0.0) && f2 != real_type(0.0))
+                {
+                    // calculate dihedral, phi
+                    //
+                    //  Si o         o Sj
+                    //      \       /
+                    //    Bi o =(= o Bj
+                    //         phi
+
+                    const auto df1 = potential_.df(bp_kind, theta1, theta1_0);
+                    const auto df2 = potential_.df(bp_kind, theta2, theta2_0);
+
+                    const auto m = math::cross_product(-SBi, Bij);
+                    const auto n = math::cross_product( Bij, SBj);
+                    const auto m_lsq = math::length_sq(m);
+                    const auto n_lsq = math::length_sq(n);
+
+                    const auto dot_phi = math::dot_product(m, n) *
+                                         math::rsqrt(m_lsq * n_lsq);
+                    const auto cos_phi = math::clamp<real_type>(dot_phi, -1, 1);
+
+                    const auto phi = std::copysign(std::acos(cos_phi),
+                                                   -math::dot_product(SBi, n));
+
+                    auto dphi = phi - this->potential_.phi_0(bp_kind);
+                    if(dphi < -pi) {dphi += two_pi;}
+                    if(pi <= dphi) {dphi -= two_pi;}
+                    const auto cos_dphi = std::cos(dphi);
+                    const auto sin_dphi = std::sin(dphi);
+
+                    // ------------------------------------------------------------
+                    // calculate attractive force
+                    //
+                    // d/dr [1/2 (1 + cos(dphi)) f(dtheta1) f(dtheta2) U_attr(Bij)]
+                    // = ( -sin(dphi))/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
+                    // + (1+cos(dphi))/2 df/dtheta1 f(dtheta2) U_attr(Bij) dtheta1/dr
+                    // + (1+cos(dphi))/2 f(dtheta1) df/dtheta2 U_attr(Bij) dtheta2/dr
+                    // + (1+cos(dphi))/2 f(dtheta1) f(dtheta2) dU_attr/dr  dBij/dr
+
+                    if(cos_dphi != real_type(-1.0))
+                    {
+                        const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
+
+                        energy += 0.5 * (1 + cos_dphi) * f1 * f2 * U_dU_attr.first;
+
+                        // --------------------------------------------------------
+                        // calc dihedral term
+                        // -sin(dphi)/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
+                        if(sin_dphi != real_type(0.0))
+                        {
+                            // remember that F = -dU. Here `coef` = -dU.
+                            const auto coef = real_type(0.5) * sin_dphi *
+                                              f1 * f2 * U_dU_attr.first;
+
+                            const auto fSi = ( coef * lBij / m_lsq) * m;
+                            const auto fSj = (-coef * lBij / n_lsq) * n;
+
+                            const auto rlBij_sq = rlBij * rlBij; // 1 / |Bij|^2
+                            const auto coef_Bi = dot_SBiBj * rlBij_sq;
+                            const auto coef_Bj = dot_SBjBi * rlBij_sq;
+
+                            sys.force_thread(thread_id, Si) += fSi;
+                            sys.force_thread(thread_id, Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                            sys.force_thread(thread_id, Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                            sys.force_thread(thread_id, Sj) += fSj;
+                        }
+
+                        const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
+
+                        // --------------------------------------------------------
+                        // calc theta1 term
+                        // (1+cos(dphi))/2 df/dtheta1 f(dtheta2) U_attr(Bij) dtheta1/dr
+                        if(df1 != real_type(0.0))
+                        {
+                            // remember that F = -dU. Here `coef` = -dU.
+                            const auto coef = -dihd_term * df1 * f2 * U_dU_attr.first;
+
+                            const auto sin_theta1 = std::sin(theta1);
+                            const auto coef_rsin  = (sin_theta1 > tolerance) ?
+                                       (coef / sin_theta1) : (coef / tolerance);
+
+                            const auto fSi = (coef_rsin * rlSBi) *
+                                             (cos_theta1 * BSi_reg - Bij_reg);
+                            const auto fBj = (coef_rsin * rlBij) *
+                                             (cos_theta1 * Bij_reg - BSi_reg);
+                            sys.force_thread(thread_id, Si) += fSi;
+                            sys.force_thread(thread_id, Bi) -= (fSi + fBj);
+                            sys.force_thread(thread_id, Bj) += fBj;
+                        }
+                        // --------------------------------------------------------
+                        // calc theta2 term
+                        // (1+cos(dphi))/2 f(dtheta1) df/dtheta2 U_attr(Bij) dtheta2/dr
+                        if(df2 != real_type(0.0))
+                        {
+                            // remember that F = -dU. Here `coef` = -dU.
+                            const auto coef = -dihd_term * f1 * df2 * U_dU_attr.first;
+
+                            const auto sin_theta2 = std::sin(theta2);
+                            const auto coef_rsin  = (sin_theta2 > tolerance) ?
+                                       (coef / sin_theta2) : (coef / tolerance);
+
+                            const auto fBi = (coef_rsin * rlBij) *
+                                             (cos_theta2 * Bji_reg - BSj_reg);
+                            const auto fSj = (coef_rsin * rlSBj) *
+                                             (cos_theta2 * BSj_reg - Bji_reg);
+                            sys.force_thread(thread_id, Bi) += fBi;
+                            sys.force_thread(thread_id, Bj) -= (fBi + fSj);
+                            sys.force_thread(thread_id, Sj) += fSj;
+                        }
+                        // --------------------------------------------------------
+                        // calc distance
+                        // + 1/2 (1+cos(dphi)) f(dtheta1) f(dtheta2) dU_attr/dr  dBij/dr
+                        if(U_dU_attr.second != real_type(0.0))
+                        {
+                            // remember that F = -dU. Here `coef` = -dU.
+                            const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
+                            sys.force_thread(thread_id, Bi) += coef * Bji_reg;
+                            sys.force_thread(thread_id, Bj) += coef * Bij_reg;
+                        }
+                    }
+                }
+
+                // ================================================================
+                // cross stacking
+                // f(theta_3) f(theta_CS) U_attr(epsilon, alpha, rij)
+                //
+                //       Si   Bi   Bj   Sj
+                //  5'    o -- o===o -- o     3'
+                //  ^    /      \ /      \    |
+                //  | P o        X        o P |
+                //  |    \      / \      /    v
+                //  3'    o -- o===o -- o     5'
+                //       Bj_next   Bj_next
+                //
+                // d/dr Vcs =
+                //    df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3  /dr
+                //  + f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS /dr
+                //  + f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+                //
+
+                const auto Bi_next        = para.Bi_next;
+                const auto Bj_next        = para.Bj_next;
+                const bool Bi_next_exists = (Bi_next != potential_type::invalid());
+                const bool Bj_next_exists = (Bj_next != potential_type::invalid());
+
+                if(!Bi_next_exists && !Bj_next_exists)
+                {
+                    continue; // if both interacting pair do not exist, do nothing.
+                }
+
+                // ----------------------------------------------------------------
+                // calc common part, theta3 and dtheta3/dr.
+
+                const auto cos_theta3 = math::dot_product(BSi_reg, BSj_reg);
+                const auto theta3     = std::acos(math::clamp<real_type>(cos_theta3, -1, 1));
+                const auto theta3_0   = potential_.theta3_0(bp_kind);
+                const auto f3         = potential_.f(bp_kind, theta3, theta3_0);
+                if(f3 == real_type(0))
+                {
+                    // f(theta) == 0 means df(theta) is also zero.
+                    // so here, both cross-stacking becomes zero. skip them.
+                    continue;
+                }
+                const auto df3 = potential_.df(bp_kind, theta3, theta3_0);
+
+                // ----------------------------------------------------------------
+                // force directions for dtheta3/dr
+
+                // here, theta3 is a return value of acos, so it is in [0, pi].
+                // and inside it, sin(theta3) should be larger than 0.
+                const auto sin_theta3  = std::sin(theta3);
+                const auto rsin_theta3 = sin_theta3 > tolerance ?
+                    real_type(1) / sin_theta3 : real_type(1) / tolerance;
+
+                const auto fBi_theta3 = rsin_theta3 * rlSBi * (BSj_reg - cos_theta3 * BSi_reg);
+                const auto fBj_theta3 = rsin_theta3 * rlSBj * (BSi_reg - cos_theta3 * BSj_reg);
+                const auto fSi_theta3 = real_type(-1) * fBi_theta3;
+                const auto fSj_theta3 = real_type(-1) * fBj_theta3;
+
+                // adjacent of Base j exists. its not the edge of the strand.
+                if(Bj_next_exists)
+                {
+                    // ------------------------------------------------------------
+                    // 5' cross stacking (the case if `Bi` is in sense strand)
+                    //
+                    //       Si   Bi   Bj   Sj
+                    //  5'    o--> o===o <--o     3'
+                    //  ^    /   `--\        \    |
+                    //  | P o   tCS  \        o P |
+                    //  |    \        \      /    v
+                    //  3'    o -- o===o -- o     5'
+                    //           Bi3   Bj5
+                    //
+                    // Hereafter, we use the notation illustrated above (excepting
+                    // the index `Bj_next` that corresponds to Bj5).
+
+                    const auto cs_kind = para.cs_i_kind;
+
+                    const auto& rBj5     = sys.position(Bj_next);
+                    const auto  Bj5i     = sys.adjust_direction(rBi - rBj5);
+                    const auto  lBj5i_sq = math::length_sq(Bj5i); // |Bj5i|^2
+                    const auto  rlBj5i   = math::rsqrt(lBj5i_sq);  // 1 / |Bj5i|
+
+                    const auto dot_theta_CS = math::dot_product(SBi, Bj5i);
+                    const auto cos_theta_CS = dot_theta_CS * rlSBi * rlBj5i;
+                    const auto theta_CS     =
+                        std::acos(math::clamp<real_type>(cos_theta_CS, -1, 1));
+                    const auto theta_CS_0   = potential_.thetaCS_0(cs_kind);
+
+                    const auto fCS  = potential_.f(cs_kind, theta_CS, theta_CS_0);
+                    // if f == 0, df is also zero. if fCS == 0, no force there
+                    if(fCS != real_type(0))
+                    {
+                        const auto dfCS  = potential_.df(cs_kind, theta_CS, theta_CS_0);
+
+                        const auto lBj5i = lBj5i_sq * rlBj5i;
+                        const auto U_dU_attr = potential_.U_dU_attr(cs_kind, lBj5i);
+                        const auto Bj5i_reg  = rlBj5i * Bj5i;
+
+                        // --------------------------------------------------------
+                        // df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3 /dr
+                        if(df3 != real_type(0))
+                        {
+                            const auto coef = -df3 * fCS * U_dU_attr.first;
+                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
+                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
+                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
+                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                        }
+                        // --------------------------------------------------------
+                        // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
+                        if(dfCS != real_type(0))
+                        {
+                            const auto coef         = -f3 * dfCS * U_dU_attr.first;
+                            const auto sin_theta_CS = std::sin(theta_CS);
+                            const auto coef_rsin    = (sin_theta_CS > tolerance) ?
+                                       (coef / sin_theta_CS) : (coef / tolerance);
+
+                            const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
+                            const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
+
+                            sys.force_thread(thread_id, Si)      += fSi;
+                            sys.force_thread(thread_id, Bi)      -= (fSi + fBj5);
+                            sys.force_thread(thread_id, Bj_next) += fBj5;
+                        }
+                        // --------------------------------------------------------
+                        // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+                        if(U_dU_attr.second != real_type(0.0))
+                        {
+                            const auto coef = -f3 * fCS * U_dU_attr.second;
+                            sys.force_thread(thread_id, Bi)      += coef * Bj5i_reg;
+                            sys.force_thread(thread_id, Bj_next) -= coef * Bj5i_reg;
+                        }
+                    }
+                }
+                if(Bi_next_exists)
+                {
+                    // ------------------------------------------------------------
+                    // 3' cross stacking (the case `Bi` is in a sense strand)
+                    //
+                    //       Si   Bi   Bj   Sj
+                    //  5'    o--> o===o <--o     3'
+                    //  ^    /        /--'   \    |
+                    //  | P o        /  tCS   o P |
+                    //  |    \      /        /    v
+                    //  3'    o -- o===o -- o     5'
+                    //           Bi3   Bj5
+                    //
+                    // Hereafter, we use the notation illustrated above (excepting
+                    // the index `Bi_next` that corresponds to Bi3).
+
+                    const auto cs_kind = para.cs_j_kind;
+
+                    const auto& rBi3     = sys.position(Bi_next);
+                    const auto  Bi3j     = sys.adjust_direction(rBj - rBi3);
+                    const auto  lBi3j_sq = math::length_sq(Bi3j); // |Bi3j|^2
+                    const auto  rlBi3j   = math::rsqrt(lBi3j_sq);  // 1 / |Bi3j|
+
+                    const auto dot_theta_CS = math::dot_product(SBj, Bi3j);
+                    const auto cos_theta_CS = dot_theta_CS * rlSBj * rlBi3j;
+                    const auto theta_CS     =
+                        std::acos(math::clamp<real_type>(cos_theta_CS, -1, 1));
+                    const auto theta_CS_0   = potential_.thetaCS_0(cs_kind);
+
+                    const auto fCS = potential_.f(cs_kind, theta_CS, theta_CS_0);
+                    // if f == 0, df is also zero. if fCS == 0, no force there
+                    if(fCS != real_type(0))
+                    {
+                        const auto dfCS  = potential_.df(cs_kind, theta_CS, theta_CS_0);
+                        const auto lBi3j = lBi3j_sq * rlBi3j;
+                        const auto U_dU_attr = potential_.U_dU_attr(cs_kind, lBi3j);
+                        const auto Bi3j_reg  = rlBi3j * Bi3j;
+
+                        // --------------------------------------------------------
+                        // df/dtheta3 f(theta_CS)  U_attr(eps, alp, rij) dtheta_3 /dr
+                        if(df3 != real_type(0))
+                        {
+                            const auto coef = -df3 * fCS * U_dU_attr.first;
+                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
+                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
+                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
+                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                        }
+                        // --------------------------------------------------------
+                        // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
+                        if(dfCS != real_type(0))
+                        {
+                            const auto coef         = -f3 * dfCS * U_dU_attr.first;
+                            const auto sin_theta_CS = std::sin(theta_CS);
+                            const auto coef_rsin    = (sin_theta_CS > tolerance) ?
+                                       (coef / sin_theta_CS) : (coef / tolerance);
+
+                            const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
+                            const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
+                            sys.force_thread(thread_id, Sj)      += fSj;
+                            sys.force_thread(thread_id, Bj)      -= (fSj + fBi3);
+                            sys.force_thread(thread_id, Bi_next) += fBi3;
+                        }
+                        // --------------------------------------------------------
+                        // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
+                        if(U_dU_attr.second != real_type(0.0))
+                        {
+                            const auto coef = -f3 * fCS * U_dU_attr.second;
+                            sys.force_thread(thread_id, Bj)      += coef * Bi3j_reg;
+                            sys.force_thread(thread_id, Bi_next) -= coef * Bi3j_reg;
+                        }
+                    }
+                }
+            }
+        }
+        return energy;
+    }
+
+
+
     std::string name() const override {return "3SPN2BaseBase";}
 
     potential_type const& potential() const noexcept {return potential_;}

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -45,6 +45,9 @@ set(TEST_NAMES
     test_3spn2_base_stacking_interaction
     test_3spn2_base_base_interaction
     test_global_pair_interaction
+    test_global_pair_excluded_volume_interaction
+    test_global_pair_lennard_jones_interaction
+    test_global_pair_uniform_lennard_jones_interaction
     test_pdns_interaction
     test_pwmcos_interaction
     test_position_restraint_interaction

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_NAMES
     test_global_pair_uniform_lennard_jones_interaction
     test_pdns_interaction
     test_pwmcos_interaction
+    test_external_distance_interaction
     test_position_restraint_interaction
     test_afm_fitting_interaction
     test_rectangular_box_interaction

--- a/test/core/test_3spn2_base_base_interaction.cpp
+++ b/test/core/test_3spn2_base_base_interaction.cpp
@@ -795,3 +795,650 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_numerical_diff,
         } // rcsi
     } // bp_kind
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_energy_and_force,
+        ParameterSet, parameters_to_test)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_3spn2_base_base_interaction.log");
+
+    using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type         = traits_type::real_type;
+    using coord_type        = traits_type::coordinate_type;
+    using boundary_type     = traits_type::boundary_type;
+    using system_type       = mjolnir::System<traits_type>;
+    using topology_type     = mjolnir::Topology;
+
+    using potential_type      = mjolnir::ThreeSPN2BaseBaseInteractionPotential<traits_type>;
+    using base_kind           = typename potential_type::base_kind;
+    using parameter_type      = typename potential_type::parameter_type;
+    using partition_type      = mjolnir::VerletList<traits_type, potential_type>;
+
+    using interaction_type     = mjolnir::ThreeSPN2BaseBaseInteraction<traits_type>;
+    using ignore_group_type    = typename potential_type::ignore_group_type;
+    using ignore_molecule_type = typename potential_type::ignore_molecule_type;
+
+    constexpr real_type pi = mjolnir::math::constants<real_type>::pi();
+
+    {
+        using unit_type = mjolnir::unit::constants<real_type>;
+        using phys_type = mjolnir::physics::constants<real_type>;
+        const std::string energy = "kcal/mol";
+        const std::string length = "angstrom";
+        phys_type::set_kB(phys_type::kB() * (unit_type::J_to_cal() / 1000.0) *
+                          unit_type::avogadro_constant());
+        phys_type::set_eps0(phys_type::eps0() * (1000.0 / unit_type::J_to_cal()) /
+                            unit_type::avogadro_constant());
+        phys_type::set_energy_unit(energy);
+
+        phys_type::set_eps0(phys_type::eps0() / unit_type::m_to_angstrom());
+
+        phys_type::set_m_to_length(unit_type::m_to_angstrom());
+        phys_type::set_length_to_m(unit_type::angstrom_to_m());
+
+        phys_type::set_L_to_volume(1e-3 * std::pow(unit_type::m_to_angstrom(), 3));
+        phys_type::set_volume_to_L(1e+3 * std::pow(unit_type::angstrom_to_m(), 3));
+
+        phys_type::set_length_unit(length);
+    }
+
+    // Here, this test case checks base pairing interaction only.
+    //
+    //  theta1    theta2
+    //       |    |
+    // Si o  v    v o Sj
+    //     \-.   .-/
+    //      o === o
+    //     Bi  r  Bj
+    //
+    // Required test cases are the combination of the following conditions
+    //
+    // BasePairing:
+    // rij:
+    //  1. (r < r0)
+    //  2. (r0 < r)
+    // theta1:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+    // theta2:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(const auto bases : {
+            std::vector<base_kind>{base_kind::A, base_kind::T},
+            std::vector<base_kind>{base_kind::T, base_kind::A},
+            std::vector<base_kind>{base_kind::C, base_kind::G},
+            std::vector<base_kind>{base_kind::G, base_kind::C}
+            })
+    {
+        //  theta1    theta2
+        //       |    |
+        //  0 o  v    v o 2
+        //     \-.   .-/
+        //      o === o
+        //     1       3
+        //
+        constexpr auto invalid = potential_type::invalid();
+
+        potential_type potential(ParameterSet{}, {
+                {1, parameter_type{bases.at(0), 0, 0, invalid, invalid}},
+                {3, parameter_type{bases.at(1), 1, 2, invalid, invalid}}
+            }, {}, ignore_molecule_type("Nothing"), ignore_group_type({})
+        );
+
+        interaction_type interaction(potential_type(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        system_type sys(4, boundary_type{});
+        topology_type topol(4);
+
+        topol.add_connection(0, 1, "bond");
+        topol.add_connection(2, 3, "bond");
+        topol.construct_molecules();
+
+        for(std::size_t i=0; i<4; ++i)
+        {
+            sys.mass(i)  = 1.0;
+            sys.rmass(i) = 1.0;
+            sys.position(i) = coord_type(0.0, 0.0, 0.0);
+            sys.velocity(i) = coord_type(0.0, 0.0, 0.0);
+            sys.force(i)    = coord_type(0.0, 0.0, 0.0);
+            sys.name(i)  = "DNA";
+            sys.group(i) = "DNA";
+        }
+        potential  .initialize(sys, topol);
+        interaction.initialize(sys, topol);
+
+        const auto bp_kind      = potential.bp_kind (bases.at(0), bases.at(1));
+        const auto rbp_0        = potential.r0(bp_kind);
+        const auto theta1_0     = potential.theta1_0(bp_kind);
+        const auto theta2_0     = potential.theta2_0(bp_kind);
+        const auto pi_over_K_BP = potential.pi_over_K_BP();
+
+        for(const auto rbp  : {rbp_0 - 0.2, rbp_0 + 0.5})
+        {
+        for(const auto theta1 : {theta1_0 + pi_over_K_BP * 0.2,
+                                 theta1_0 + pi_over_K_BP * 0.7,
+                                 theta1_0 + pi_over_K_BP * 1.2,
+                                 theta1_0 - pi_over_K_BP * 1.2,
+                                 theta1_0 - pi_over_K_BP * 0.7,
+                                 theta1_0 - pi_over_K_BP * 0.2})
+        {
+        for(const auto theta2 : {theta2_0 + pi_over_K_BP * 0.2,
+                                 theta2_0 + pi_over_K_BP * 0.7,
+                                 theta2_0 + pi_over_K_BP * 1.2,
+                                 theta2_0 - pi_over_K_BP * 1.2,
+                                 theta2_0 - pi_over_K_BP * 0.7,
+                                 theta2_0 - pi_over_K_BP * 0.2})
+        {
+            BOOST_TEST_MESSAGE("===========================================");
+            BOOST_TEST_MESSAGE("rbp    = " << rbp);
+            BOOST_TEST_MESSAGE("theta1 = " << theta1);
+            BOOST_TEST_MESSAGE("theta2 = " << theta2);
+
+            //  theta1    theta2
+            //       |    |
+            //  0 o  v    v o 2
+            //     \-.   .-/
+            //      o === o
+            //     1       3
+            //
+            sys.position(1) = coord_type(0.0, 0.0, 0.0);
+            sys.position(3) = coord_type(rbp, 0.0, 0.0);
+
+            sys.position(0) = coord_type(std::cos(theta1),          std::sin(theta1),    0.0);
+            sys.position(2) = coord_type(std::cos(pi-theta2) + rbp, std::sin(pi-theta2), 0.0);
+
+            // rotate in random direction
+            {
+                using matrix33_type = typename traits_type::matrix33_type;
+
+                const auto rot_x = uni(mt) * pi;
+                const auto rot_y = uni(mt) * pi;
+                const auto rot_z = uni(mt) * pi;
+
+                matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                     0.0, std::cos(rot_x), -std::sin(rot_x),
+                                     0.0, std::sin(rot_x),  std::cos(rot_x));
+                matrix33_type rotm_y( std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                                  0.0, 1.0,              0.0,
+                                     -std::sin(rot_y), 0.0,  std::cos(rot_y));
+                matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                     std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                                 0.0,              0.0, 1.0);
+
+                const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    sys.position(idx) = rotm * sys.position(idx);
+                }
+            }
+            // check configuration is okay
+            {
+                const auto v13 = sys.position(3) - sys.position(1);
+                BOOST_TEST_REQUIRE(mjolnir::math::length(v13) == rbp,
+                                   boost::test_tools::tolerance(1e-3));
+
+                const auto v10 = sys.position(0) - sys.position(1);
+                const auto cos_013 = mjolnir::math::dot_product(v13, v10) /
+                    (mjolnir::math::length(v13) * mjolnir::math::length(v10));
+                BOOST_TEST_REQUIRE(std::acos(cos_013) == theta1,
+                                   boost::test_tools::tolerance(1e-3));
+
+                const auto v23 = sys.position(3) - sys.position(2);
+                const auto cos_132 = mjolnir::math::dot_product(v13, v23) /
+                    (mjolnir::math::length(v13) * mjolnir::math::length(v23));
+                BOOST_TEST_REQUIRE(std::acos(cos_132) == theta2,
+                                   boost::test_tools::tolerance(1e-3));
+            }
+
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+                sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
+            }
+            system_type ref_sys = sys;
+
+            constexpr real_type tol = 1e-4;
+
+            const auto energy = interaction.calc_force_and_energy(sys);
+            const auto ref_energy = interaction.calc_energy(ref_sys);
+            interaction.calc_force(ref_sys);
+            BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+        } // theta2
+        } // theta1
+        } // rbp
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force,
+        ParameterSet, parameters_to_test)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_3spn2_base_base_interaction.log");
+
+    using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type         = traits_type::real_type;
+    using coord_type        = traits_type::coordinate_type;
+    using boundary_type     = traits_type::boundary_type;
+    using system_type       = mjolnir::System<traits_type>;
+    using topology_type     = mjolnir::Topology;
+
+    using potential_type    = mjolnir::ThreeSPN2BaseBaseInteractionPotential<traits_type>;
+    using base_kind         = typename potential_type::base_kind;
+    using parameter_type    = typename potential_type::parameter_type;
+    using partition_type      = mjolnir::VerletList<traits_type, potential_type>;
+
+    using interaction_type     = mjolnir::ThreeSPN2BaseBaseInteraction<traits_type>;
+    using ignore_group_type    = typename potential_type::ignore_group_type;
+    using ignore_molecule_type = typename potential_type::ignore_molecule_type;
+
+    constexpr real_type pi = mjolnir::math::constants<real_type>::pi();
+
+    {
+        using unit_type = mjolnir::unit::constants<real_type>;
+        using phys_type = mjolnir::physics::constants<real_type>;
+        const std::string energy = "kcal/mol";
+        const std::string length = "angstrom";
+        phys_type::set_kB(phys_type::kB() * (unit_type::J_to_cal() / 1000.0) *
+                          unit_type::avogadro_constant());
+        phys_type::set_eps0(phys_type::eps0() * (1000.0 / unit_type::J_to_cal()) /
+                            unit_type::avogadro_constant());
+        phys_type::set_energy_unit(energy);
+
+        phys_type::set_eps0(phys_type::eps0() / unit_type::m_to_angstrom());
+
+        phys_type::set_m_to_length(unit_type::m_to_angstrom());
+        phys_type::set_length_to_m(unit_type::angstrom_to_m());
+
+        phys_type::set_L_to_volume(1e-3 * std::pow(unit_type::m_to_angstrom(), 3));
+        phys_type::set_volume_to_L(1e+3 * std::pow(unit_type::angstrom_to_m(), 3));
+
+        phys_type::set_length_unit(length);
+    }
+
+    //       Si   Bi   Bj   Sj
+    //  5'    o -- o===o -- o     3'
+    //  ^    /      \ /      \    |
+    //  | P o        X        o P |
+    //  |    \      / \      /    v
+    //  3'    o -- o===o -- o     5'
+    //       Bj_next   Bj_next
+    //
+    // Required test cases are the combination of the following conditions
+    //
+    // CrossStacking
+    // theta3:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+    // thetaCS_i:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+    // thetaCS_j:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+    // thetaCS_j:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+    // ri_jnext
+    //  1. (r < r0)
+    //  2. (r0 < r)
+    // rj_inext
+    //  1. (r < r0)
+    //  2. (r0 < r)
+    //
+    // Oh, okay, we have 3^4 * 2^2 = 324 test configurations.
+    //
+    // Also, this interaction is a sum of two, BasePairing and CrossStacking.
+    // This makes numeric differentiation unstable.
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(const auto bases : {
+            std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::G, base_kind::G},
+            std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::C, base_kind::C},
+            std::vector<base_kind>{base_kind::T, base_kind::A, base_kind::G, base_kind::G},
+            std::vector<base_kind>{base_kind::T, base_kind::A, base_kind::C, base_kind::C},
+            std::vector<base_kind>{base_kind::C, base_kind::G, base_kind::A, base_kind::A},
+            std::vector<base_kind>{base_kind::C, base_kind::G, base_kind::T, base_kind::T},
+            std::vector<base_kind>{base_kind::G, base_kind::C, base_kind::A, base_kind::A},
+            std::vector<base_kind>{base_kind::G, base_kind::C, base_kind::T, base_kind::T}
+        })
+    {
+        //        0    1   9    8
+        //  5'    o -- o===o -- o     3'
+        //  ^    /      \ /      \    |
+        //  | 2 o        X        o 7 |
+        //  |    \      / \      /    v
+        //  3'    o -- o===o -- o     5'
+        //        3    4   6    5
+
+        constexpr auto invalid = potential_type::invalid();
+
+        potential_type potential(ParameterSet{}, {
+                {1, parameter_type{bases.at(0), 0, 0, 4, invalid}},
+                {9, parameter_type{bases.at(1), 3, 8, invalid, 6}},
+                {4, parameter_type{bases.at(2), 1, 3, invalid, 1}},
+                {6, parameter_type{bases.at(3), 2, 5, 9, invalid}},
+            }, {}, ignore_molecule_type("Nothing"), ignore_group_type({})
+        );
+
+        interaction_type interaction(potential_type(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        system_type sys(10, boundary_type{});
+        topology_type topol(10);
+
+        topol.add_connection(0, 1, "bond");
+        topol.add_connection(0, 2, "bond");
+        topol.add_connection(2, 3, "bond");
+        topol.add_connection(3, 4, "bond");
+
+        topol.add_connection(5, 6, "bond");
+        topol.add_connection(5, 7, "bond");
+        topol.add_connection(7, 8, "bond");
+        topol.add_connection(8, 9, "bond");
+
+        topol.add_connection(0, 2, "next_nucl");
+        topol.add_connection(1, 2, "next_nucl");
+        topol.add_connection(0, 3, "next_nucl");
+        topol.add_connection(1, 3, "next_nucl");
+        topol.add_connection(0, 4, "next_nucl");
+        topol.add_connection(1, 4, "next_nucl");
+
+        topol.add_connection(5, 7, "next_nucl");
+        topol.add_connection(6, 7, "next_nucl");
+        topol.add_connection(5, 8, "next_nucl");
+        topol.add_connection(6, 8, "next_nucl");
+        topol.add_connection(5, 9, "next_nucl");
+        topol.add_connection(6, 9, "next_nucl");
+
+        topol.construct_molecules();
+
+        for(std::size_t i=0; i<10; ++i)
+        {
+            sys.mass(i)  = 1.0;
+            sys.rmass(i) = 1.0;
+            sys.position(i) = coord_type(0.0, 0.0, 0.0);
+            sys.velocity(i) = coord_type(0.0, 0.0, 0.0);
+            sys.force(i)    = coord_type(0.0, 0.0, 0.0);
+            sys.name(i)  = "DNA";
+            sys.group(i) = "DNA";
+        }
+        potential  .initialize(sys, topol);
+        interaction.initialize(sys, topol);
+
+        const auto bp_kind      = potential.bp_kind (bases.at(0), bases.at(1));
+        const auto cs_i_kind    = potential.cs5_kind(bases.at(0), bases.at(3));
+        const auto cs_j_kind    = potential.cs3_kind(bases.at(1), bases.at(2));
+
+        const auto rbp          = potential.r0(bp_kind) + 0.2;
+        const auto rcs_i_0      = potential.r0(cs_i_kind);
+        const auto rcs_j_0      = potential.r0(cs_j_kind);
+        const auto theta1       = potential.theta1_0(bp_kind);
+        const auto theta2       = potential.theta2_0(bp_kind);
+        const auto theta3_0     = potential.theta3_0(bp_kind);
+        const auto thetaCS_i_0  = potential.thetaCS_0(cs_i_kind);
+        const auto thetaCS_j_0  = potential.thetaCS_0(cs_j_kind);
+
+        const auto pi_over_K_BP = potential.pi_over_K_BP();
+        const auto pi_over_K_CS = potential.pi_over_K_CS();
+
+        for(const auto rcsi : {rcs_i_0 - 0.2, rcs_i_0 + 0.5})
+        {
+        for(const auto rcsj : {rcs_j_0 - 0.2, rcs_j_0 + 0.5})
+        {
+        for(const auto theta3 : {theta3_0 + pi_over_K_BP * 0.1, theta3_0 + pi_over_K_BP * 0.6, theta3_0 + pi_over_K_BP * 1.1})
+        {
+        for(const auto thetaCS_i : {thetaCS_i_0 - pi_over_K_CS * 0.1, thetaCS_i_0 - pi_over_K_CS * 0.6, thetaCS_i_0 - pi_over_K_CS * 1.1})
+        {
+        for(const auto thetaCS_j : {thetaCS_j_0 + pi_over_K_CS * 0.1, thetaCS_j_0 + pi_over_K_CS * 0.6, thetaCS_j_0 + pi_over_K_CS * 1.1})
+        {
+            BOOST_TEST_REQUIRE(0.0 <= theta3   );BOOST_TEST_REQUIRE(theta3    <= pi);
+            BOOST_TEST_REQUIRE(0.0 <= thetaCS_i);BOOST_TEST_REQUIRE(thetaCS_i <= pi);
+            BOOST_TEST_REQUIRE(0.0 <= thetaCS_j);BOOST_TEST_REQUIRE(thetaCS_j <= pi);
+
+            // generate positions...
+            //        0    1   9    8
+            //  5'    o -- o===o -- o     3'
+            //  ^    /      \ /      \    |
+            //  | 2 o        X        o 7 |
+            //  |    \      / \      /    v
+            //  3'    o -- o===o -- o     5'
+            //        3    4   6    5
+
+            sys.position(1) = coord_type(0.0, 0.0, 0.0);
+            sys.position(9) = coord_type(0.0, 0.0, 0.0);
+
+            sys.position(0) = coord_type(4.0 * std::cos(theta1),
+                                         4.0 * std::sin(theta1), 0.0);
+            sys.position(8) = coord_type(4.0 * std::cos(pi - theta2),
+                                         4.0 * std::sin(pi - theta2), 0.0);
+            // rotate around x axis
+            // to make angle between 0->1 and 8->9 theta3
+            {
+                using matrix33_type = typename traits_type::matrix33_type;
+                real_type best_phi = 0.0;
+                real_type dtheta   = std::numeric_limits<real_type>::max();
+                const auto bck = sys;
+                for(int i=-999; i<1000; ++i)
+                {
+                    const real_type phi = pi * 0.001 * i;
+                    const matrix33_type rot(
+                       1.0,           0.0,           0.0,
+                       0.0, std::cos(phi), -std::sin(phi),
+                       0.0, std::sin(phi),  std::cos(phi));
+
+                    sys.position(8) = rot * sys.position(8);
+                    sys.position(9) = rot * sys.position(9);
+
+                    const auto v01 = sys.position(1) - sys.position(0);
+                    const auto v89 = sys.position(9) - sys.position(8);
+                    const auto theta_0189 = std::acos(mjolnir::math::clamp<real_type>(
+                         mjolnir::math::dot_product(v01, v89) /
+                        (mjolnir::math::length(v01) * mjolnir::math::length(v89)),
+                        -1.0, 1.0));
+
+                    BOOST_TEST_MESSAGE("dtheta = " << dtheta << ", current configuration = " << std::abs(theta_0189 - theta3));
+
+                    if(std::abs(theta_0189 - theta3) < dtheta)
+                    {
+                        dtheta   = std::abs(theta_0189 - theta3);
+                        best_phi = phi;
+                    }
+                    sys = bck;
+                }
+
+                BOOST_TEST_MESSAGE("best_phi = " << best_phi << ", dtheta = " << dtheta);
+
+                {
+                    const matrix33_type rot(
+                            1.0,                0.0,                 0.0,
+                            0.0, std::cos(best_phi), -std::sin(best_phi),
+                            0.0, std::sin(best_phi),  std::cos(best_phi));
+                    sys.position(8) = rot * sys.position(8);
+                    sys.position(9) = rot * sys.position(9);
+                }
+
+                mjolnir::math::X(sys.position(4)) += rbp;
+                mjolnir::math::X(sys.position(8)) += rbp;
+                mjolnir::math::X(sys.position(9)) += rbp;
+            }
+
+            {
+                using matrix33_type = typename traits_type::matrix33_type;
+                const auto v01 = sys.position(1) - sys.position(0);
+                const auto v89 = sys.position(9) - sys.position(8);
+                const auto n4 = mjolnir::math::cross_product(coord_type(0.0, 0.0, 1.0), v89);
+                const auto n6 = mjolnir::math::cross_product(coord_type(0.0, 0.0, 1.0), v01);
+
+                const auto n4_reg = n4 / mjolnir::math::length(n4);
+                const auto n6_reg = n6 / mjolnir::math::length(n6);
+
+                coord_type v16 = v01 / mjolnir::math::length(v01);
+                coord_type v94 = v89 / mjolnir::math::length(v89);
+                {
+                    const auto cos_theta = std::cos(pi - thetaCS_i);
+                    const auto sin_theta = std::sin(pi - thetaCS_i);
+
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(n6_reg) == 1.0, boost::test_tools::tolerance(1e-8));
+                    const auto nx = mjolnir::math::X(n6_reg);
+                    const auto ny = mjolnir::math::Y(n6_reg);
+                    const auto nz = mjolnir::math::Z(n6_reg);
+                    const matrix33_type rot_16(
+                        cos_theta + nx*nx*(1-cos_theta),    nx*ny*(1-cos_theta) - nz*sin_theta, nx*nz*(1-cos_theta) + ny*sin_theta,
+                        ny*nx*(1-cos_theta) + nz*sin_theta, cos_theta + ny*ny*(1-cos_theta),    ny*nz*(1-cos_theta) - nx*sin_theta,
+                        nz*nx*(1-cos_theta) - ny*sin_theta, nz*ny*(1-cos_theta) + nx*sin_theta, cos_theta + nz*nz*(1-cos_theta));
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(v16) == 1.0, boost::test_tools::tolerance(1e-8));
+                    v16 = rot_16 * v16;
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(v16) == 1.0, boost::test_tools::tolerance(1e-8));
+                }
+                {
+                    const auto cos_theta = std::cos(pi - thetaCS_j);
+                    const auto sin_theta = std::sin(pi - thetaCS_j);
+
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(n4_reg) == 1.0, boost::test_tools::tolerance(1e-8));
+                    const auto nx = mjolnir::math::X(n4_reg);
+                    const auto ny = mjolnir::math::Y(n4_reg);
+                    const auto nz = mjolnir::math::Z(n4_reg);
+
+                    const matrix33_type rot_94(
+                        cos_theta + nx*nx*(1-cos_theta),    nx*ny*(1-cos_theta) - nz*sin_theta, nx*nz*(1-cos_theta) + ny*sin_theta,
+                        ny*nx*(1-cos_theta) + nz*sin_theta, cos_theta + ny*ny*(1-cos_theta),    ny*nz*(1-cos_theta) - nx*sin_theta,
+                        nz*nx*(1-cos_theta) - ny*sin_theta, nz*ny*(1-cos_theta) + nx*sin_theta, cos_theta + nz*nz*(1-cos_theta));
+
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(v94) == 1.0, boost::test_tools::tolerance(1e-8));
+                    v94 = rot_94 * v94;
+                    BOOST_TEST_REQUIRE(mjolnir::math::length(v94) == 1.0, boost::test_tools::tolerance(1e-8));
+                }
+                sys.position(4) = sys.position(9) + v94 * rcsj;
+                sys.position(6) = sys.position(1) + v16 * rcsi;
+            }
+
+            // check the configurations are okay
+            {
+                const auto v19 = sys.position(9) - sys.position(1);
+                BOOST_TEST_REQUIRE(mjolnir::math::length(v19) == rbp,
+                           boost::test_tools::tolerance(0.01));
+
+                const auto v01 = sys.position(1) - sys.position(0);
+                const auto v89 = sys.position(9) - sys.position(8);
+                {
+                    const auto dot = mjolnir::math::dot_product(v01, v89);
+                    const auto cos_theta = dot /
+                        (mjolnir::math::length(v01) * mjolnir::math::length(v89));
+                    const auto theta = std::acos(cos_theta);
+                    BOOST_TEST_REQUIRE(theta == theta3, boost::test_tools::tolerance(0.01));
+                }
+
+                {
+                    const auto dot = mjolnir::math::dot_product(-v01, v19);
+                    const auto cos_theta = dot /
+                        (mjolnir::math::length(v01) * mjolnir::math::length(v19));
+                    const auto theta = std::acos(cos_theta);
+                    BOOST_TEST_REQUIRE(theta == theta1, boost::test_tools::tolerance(0.01));
+                }
+                {
+                    const auto dot = mjolnir::math::dot_product(v89, v19);
+                    const auto cos_theta = dot /
+                        (mjolnir::math::length(v89) * mjolnir::math::length(v19));
+                    const auto theta = std::acos(cos_theta);
+                    BOOST_TEST_REQUIRE(theta == theta2, boost::test_tools::tolerance(0.01));
+                }
+
+                const auto v61 = sys.position(1) - sys.position(6);
+                BOOST_TEST_REQUIRE(mjolnir::math::length(v61) == rcsi,
+                                   boost::test_tools::tolerance(0.01));
+                {
+                    const auto dot = mjolnir::math::dot_product(
+                            v01 / mjolnir::math::length(v01),
+                            v61 / mjolnir::math::length(v61));
+                    const auto theta = std::acos(dot);
+                    BOOST_TEST_REQUIRE(theta == thetaCS_i,
+                            boost::test_tools::tolerance(0.01));
+                }
+                const auto v49 = sys.position(9) - sys.position(4);
+                BOOST_TEST_REQUIRE(mjolnir::math::length(v49) == rcsj,
+                           boost::test_tools::tolerance(0.01));
+                {
+                    const auto dot = mjolnir::math::dot_product(
+                            v89 / mjolnir::math::length(v89),
+                            v49 / mjolnir::math::length(v49));
+                    const auto theta = std::acos(dot);
+                    BOOST_TEST_REQUIRE(theta == thetaCS_j, boost::test_tools::tolerance(0.01));
+                }
+            }
+
+            // positions generated!
+            // ... and then rotate random direction to remove special axis
+            {
+                using matrix33_type = typename traits_type::matrix33_type;
+
+                const auto rot_x = uni(mt) * pi;
+                const auto rot_y = uni(mt) * pi;
+                const auto rot_z = uni(mt) * pi;
+
+                matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                     0.0, std::cos(rot_x), -std::sin(rot_x),
+                                     0.0, std::sin(rot_x),  std::cos(rot_x));
+                matrix33_type rotm_y( std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                                  0.0, 1.0,              0.0,
+                                     -std::sin(rot_y), 0.0,  std::cos(rot_y));
+                matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                     std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                                 0.0,              0.0, 1.0);
+
+                const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    sys.position(idx) = rotm * sys.position(idx);
+                }
+            }
+
+            // add perturbation and reset force
+            for(std::size_t idx=0; idx<10; ++idx)
+            {
+                sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+                sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
+            }
+            system_type ref_sys = sys;
+
+            constexpr real_type tol = 1e-4;
+
+            const auto energy = interaction.calc_force_and_energy(sys);
+            const auto ref_energy = interaction.calc_energy(ref_sys);
+            interaction.calc_force(ref_sys);
+            BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+        } // thetaCS_j
+        } // thetaCS_i
+        } // theta3
+        } // rcsj
+        } // rcsi
+    } // bp_kind
+}

--- a/test/core/test_3spn2_base_stacking_interaction.cpp
+++ b/test/core/test_3spn2_base_stacking_interaction.cpp
@@ -313,3 +313,208 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_numerical_diff,
         } // r
     }
 }
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_energy,
+        ParameterSet, parameter_set_to_test)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_3spn2_base_stacking_interaction.log");
+
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coord_type       = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using interaction_type = mjolnir::ThreeSPN2BaseStackingInteraction<traits_type>;
+    using potential_type   = mjolnir::ThreeSPN2BaseStackingPotential<real_type>;
+    using base_stack_kind  = typename potential_type::base_stack_kind;
+
+    {
+        using unit_type = mjolnir::unit::constants<real_type>;
+        using phys_type = mjolnir::physics::constants<real_type>;
+        const std::string energy = "kcal/mol";
+        const std::string length = "angstrom";
+        phys_type::set_kB(phys_type::kB() * (unit_type::J_to_cal() / 1000.0) *
+                          unit_type::avogadro_constant());
+        phys_type::set_eps0(phys_type::eps0() * (1000.0 / unit_type::J_to_cal()) /
+                            unit_type::avogadro_constant());
+        phys_type::set_energy_unit(energy);
+
+        phys_type::set_eps0(phys_type::eps0() / unit_type::m_to_angstrom());
+
+        phys_type::set_m_to_length(unit_type::m_to_angstrom());
+        phys_type::set_length_to_m(unit_type::angstrom_to_m());
+
+        phys_type::set_L_to_volume(1e-3 * std::pow(unit_type::m_to_angstrom(), 3));
+        phys_type::set_volume_to_L(1e+3 * std::pow(unit_type::angstrom_to_m(), 3));
+
+        phys_type::set_length_unit(length);
+    }
+
+    //        SBi
+    //     Si --> Bi
+    //    /     `-^
+    //   Pj theta | rij
+    //    \       |
+    //     Sj --- Bj
+    //
+    //  rij:
+    //  1. (r < r0)
+    //  2. (r0 < r)
+    //  theta:
+    //  1. theta < pi/2K
+    //  2. pi/2K < theta < pi/K
+    //  3. pi/K  < theta
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+    constexpr real_type pi = mjolnir::math::constants<real_type>::pi();
+
+    for(const auto bs_kind : {base_stack_kind::AA, base_stack_kind::AT,
+                              base_stack_kind::AG, base_stack_kind::AC,
+                              base_stack_kind::TA, base_stack_kind::TT,
+                              base_stack_kind::TG, base_stack_kind::TC,
+                              base_stack_kind::GA, base_stack_kind::GT,
+                              base_stack_kind::GG, base_stack_kind::GC,
+                              base_stack_kind::CA, base_stack_kind::CT,
+                              base_stack_kind::CG, base_stack_kind::CC})
+    {
+        potential_type   potential(ParameterSet{});
+        interaction_type interaction("none",
+                std::vector<std::pair<std::array<std::size_t, 3>, base_stack_kind>>{
+                    { {{0, 1, 2}}, bs_kind }
+                }, potential_type(potential), {});
+
+        system_type sys(3, boundary_type{});
+
+        sys.mass(0) = 1.0;
+        sys.mass(1) = 1.0;
+        sys.mass(2) = 1.0;
+
+        sys.rmass(0) = 1.0;
+        sys.rmass(1) = 1.0;
+        sys.rmass(2) = 1.0;
+
+        sys.position(0) = coord_type(0.0, 0.0, 0.0);
+        sys.position(1) = coord_type(0.0, 0.0, 0.0);
+        sys.position(2) = coord_type(0.0, 0.0, 0.0);
+
+        sys.velocity(0) = coord_type(0.0, 0.0, 0.0);
+        sys.velocity(1) = coord_type(0.0, 0.0, 0.0);
+        sys.velocity(2) = coord_type(0.0, 0.0, 0.0);
+
+        sys.force(0)    = coord_type(0.0, 0.0, 0.0);
+        sys.force(1)    = coord_type(0.0, 0.0, 0.0);
+        sys.force(2)    = coord_type(0.0, 0.0, 0.0);
+
+        sys.name(0)  = "Si";
+        sys.name(1)  = "Bi";
+        sys.name(2)  = "Bj";
+        sys.group(0) = "DNA";
+        sys.group(1) = "DNA";
+        sys.group(2) = "DNA";
+
+        potential.initialize(sys);
+        interaction.initialize(sys);
+
+        const auto theta0    = potential.theta_0(bs_kind);
+        const auto pi_over_K = potential.pi_over_K_BS();
+        const auto theta0_1  = theta0 + 0.2 * pi_over_K; //         dtheta < pi/2K
+        const auto theta0_2  = theta0 + 0.7 * pi_over_K; // pi/2K < dtheta < pi/K
+        const auto theta0_3  = theta0 + 1.2 * pi_over_K; // pi/K  < dtheta
+        const auto r0_1      = potential.r0(bs_kind) - 0.2;
+        const auto r0_2      = potential.r0(bs_kind) + 0.5;
+
+        for(const auto r : {r0_1, r0_2})
+        {
+        for(const auto theta : {theta0_1, theta0_2, theta0_3})
+        {
+            BOOST_TEST_MESSAGE("======================================");
+            BOOST_TEST_MESSAGE("r = " << r << ", theta = " << theta);
+
+        for(std::size_t i=0; i<100; ++i)
+        {
+            // generate particle configuration in the following way
+            //    y
+            // Bj ^
+            //  \ | theta0
+            // r0\|-.
+            // ---o-----o--> x
+            //  Bi      Si
+            //
+
+            sys.position(0) = coord_type(4.0, 0.0, 0.0); // Si
+            sys.position(1) = coord_type(0.0, 0.0, 0.0); // Bi
+            sys.position(2) = coord_type(r * std::cos(theta), r * std::sin(theta), 0.0); // Bj
+            sys.force(0) = coord_type(0.0, 0.0, 0.0);
+            sys.force(1) = coord_type(0.0, 0.0, 0.0);
+            sys.force(2) = coord_type(0.0, 0.0, 0.0);
+
+            // ... and then rotate random direction to remove special axis
+            //
+            // Do this thousand times with different random numbers!
+            {
+                using matrix33_type = typename traits_type::matrix33_type;
+
+                const auto rot_x = uni(mt) * pi;
+                const auto rot_y = uni(mt) * pi;
+                const auto rot_z = uni(mt) * pi;
+
+                matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                     0.0, std::cos(rot_x), -std::sin(rot_x),
+                                     0.0, std::sin(rot_x),  std::cos(rot_x));
+                matrix33_type rotm_y( std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                                  0.0, 1.0,              0.0,
+                                     -std::sin(rot_y), 0.0,  std::cos(rot_y));
+                matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                     std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                                 0.0,              0.0, 1.0);
+
+                const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+                sys.position(0) = rotm * sys.position(0);
+                sys.position(1) = rotm * sys.position(1);
+                sys.position(2) = rotm * sys.position(2);
+
+                BOOST_TEST(mjolnir::math::length(sys.position(0)) == 4.0,
+                           boost::test_tools::tolerance(1e-6));
+                BOOST_TEST(mjolnir::math::length(sys.position(1)) == 0.0,
+                           boost::test_tools::tolerance(1e-6));
+                BOOST_TEST(mjolnir::math::length(sys.position(2)) == r,
+                           boost::test_tools::tolerance(1e-6));
+            }
+
+            sys.position(0) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.position(1) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.position(2) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+
+            BOOST_TEST(mjolnir::math::X(sys.force(0)) == 0.0);
+            BOOST_TEST(mjolnir::math::Y(sys.force(0)) == 0.0);
+            BOOST_TEST(mjolnir::math::Z(sys.force(0)) == 0.0);
+
+            BOOST_TEST(mjolnir::math::X(sys.force(1)) == 0.0);
+            BOOST_TEST(mjolnir::math::Y(sys.force(1)) == 0.0);
+            BOOST_TEST(mjolnir::math::Z(sys.force(1)) == 0.0);
+
+            BOOST_TEST(mjolnir::math::X(sys.force(2)) == 0.0);
+            BOOST_TEST(mjolnir::math::Y(sys.force(2)) == 0.0);
+            BOOST_TEST(mjolnir::math::Z(sys.force(2)) == 0.0);
+
+            auto ref_sys = sys;
+            constexpr real_type tol = 1e-4;
+
+            const auto energy = interaction.calc_force_and_energy(sys);
+            const auto ref_energy = interaction.calc_energy(ref_sys);
+            interaction.calc_force(ref_sys);
+            BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+            for(std::size_t idx=0; idx<3; ++idx)
+            {
+                BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+        } // perturbation
+        } // theta
+        } // r
+    }
+}

--- a/test/core/test_bond_length_interaction.cpp
+++ b/test/core/test_bond_length_interaction.cpp
@@ -232,3 +232,60 @@ BOOST_AUTO_TEST_CASE(BondLength_numerical_difference)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(BondLength_calc_force_and_energy)
+{
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coord_type       = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type    = mjolnir::HarmonicPotential<real_type>;
+    using interaction_type = mjolnir::BondLengthInteraction<traits_type, potential_type>;
+
+    const real_type k(100.0);
+    const real_type native(std::sqrt(3.0));
+
+    potential_type   potential(k, native);
+    interaction_type interaction("none", {{ {{0,1}}, potential}});
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t i = 0; i < 1000; ++i)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        constexpr real_type tol = 1e-4;
+        auto ref_sys = sys;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_contact_gocontact_interaction.cpp
+++ b/test/core/test_contact_gocontact_interaction.cpp
@@ -207,3 +207,62 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_numerical_difference)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(ContactGoContact_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_contact_gocontact.log");
+
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coord_type       = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::GoContactPotential<real_type>;
+    using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
+
+    const real_type k(1.0);
+    const real_type native(std::sqrt(3.0));
+
+    potential_type   potential(k, native);
+    interaction_type interaction("none", {{ {{0,1}}, potential}});
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t i = 0; i < 1000; ++i)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        constexpr real_type tol = 1e-4;
+        auto ref_sys = sys;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_contact_interaction.cpp
+++ b/test/core/test_contact_interaction.cpp
@@ -14,7 +14,7 @@
 
 BOOST_AUTO_TEST_CASE(Contact_calc_force)
 {
-    mjolnir::LoggerManager::set_default_logger("test_Contact_calc_force");
+    mjolnir::LoggerManager::set_default_logger("test_contact_calc_force");
 
     using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type        = traits_type::real_type;
@@ -106,3 +106,5 @@ BOOST_AUTO_TEST_CASE(Contact_calc_force)
         dist += dr;
     }
 }
+
+

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -281,3 +281,77 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_numerical_diff)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_calc_force_and_energy)
+{
+    using traits_type         = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type           = traits_type::real_type;
+    using coord_type          = traits_type::coordinate_type;
+    using boundary_type       = traits_type::boundary_type;
+    using system_type         = mjolnir::System<traits_type>;
+    using potential_type       = mjolnir::ClementiDihedralPotential<real_type>;
+    using dihedral_angle_type = mjolnir::DihedralAngleInteraction<traits_type, potential_type>;
+
+    const real_type k1(1e0);
+    const real_type k3(1e0);
+    const real_type native(mjolnir::math::constants<real_type>::pi() / 2.0);
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    potential_type potential{k1, k3, native};
+    dihedral_angle_type interaction("none", {{ {{0,1,2,3}}, potential}});
+
+    for(std::size_t i=0; i<100; ++i)
+    {
+        system_type sys(4, boundary_type{});
+
+        sys.mass (0) = 1.0;
+        sys.mass (1) = 1.0;
+        sys.mass (2) = 1.0;
+        sys.mass (3) = 1.0;
+        sys.rmass(0) = 1.0;
+        sys.rmass(1) = 1.0;
+        sys.rmass(2) = 1.0;
+        sys.rmass(3) = 1.0;
+
+        sys.position(0) = coord_type(2.0 + 1e-2 * uni(mt), 0.0 + 1e-2 * uni(mt),  1.0 + 1e-2 * uni(mt));
+        sys.position(1) = coord_type(1.0 + 1e-2 * uni(mt), 1.0 + 1e-2 * uni(mt),  0.0 + 1e-2 * uni(mt));
+        sys.position(2) = coord_type(0.0 + 1e-2 * uni(mt), 0.0 + 1e-2 * uni(mt),  0.0 + 1e-2 * uni(mt));
+        sys.position(3) = coord_type(1.0 + 1e-2 * uni(mt), 1.0 + 1e-2 * uni(mt), -1.0 + 1e-2 * uni(mt));
+        sys.velocity(0) = coord_type(0.0, 0.0,  0.0);
+        sys.velocity(1) = coord_type(0.0, 0.0,  0.0);
+        sys.velocity(2) = coord_type(0.0, 0.0,  0.0);
+        sys.velocity(3) = coord_type(0.0, 0.0,  0.0);
+        sys.force   (0) = coord_type(0.0, 0.0,  0.0);
+        sys.force   (1) = coord_type(0.0, 0.0,  0.0);
+        sys.force   (2) = coord_type(0.0, 0.0,  0.0);
+        sys.force   (3) = coord_type(0.0, 0.0,  0.0);
+
+        const auto init = sys;
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(2).name  = "X";
+        sys.at(3).name  = "X";
+        sys.at(0).group = "NONE";
+        sys.at(1).group = "NONE";
+        sys.at(2).group = "NONE";
+        sys.at(3).group = "NONE";
+
+        constexpr real_type tol = 1e-4;
+        auto ref_sys = sys;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_directional_contact_interaction.cpp
+++ b/test/core/test_directional_contact_interaction.cpp
@@ -228,3 +228,126 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_numerical_diff)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_directional_contact_interaction.log");
+    using traits_type              = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type                = traits_type::real_type;
+    using coord_type               = traits_type::coordinate_type;
+    using boundary_type            = traits_type::boundary_type;
+    using system_type              = mjolnir::System<traits_type>;
+    using angle_potential_type     = mjolnir::CosinePotential<real_type>;
+    using contact_potential_type   = mjolnir::GoContactPotential<real_type>;
+    using directional_contact_type = mjolnir::DirectionalContactInteraction<
+        traits_type, angle_potential_type, angle_potential_type, contact_potential_type>;
+
+    constexpr real_type pi = mjolnir::math::constants<real_type>::pi();
+    const     real_type k_angle(1e0);
+    const     real_type k_contact(1e0);
+    const     real_type angle1_native(pi);
+    const     real_type angle2_native(pi);
+    const     real_type contact_native(2.0);
+    const auto angle1_potential    = angle_potential_type{k_angle, 1, angle1_native};
+    const auto angle2_potential    = angle_potential_type{k_angle, 1, angle2_native};
+    const auto contact_potential   = contact_potential_type{k_contact, contact_native};
+    directional_contact_type interaction("none",
+        {{std::make_tuple(std::array<std::size_t, 4>{{0,1,2,3}},
+        angle1_potential, angle2_potential, contact_potential)
+        }});
+
+    system_type sys(4, boundary_type{});
+    sys.mass(0) = 1.0;
+    sys.mass(1) = 1.0;
+    sys.mass(2) = 1.0;
+    sys.mass(3) = 1.0;
+    sys.position(0) = mjolnir::math::make_coordinate<coord_type>(0.0, 0.0, 0.0);
+    sys.position(1) = mjolnir::math::make_coordinate<coord_type>(0.0, 0.0, 0.0);
+    sys.position(2) = mjolnir::math::make_coordinate<coord_type>(0.0, 0.0, 0.0);
+    sys.position(3) = mjolnir::math::make_coordinate<coord_type>(0.0, 0.0, 0.0);
+    interaction.initialize(sys);
+
+    const int angle_step_num           = 108;
+    const std::size_t contact_step_num = 10;
+    const real_type dtheta             = pi / real_type(angle_step_num);
+    const real_type contact_cutoff     = contact_potential.cutoff();
+    const real_type test_contact_range = 1.1 * contact_cutoff;
+    const real_type dr                 = test_contact_range / real_type(contact_step_num);
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t i = 0; i < angle_step_num; ++i)
+    {
+        for(std::size_t j = 0; j < angle_step_num; ++j)
+        {
+            for(std::size_t k = 1; k <= contact_step_num; ++k)
+            {
+                const real_type theta1 = i * dtheta;
+                const real_type theta2 = j * dtheta;
+                if(std::sin(theta1) < 1e-2 || std::sin(theta2) < 1e-2)
+                {
+                    // In this case, numerical error become big and difficult to
+                    // implement appropriate test. So skip.
+                    continue;
+                }
+
+                const real_type r = k * dr;
+                BOOST_TEST_MESSAGE("theta1 = " << theta1 << ", theta2 = " << pi + theta2
+                                   << ", r = " << r);
+
+                sys.position(0) = coord_type(std::cos(theta1), std::sin(theta1), 0e0);
+                sys.position(1) = coord_type(0e0, 0e0, 0e0);
+                sys.position(2) = coord_type(r, 0e0, 0e0);
+                sys.position(3) = coord_type(r - std::cos(theta2), std::sin(theta2), 0e0);
+                sys.velocity(0) = coord_type(0.0, 0.0, 0.0);
+                sys.velocity(1) = coord_type(0.0, 0.0, 0.0);
+                sys.velocity(2) = coord_type(0.0, 0.0, 0.0);
+                sys.velocity(3) = coord_type(0.0, 0.0, 0.0);
+                sys.force   (0) = coord_type(0.0, 0.0, 0.0);
+                sys.force   (1) = coord_type(0.0, 0.0, 0.0);
+                sys.force   (2) = coord_type(0.0, 0.0, 0.0);
+                sys.force   (3) = coord_type(0.0, 0.0, 0.0);
+
+
+                // rotate randomly system
+                using matrix33_type = typename traits_type::matrix33_type;
+
+                const auto rot_x = uni(mt) * pi;
+                const auto rot_y = uni(mt) * pi;
+                const auto rot_z = uni(mt) * pi;
+
+                const matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                           0.0, std::cos(rot_x), -std::sin(rot_x),
+                                           0.0, std::sin(rot_x),  std::cos(rot_x));
+                const matrix33_type rotm_y(std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                           0.0,             1.0,              0.0,
+                                          -std::sin(rot_y), 0.0,  std::cos(rot_y));
+                const matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                           std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                           0.0,              0.0,             1.0);
+
+                const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    sys.position(idx) = rotm * sys.position(idx);
+                }
+
+                interaction.update(sys);
+                constexpr real_type tol = 1e-4;
+                auto ref_sys = sys;
+
+                const auto energy = interaction.calc_force_and_energy(sys);
+                const auto ref_energy = interaction.calc_energy(ref_sys);
+                interaction.calc_force(ref_sys);
+                BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                    BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                    BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                }
+            }
+        }
+    }
+}

--- a/test/core/test_external_distance_interaction.cpp
+++ b/test/core/test_external_distance_interaction.cpp
@@ -1,0 +1,225 @@
+#define BOOST_TEST_MODULE "test_external_distance_interaction"
+
+#ifdef BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include <mjolnir/core/BoundaryCondition.hpp>
+#include <mjolnir/core/SimulatorTraits.hpp>
+#include <mjolnir/forcefield/external/ExternalDistanceInteraction.hpp>
+#include <mjolnir/forcefield/external/ExcludedVolumeWallPotential.hpp>
+#include <mjolnir/core/AxisAlignedPlane.hpp>
+#include <mjolnir/util/make_unique.hpp>
+#include <random>
+
+BOOST_AUTO_TEST_CASE(ExternalDistanceInteraction_numerical_difference)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_external_distance_interaction.log");
+
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::ExcludedVolumeWallPotential<real_type>;
+    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>>;
+    using interaction_type = mjolnir::ExternalDistanceInteraction<traits_type, potential_type, shape_type>;
+
+    interaction_type interaction(shape_type(0.0, 0.5),
+        potential_type(/*epsilon = */1.0, /* cutoff = */2.0, {
+            {0, 1.0}, {1, 1.0}
+        }));
+
+    system_type sys(2, boundary_type{});
+
+    sys.at(0).mass  = 1.0;
+    sys.at(1).mass  = 1.0;
+    sys.at(0).rmass = 1.0;
+    sys.at(1).rmass = 1.0;
+
+    sys.at(0).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(1).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(0).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(0).force    = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).force    = coordinate_type( 0.0, 0.0, 0.0);
+
+    sys.at(0).name  = "X";
+    sys.at(1).name  = "X";
+    sys.at(0).group = "NONE";
+    sys.at(1).group = "NONE";
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+    std::normal_distribution<real_type> gauss(0.0, 1.0);
+
+    for(int i = 0; i < 10000; ++i)
+    {
+        sys.at(0).position = coordinate_type(0.0, 0.0, 1.0);
+        sys.at(1).position = coordinate_type(0.0, 0.0, 1.0);
+
+        // move particles a bit, randomly. and reset forces.
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coordinate_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coordinate_type(0.0, 0.0, 0.0);
+        }
+        const system_type init = sys;
+
+        // compare between numerical diff and force implementation
+        constexpr real_type tol = 1e-4;
+        constexpr real_type dr  = 1e-5;
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE / dr == mjolnir::math::X(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE / dr == mjolnir::math::Y(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE / dr == mjolnir::math::Z(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+        }
+
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ExternalDistanceInteraction_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_external_distance_interaction.log");
+
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::ExcludedVolumeWallPotential<real_type>;
+    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>>;
+    using interaction_type = mjolnir::ExternalDistanceInteraction<traits_type, potential_type, shape_type>;
+
+    interaction_type interaction(shape_type(0.0, 0.5),
+        potential_type(/*epsilon = */1.0, /* cutoff = */2.0, {
+            {0, 1.0}, {1, 1.0}
+        }));
+
+
+    system_type sys(2, boundary_type{});
+
+    sys.at(0).mass  = 1.0;
+    sys.at(1).mass  = 1.0;
+    sys.at(0).rmass = 1.0;
+    sys.at(1).rmass = 1.0;
+
+    sys.at(0).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(1).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(0).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(0).force    = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).force    = coordinate_type( 0.0, 0.0, 0.0);
+
+    sys.at(0).name  = "X";
+    sys.at(1).name  = "X";
+    sys.at(0).group = "NONE";
+    sys.at(1).group = "NONE";
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+    std::normal_distribution<real_type> gauss(0.0, 1.0);
+
+    for(int i = 0; i < 10000; ++i)
+    {
+        sys.at(0).position = coordinate_type(0.0, 0.0, 1.0);
+        sys.at(1).position = coordinate_type(0.0, 0.0, 1.0);
+
+        // move particles a bit, randomly. and reset forces.
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coordinate_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coordinate_type(0.0, 0.0, 0.0);
+        }
+
+        system_type ref_sys = sys;
+
+        constexpr real_type tol = 1e-4;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE "test_global_pair_interaction"
+#define BOOST_TEST_MODULE "test_global_pair_excluded_volume_interaction"
 
 #ifdef BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -9,127 +9,13 @@
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/NaivePairCalculation.hpp>
-#include <mjolnir/forcefield/global/GlobalPairInteraction.hpp>
-#include <mjolnir/forcefield/global/LennardJonesPotential.hpp>
+#include <mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp>
 #include <mjolnir/util/make_unique.hpp>
 #include <random>
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_double)
+BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_limits)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
-    using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
-    constexpr static traits::real_type tol = 1e-8;
-
-    using real_type        = traits::real_type;
-    using coordinate_type  = traits::coordinate_type;
-    using boundary_type    = traits::boundary_type;
-    using system_type      = mjolnir::System<traits>;
-    using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
-    using parameter_type   = typename potential_type::parameter_type;
-    using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
-    using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
-
-    auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
-
-    potential_type   potential(potential_type::default_cutoff(),
-        std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
-        }, {}, typename potential_type::ignore_molecule_type("Nothing"),
-               typename potential_type::ignore_group_type   ({})
-        );
-
-    interaction_type interaction(potential_type{potential},
-        mjolnir::SpatialPartition<traits, potential_type>(
-            mjolnir::make_unique<partition_type>()));
-
-    const real_type eq_dist = 1.0 * std::pow(2.0, 1.0 / 6.0);
-
-    system_type sys(2, boundary_type{});
-    topology_type topol(2);
-
-    sys.mass(0)  = 1.0;
-    sys.mass(1)  = 1.0;
-    sys.rmass(0) = 1.0;
-    sys.rmass(1) = 1.0;
-
-    sys.position(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.position(1) = coordinate_type(0.5, 0.0, 0.0);
-    sys.velocity(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.velocity(1) = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(0)    = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(1)    = coordinate_type(0.0, 0.0, 0.0);
-
-    topol.construct_molecules();
-
-    sys.name(0)  = "X";
-    sys.name(1)  = "X";
-    sys.group(0) = "NONE";
-    sys.group(1) = "NONE";
-
-    interaction.initialize(sys, topol);
-
-    std::mt19937 rng(123456789);
-    std::normal_distribution<real_type> gauss(0.0, 1.0);
-
-    const real_type rc = potential.max_cutoff_length();
-
-    const real_type r_min = 0.5;
-    const real_type r_max = rc;
-    const real_type dr = 1e-3;
-
-    const int max_count = (r_max - r_min) / dr;
-
-    real_type dist = r_min;
-    for(int i = 0; i < max_count-1; ++i)
-    {
-        sys.position(0) = coordinate_type(0,0,0);
-        sys.position(1) = coordinate_type(0,0,0);
-        sys.force(0)    = coordinate_type(0,0,0);
-        sys.force(1)    = coordinate_type(0,0,0);
-
-        sys.position(1) += dist *
-            normalize(coordinate_type(gauss(rng), gauss(rng), gauss(rng)));
-
-        const real_type deriv = potential.derivative(0, 1, dist);
-        const real_type coef  = std::abs(deriv);
-
-        interaction.calc_force(sys);
-
-        // check force strength
-        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
-        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
-        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
-        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
-
-        // check force direction
-        const real_type dir1 = mjolnir::math::dot_product(
-            normalize(sys.force(0)), normalize(sys.position(0) - sys.position(1)));
-        const real_type dir2 = mjolnir::math::dot_product( 
-            normalize(sys.force(1)), normalize(sys.position(1) - sys.position(0)));
-
-        if(dist < eq_dist) // repulsive
-        {
-            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
-        }
-        else // attractive
-        {
-            BOOST_TEST(dir1 == -1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == -1.0, boost::test_tools::tolerance(tol));
-        }
-
-        BOOST_TEST(mjolnir::math::length(sys.force(0) + sys.force(1)) == 0.0,
-                   boost::test_tools::tolerance(tol));
-
-        dist += dr;
-    }
-}
-
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
-{
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_excluded_volume_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;
@@ -137,17 +23,16 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
     using boundary_type    = traits::boundary_type;
     using system_type      = mjolnir::System<traits>;
     using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
+    using potential_type   = mjolnir::ExcludedVolumePotential<traits>;
     using parameter_type   = typename potential_type::parameter_type;
     using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
     using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
 
     auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
 
-    potential_type   potential(potential_type::default_cutoff(),
+    potential_type   potential(1.0, potential_type::default_cutoff(),
         std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
+            {0, 1.0}, {1, 1.0}
         }, {}, typename potential_type::ignore_molecule_type("Nothing"),
                typename potential_type::ignore_group_type   ({})
         );
@@ -285,9 +170,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
     }
 }
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
+BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_force_and_energy)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_excluded_volume_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;
@@ -295,17 +180,16 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
     using boundary_type    = traits::boundary_type;
     using system_type      = mjolnir::System<traits>;
     using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
+    using potential_type   = mjolnir::ExcludedVolumePotential<traits>;
     using parameter_type   = typename potential_type::parameter_type;
     using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
     using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
 
     auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
 
-    potential_type   potential(potential_type::default_cutoff(),
+    potential_type   potential(1.0, potential_type::default_cutoff(),
         std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
+            {0, 1.0}, {1, 1.0}
         }, {}, typename potential_type::ignore_molecule_type("Nothing"),
                typename potential_type::ignore_group_type   ({})
         );

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE "test_global_pair_interaction"
+#define BOOST_TEST_MODULE "test_global_pair_lennard_jones_interaction"
 
 #ifdef BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -9,127 +9,13 @@
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/NaivePairCalculation.hpp>
-#include <mjolnir/forcefield/global/GlobalPairInteraction.hpp>
-#include <mjolnir/forcefield/global/LennardJonesPotential.hpp>
+#include <mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp>
 #include <mjolnir/util/make_unique.hpp>
 #include <random>
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_double)
+BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_limits)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
-    using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
-    constexpr static traits::real_type tol = 1e-8;
-
-    using real_type        = traits::real_type;
-    using coordinate_type  = traits::coordinate_type;
-    using boundary_type    = traits::boundary_type;
-    using system_type      = mjolnir::System<traits>;
-    using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
-    using parameter_type   = typename potential_type::parameter_type;
-    using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
-    using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
-
-    auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
-
-    potential_type   potential(potential_type::default_cutoff(),
-        std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
-        }, {}, typename potential_type::ignore_molecule_type("Nothing"),
-               typename potential_type::ignore_group_type   ({})
-        );
-
-    interaction_type interaction(potential_type{potential},
-        mjolnir::SpatialPartition<traits, potential_type>(
-            mjolnir::make_unique<partition_type>()));
-
-    const real_type eq_dist = 1.0 * std::pow(2.0, 1.0 / 6.0);
-
-    system_type sys(2, boundary_type{});
-    topology_type topol(2);
-
-    sys.mass(0)  = 1.0;
-    sys.mass(1)  = 1.0;
-    sys.rmass(0) = 1.0;
-    sys.rmass(1) = 1.0;
-
-    sys.position(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.position(1) = coordinate_type(0.5, 0.0, 0.0);
-    sys.velocity(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.velocity(1) = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(0)    = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(1)    = coordinate_type(0.0, 0.0, 0.0);
-
-    topol.construct_molecules();
-
-    sys.name(0)  = "X";
-    sys.name(1)  = "X";
-    sys.group(0) = "NONE";
-    sys.group(1) = "NONE";
-
-    interaction.initialize(sys, topol);
-
-    std::mt19937 rng(123456789);
-    std::normal_distribution<real_type> gauss(0.0, 1.0);
-
-    const real_type rc = potential.max_cutoff_length();
-
-    const real_type r_min = 0.5;
-    const real_type r_max = rc;
-    const real_type dr = 1e-3;
-
-    const int max_count = (r_max - r_min) / dr;
-
-    real_type dist = r_min;
-    for(int i = 0; i < max_count-1; ++i)
-    {
-        sys.position(0) = coordinate_type(0,0,0);
-        sys.position(1) = coordinate_type(0,0,0);
-        sys.force(0)    = coordinate_type(0,0,0);
-        sys.force(1)    = coordinate_type(0,0,0);
-
-        sys.position(1) += dist *
-            normalize(coordinate_type(gauss(rng), gauss(rng), gauss(rng)));
-
-        const real_type deriv = potential.derivative(0, 1, dist);
-        const real_type coef  = std::abs(deriv);
-
-        interaction.calc_force(sys);
-
-        // check force strength
-        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
-        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
-        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
-        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
-
-        // check force direction
-        const real_type dir1 = mjolnir::math::dot_product(
-            normalize(sys.force(0)), normalize(sys.position(0) - sys.position(1)));
-        const real_type dir2 = mjolnir::math::dot_product( 
-            normalize(sys.force(1)), normalize(sys.position(1) - sys.position(0)));
-
-        if(dist < eq_dist) // repulsive
-        {
-            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
-        }
-        else // attractive
-        {
-            BOOST_TEST(dir1 == -1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == -1.0, boost::test_tools::tolerance(tol));
-        }
-
-        BOOST_TEST(mjolnir::math::length(sys.force(0) + sys.force(1)) == 0.0,
-                   boost::test_tools::tolerance(tol));
-
-        dist += dr;
-    }
-}
-
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
-{
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_lennard_jones_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;
@@ -285,9 +171,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
     }
 }
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
+BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_force_and_energy)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_lennard_jones_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE "test_global_pair_interaction"
+#define BOOST_TEST_MODULE "test_global_pair_uniform_lennard_jones_interaction"
 
 #ifdef BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -9,127 +9,13 @@
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/NaivePairCalculation.hpp>
-#include <mjolnir/forcefield/global/GlobalPairInteraction.hpp>
-#include <mjolnir/forcefield/global/LennardJonesPotential.hpp>
+#include <mjolnir/forcefield/global/GlobalPairUniformLennardJonesInteraction.hpp>
 #include <mjolnir/util/make_unique.hpp>
 #include <random>
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_double)
+BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_limits)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
-    using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
-    constexpr static traits::real_type tol = 1e-8;
-
-    using real_type        = traits::real_type;
-    using coordinate_type  = traits::coordinate_type;
-    using boundary_type    = traits::boundary_type;
-    using system_type      = mjolnir::System<traits>;
-    using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
-    using parameter_type   = typename potential_type::parameter_type;
-    using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
-    using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
-
-    auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
-
-    potential_type   potential(potential_type::default_cutoff(),
-        std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
-        }, {}, typename potential_type::ignore_molecule_type("Nothing"),
-               typename potential_type::ignore_group_type   ({})
-        );
-
-    interaction_type interaction(potential_type{potential},
-        mjolnir::SpatialPartition<traits, potential_type>(
-            mjolnir::make_unique<partition_type>()));
-
-    const real_type eq_dist = 1.0 * std::pow(2.0, 1.0 / 6.0);
-
-    system_type sys(2, boundary_type{});
-    topology_type topol(2);
-
-    sys.mass(0)  = 1.0;
-    sys.mass(1)  = 1.0;
-    sys.rmass(0) = 1.0;
-    sys.rmass(1) = 1.0;
-
-    sys.position(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.position(1) = coordinate_type(0.5, 0.0, 0.0);
-    sys.velocity(0) = coordinate_type(0.0, 0.0, 0.0);
-    sys.velocity(1) = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(0)    = coordinate_type(0.0, 0.0, 0.0);
-    sys.force(1)    = coordinate_type(0.0, 0.0, 0.0);
-
-    topol.construct_molecules();
-
-    sys.name(0)  = "X";
-    sys.name(1)  = "X";
-    sys.group(0) = "NONE";
-    sys.group(1) = "NONE";
-
-    interaction.initialize(sys, topol);
-
-    std::mt19937 rng(123456789);
-    std::normal_distribution<real_type> gauss(0.0, 1.0);
-
-    const real_type rc = potential.max_cutoff_length();
-
-    const real_type r_min = 0.5;
-    const real_type r_max = rc;
-    const real_type dr = 1e-3;
-
-    const int max_count = (r_max - r_min) / dr;
-
-    real_type dist = r_min;
-    for(int i = 0; i < max_count-1; ++i)
-    {
-        sys.position(0) = coordinate_type(0,0,0);
-        sys.position(1) = coordinate_type(0,0,0);
-        sys.force(0)    = coordinate_type(0,0,0);
-        sys.force(1)    = coordinate_type(0,0,0);
-
-        sys.position(1) += dist *
-            normalize(coordinate_type(gauss(rng), gauss(rng), gauss(rng)));
-
-        const real_type deriv = potential.derivative(0, 1, dist);
-        const real_type coef  = std::abs(deriv);
-
-        interaction.calc_force(sys);
-
-        // check force strength
-        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
-        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
-        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
-        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
-
-        // check force direction
-        const real_type dir1 = mjolnir::math::dot_product(
-            normalize(sys.force(0)), normalize(sys.position(0) - sys.position(1)));
-        const real_type dir2 = mjolnir::math::dot_product( 
-            normalize(sys.force(1)), normalize(sys.position(1) - sys.position(0)));
-
-        if(dist < eq_dist) // repulsive
-        {
-            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
-        }
-        else // attractive
-        {
-            BOOST_TEST(dir1 == -1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == -1.0, boost::test_tools::tolerance(tol));
-        }
-
-        BOOST_TEST(mjolnir::math::length(sys.force(0) + sys.force(1)) == 0.0,
-                   boost::test_tools::tolerance(tol));
-
-        dist += dr;
-    }
-}
-
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
-{
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_uniform_lennard_jones_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;
@@ -137,17 +23,16 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
     using boundary_type    = traits::boundary_type;
     using system_type      = mjolnir::System<traits>;
     using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
+    using potential_type   = mjolnir::UniformLennardJonesPotential<traits>;
     using parameter_type   = typename potential_type::parameter_type;
     using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
     using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
 
     auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
 
-    potential_type   potential(potential_type::default_cutoff(),
+    potential_type   potential(1.0, 1.2, potential_type::default_cutoff(),
         std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
+            {0, {}}, {1, {}}
         }, {}, typename potential_type::ignore_molecule_type("Nothing"),
                typename potential_type::ignore_group_type   ({})
         );
@@ -285,9 +170,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
     }
 }
 
-BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
+BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_force_and_energy)
 {
-    mjolnir::LoggerManager::set_default_logger("test_global_pair_interaction.log");
+    mjolnir::LoggerManager::set_default_logger("test_global_pair_uniform_lennard_jones_interaction.log");
     using traits = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
 
     using real_type        = traits::real_type;
@@ -295,17 +180,16 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
     using boundary_type    = traits::boundary_type;
     using system_type      = mjolnir::System<traits>;
     using topology_type    = mjolnir::Topology;
-    using potential_type   = mjolnir::LennardJonesPotential<traits>;
+    using potential_type   = mjolnir::UniformLennardJonesPotential<traits>;
     using parameter_type   = typename potential_type::parameter_type;
     using partition_type   = mjolnir::NaivePairCalculation<traits, potential_type>;
     using interaction_type = mjolnir::GlobalPairInteraction<traits, potential_type>;
 
     auto normalize = [](const coordinate_type& v){return v / mjolnir::math::length(v);};
 
-    potential_type   potential(potential_type::default_cutoff(),
+    potential_type   potential(1.0, 1.2, potential_type::default_cutoff(),
         std::vector<std::pair<std::size_t, parameter_type>>{
-            {0, {/* sigma = */ 1.0, /* epsilon = */1.2}},
-            {1, {/* sigma = */ 1.0, /* epsilon = */1.2}}
+            {0, {}}, {1, {}}
         }, {}, typename potential_type::ignore_molecule_type("Nothing"),
                typename potential_type::ignore_group_type   ({})
         );

--- a/test/core/test_pdns_interaction.cpp
+++ b/test/core/test_pdns_interaction.cpp
@@ -259,3 +259,183 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction)
     } // theta1
     } // rbp
 }
+
+BOOST_AUTO_TEST_CASE(PDNS_Interaction_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_pdns_interaction.log");
+
+    using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type         = traits_type::real_type;
+    using coord_type        = traits_type::coordinate_type;
+    using boundary_type     = traits_type::boundary_type;
+    using system_type       = mjolnir::System<traits_type>;
+    using topology_type     = mjolnir::Topology;
+
+    using real_type              = double;
+    using potential_type         = mjolnir::ProteinDNANonSpecificPotential<traits_type>;
+    using contact_parameter_type = typename potential_type::contact_parameter_type;
+    using dna_index_type         = typename potential_type::dna_index_type;
+    using interaction_type       = mjolnir::ProteinDNANonSpecificInteraction<traits_type>;
+    using ignore_molecule_type   = typename potential_type::ignore_molecule_type;
+    using ignore_group_type      = typename potential_type::ignore_group_type;
+    using partition_type         = mjolnir::NaivePairCalculation<traits_type, potential_type>;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    //  0 o              |
+    //     \             |
+    //    1 o === o 3    |
+    //     /       \     |
+    //  2 o         o 4  |
+
+    constexpr auto pi  = mjolnir::math::constants<real_type>::pi();
+
+    const real_type r0     = 5.0;
+    const real_type theta0 = pi * 0.5;
+    const real_type phi0   = pi * 2.0 / 3.0;
+
+    const real_type sigma  = 1.0;
+    const real_type delta  = pi / 18.0;
+
+    const contact_parameter_type p_pro{1, 0, 2, -1.2, r0, theta0, phi0, r0+5.0, (r0+5.0)*(r0+5.0)};
+    const dna_index_type p_dna{3, 4};
+
+    potential_type potential(
+        sigma, delta, 5.0, {p_pro}, {p_dna}, {/*exclusion*/},
+        ignore_molecule_type("Nothing"), ignore_group_type({}));
+
+    interaction_type interaction(potential_type(potential),
+        mjolnir::SpatialPartition<traits_type, potential_type>(
+            mjolnir::make_unique<partition_type>()));
+
+    system_type sys(5, boundary_type{});
+    topology_type topol(5);
+
+    topol.add_connection(0, 1, "bond");
+    topol.add_connection(1, 2, "bond");
+    topol.add_connection(3, 4, "bond");
+    topol.construct_molecules();
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)  = 1.0;
+        sys.rmass(i) = 1.0;
+        sys.position(i) = coord_type(0.0, 0.0, 0.0);
+        sys.velocity(i) = coord_type(0.0, 0.0, 0.0);
+        sys.force(i)    = coord_type(0.0, 0.0, 0.0);
+        sys.name(i)  = "DNA";
+        sys.group(i) = "DNA";
+    }
+    potential  .initialize(sys, topol);
+    interaction.initialize(sys, topol);
+
+    for(const auto r     : {r0 - 0.2, r0 + 0.5})
+    {
+    for(const auto theta : {theta0 + delta * 0.2,
+                            theta0 + delta * 0.7,
+                            theta0 + delta * 1.2,
+                            theta0 - delta * 1.2,
+                            theta0 - delta * 0.7,
+                            theta0 - delta * 0.2})
+    {
+    for(const auto phi   : {phi0 + delta * 0.2,
+                            phi0 + delta * 0.7,
+                            phi0 + delta * 1.2,
+                            phi0 - delta * 1.2,
+                            phi0 - delta * 0.7,
+                            phi0 - delta * 0.2})
+    {
+        BOOST_TEST_MESSAGE("=======================================================");
+        BOOST_TEST_MESSAGE("r = " << r << ", theta = " << theta << ", phi = " << phi);
+        BOOST_TEST_MESSAGE("theta0 = " << theta0 << ", delta = " << delta);
+        //  2 o              |
+        //     \             |
+        //  ^ 1 o === o 3    |
+        //     /       \     |
+        //  0 o         o 4  |
+
+
+        sys.position(1) = mjolnir::math::make_coordinate<coord_type>(0.0, 0.0, 0.0);
+        sys.position(0) = mjolnir::math::make_coordinate<coord_type>(
+                -std::cos(theta) - 1.0, -std::sin(theta), 0.0);
+        sys.position(2) = mjolnir::math::make_coordinate<coord_type>(
+                 std::cos(theta) - 1.0,  std::sin(theta), 0.0);
+
+        sys.position(3) = mjolnir::math::make_coordinate<coord_type>(
+                r, 0.0, 0.0);
+        sys.position(4) = mjolnir::math::make_coordinate<coord_type>(
+                r + std::cos(pi-phi), -std::sin(pi-phi), 0.0);
+
+        // rotate in random direction
+        {
+            using matrix33_type = typename traits_type::matrix33_type;
+
+            const auto rot_x = uni(mt) * pi;
+            const auto rot_y = uni(mt) * pi;
+            const auto rot_z = uni(mt) * pi;
+
+            matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                 0.0, std::cos(rot_x), -std::sin(rot_x),
+                                 0.0, std::sin(rot_x),  std::cos(rot_x));
+            matrix33_type rotm_y( std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                              0.0, 1.0,              0.0,
+                                 -std::sin(rot_y), 0.0,  std::cos(rot_y));
+            matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                 std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                             0.0,              0.0, 1.0);
+
+            const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.position(idx) = rotm * sys.position(idx);
+            }
+        }
+        // check configuration is okay
+        {
+            // XXX here it does not use boundary condition.
+            const auto v13 = sys.position(3) - sys.position(1);
+            BOOST_TEST_REQUIRE(mjolnir::math::length(v13) == r,
+                               boost::test_tools::tolerance(1e-3));
+
+            const auto v02 = sys.position(2) - sys.position(0);
+            const auto dot_1302 = mjolnir::math::dot_product(v02, v13);
+            const auto cos_1302 = mjolnir::math::clamp<real_type>(dot_1302 *
+                mjolnir::math::rlength(v13) * mjolnir::math::rlength(v02), -1, 1);
+            BOOST_TEST_REQUIRE(std::acos(cos_1302) == theta,
+                               boost::test_tools::tolerance(1e-3));
+
+            const auto v43 = sys.position(3) - sys.position(4);
+            const auto dot_134 = mjolnir::math::dot_product(v13, v43);
+            const auto cos_134 = mjolnir::math::clamp<real_type>(dot_134 *
+                mjolnir::math::rlength(v13) * mjolnir::math::rlength(v43), -1, 1);
+            BOOST_TEST_REQUIRE(std::acos(cos_134) == phi,
+                               boost::test_tools::tolerance(1e-3));
+        }
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
+        }
+        system_type ref_sys = sys;
+        interaction.initialize(sys, topol);
+
+        constexpr real_type tol = 1e-4;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+
+    } // theta2
+    } // theta1
+    } // rbp
+}

--- a/test/core/test_position_restraint_interaction.cpp
+++ b/test/core/test_position_restraint_interaction.cpp
@@ -113,3 +113,199 @@ BOOST_AUTO_TEST_CASE(PositionRestraint_Harmonic)
         }
     }
 }
+
+BOOST_AUTO_TEST_CASE(PositionRestraint_numerical_differentiation)
+{
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::HarmonicPotential<real_type>;
+    using interaction_type = mjolnir::PositionRestraintInteraction<traits_type, potential_type>;
+
+    const potential_type pot1{/*k =*/1.0, /*r0 =*/ 0.0};
+    const potential_type pot2{/*k =*/1.0, /*r0 =*/10.0};
+
+    interaction_type interaction(
+        std::vector<std::tuple<std::size_t, coordinate_type, potential_type>>{
+            std::make_tuple(0, coordinate_type{0.0,0.0,0.0}, pot1),
+            std::make_tuple(1, coordinate_type{0.0,0.0,0.0}, pot2)
+        });
+
+
+    std::mt19937 rng(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t trial = 0; trial < 1000; ++trial)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).position = coordinate_type(10.0,  0.0,  0.0);
+        sys.at(0).velocity = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).velocity = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(0).force    = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).force    = coordinate_type( 0.0,  0.0,  0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "NONE";
+        sys.at(1).group = "NONE";
+
+        sys.position(0) += coordinate_type(uni(rng), uni(rng), uni(rng));
+        sys.position(1) += coordinate_type(uni(rng), uni(rng), uni(rng));
+
+        const auto init = sys;
+        interaction.initialize(init);
+
+        constexpr real_type tol = 1e-3;
+        constexpr real_type dr  = 1e-4;
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::X(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Y(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Z(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PositionRestraint_force_and_energy)
+{
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::HarmonicPotential<real_type>;
+    using interaction_type = mjolnir::PositionRestraintInteraction<traits_type, potential_type>;
+
+    const potential_type pot1{/*k =*/1.0, /*r0 =*/ 0.0};
+    const potential_type pot2{/*k =*/1.0, /*r0 =*/10.0};
+
+    interaction_type interaction(
+        std::vector<std::tuple<std::size_t, coordinate_type, potential_type>>{
+            std::make_tuple(0, coordinate_type{0.0,0.0,0.0}, pot1),
+            std::make_tuple(1, coordinate_type{0.0,0.0,0.0}, pot2)
+        });
+
+
+    std::mt19937 rng(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t trial = 0; trial < 1000; ++trial)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).position = coordinate_type(10.0,  0.0,  0.0);
+        sys.at(0).velocity = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).velocity = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(0).force    = coordinate_type( 0.0,  0.0,  0.0);
+        sys.at(1).force    = coordinate_type( 0.0,  0.0,  0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "NONE";
+        sys.at(1).group = "NONE";
+
+        sys.position(0) += coordinate_type(uni(rng), uni(rng), uni(rng));
+        sys.position(1) += coordinate_type(uni(rng), uni(rng), uni(rng));
+
+        interaction.initialize(sys);
+        system_type ref_sys = sys;
+
+        constexpr real_type tol = 1e-3;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_pwmcos_interaction.cpp
+++ b/test/core/test_pwmcos_interaction.cpp
@@ -275,3 +275,199 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction)
     } // theta1
     } // rbp
 }
+
+BOOST_AUTO_TEST_CASE(PWMcos_Interaction_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_pdns_interaction.log");
+
+    using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type         = traits_type::real_type;
+    using coord_type        = traits_type::coordinate_type;
+    using boundary_type     = traits_type::boundary_type;
+    using system_type       = mjolnir::System<traits_type>;
+    using topology_type     = mjolnir::Topology;
+
+    using real_type              = double;
+    using potential_type         = mjolnir::PWMcosPotential<traits_type>;
+    using base_kind              = typename potential_type::base_kind;
+    using contact_parameter_type = typename potential_type::contact_parameter_type;
+    using dna_parameter_type     = typename potential_type::dna_parameter_type;
+    using interaction_type       = mjolnir::PWMcosInteraction<traits_type>;
+    using ignore_molecule_type   = typename potential_type::ignore_molecule_type;
+    using ignore_group_type      = typename potential_type::ignore_group_type;
+    using partition_type         = mjolnir::NaivePairCalculation<traits_type, potential_type>;
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    // protein     DNA
+    //
+    //  0 o       3 o --o  |
+    //     \     4         |
+    //    1 o === o -- o 6 |
+    //     /               |
+    //  2 o       5 o--o   |
+
+    constexpr auto pi  = mjolnir::math::constants<real_type>::pi();
+
+    const real_type r0       = 5.0;
+    const real_type theta1_0 = pi * 0.4;
+    const real_type theta2_0 = pi * 0.5;
+    const real_type theta3_0 = pi * 0.6;
+
+    const real_type sigma  = 1.0;
+    const real_type delta  = pi / 18.0;
+
+    const contact_parameter_type p_pro{1, 0, 2, -1.2, 0.0, r0, theta1_0, theta2_0, theta3_0, r0 + 5*sigma, {{1.0, 1.0, 1.0, 1.0}} };
+    const dna_parameter_type     p_dna{base_kind::A, 4, 6, 3, 5};
+
+    potential_type potential(
+        sigma, delta, 1.0, 0.0, 5.0, {p_pro}, {p_dna}, {/*exclusion*/},
+        ignore_molecule_type("Nothing"), ignore_group_type({}));
+
+    interaction_type interaction(potential_type(potential),
+        mjolnir::SpatialPartition<traits_type, potential_type>(
+            mjolnir::make_unique<partition_type>()));
+
+    system_type sys(7, boundary_type{});
+    topology_type topol(7);
+
+    topol.add_connection(0, 1, "bond");
+    topol.add_connection(1, 2, "bond");
+    topol.add_connection(3, 4, "bond");
+    topol.add_connection(4, 5, "bond");
+    topol.add_connection(4, 6, "bond");
+    topol.construct_molecules();
+
+    for(std::size_t i=0; i<sys.size(); ++i)
+    {
+        sys.mass(i)  = 1.0;
+        sys.rmass(i) = 1.0;
+        sys.position(i) = coord_type(0.0, 0.0, 0.0);
+        sys.velocity(i) = coord_type(0.0, 0.0, 0.0);
+        sys.force(i)    = coord_type(0.0, 0.0, 0.0);
+        sys.name(i)  = "A";
+        sys.group(i) = "A";
+    }
+    potential  .initialize(sys, topol);
+    interaction.initialize(sys, topol);
+
+    for(const auto r     : {r0 - 0.2, r0 + 0.5})
+    {
+    for(const auto theta1 : {theta1_0 + delta * 0.2,
+                             theta1_0 + delta * 0.7,
+                             theta1_0 + delta * 1.2,
+                             theta1_0 - delta * 1.2,
+                             theta1_0 - delta * 0.7,
+                             theta1_0 - delta * 0.2})
+    {
+    for(const auto theta2 : {theta2_0 + delta * 0.2,
+                             theta2_0 + delta * 0.7,
+                             theta2_0 + delta * 1.2,
+                             theta2_0 - delta * 1.2,
+                             theta2_0 - delta * 0.7,
+                             theta2_0 - delta * 0.2})
+    {
+    for(const auto theta3 : {theta3_0 + delta * 0.2,
+                             theta3_0 + delta * 0.7,
+                             theta3_0 + delta * 1.2,
+                             theta3_0 - delta * 1.2,
+                             theta3_0 - delta * 0.7,
+                             theta3_0 - delta * 0.2})
+    {
+        // r
+        sys.position(1) = mjolnir::math::make_coordinate<coord_type>(r, 0, 0);
+        sys.position(4) = mjolnir::math::make_coordinate<coord_type>(0, 0, 0);
+        // theta1
+        sys.position(6) = mjolnir::math::make_coordinate<coord_type>(std::cos(theta1), std::sin(theta1), 0);
+        // theta2
+        sys.position(3) = mjolnir::math::make_coordinate<coord_type>(std::cos(theta2+pi), std::sin(theta2+pi), 0);
+        sys.position(5) = mjolnir::math::make_coordinate<coord_type>(std::cos(theta2),    std::sin(theta2),    0);
+        // theta3
+        sys.position(0) = mjolnir::math::make_coordinate<coord_type>(r + std::cos(theta3),    std::sin(theta3),    0);
+        sys.position(2) = mjolnir::math::make_coordinate<coord_type>(r + std::cos(theta3+pi), std::sin(theta3+pi), 0);
+
+        // rotate in random direction
+        {
+            using matrix33_type = typename traits_type::matrix33_type;
+
+            const auto rot_x = uni(mt) * pi;
+            const auto rot_y = uni(mt) * pi;
+            const auto rot_z = uni(mt) * pi;
+
+            matrix33_type rotm_x(1.0,             0.0,              0.0,
+                                 0.0, std::cos(rot_x), -std::sin(rot_x),
+                                 0.0, std::sin(rot_x),  std::cos(rot_x));
+            matrix33_type rotm_y( std::cos(rot_y), 0.0,  std::sin(rot_y),
+                                              0.0, 1.0,              0.0,
+                                 -std::sin(rot_y), 0.0,  std::cos(rot_y));
+            matrix33_type rotm_z(std::cos(rot_z), -std::sin(rot_z), 0.0,
+                                 std::sin(rot_z),  std::cos(rot_z), 0.0,
+                                             0.0,              0.0, 1.0);
+
+            const matrix33_type rotm = rotm_x * rotm_y * rotm_z;
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.position(idx) = rotm * sys.position(idx);
+            }
+        }
+        // check configuration is okay
+        {
+            // XXX here it does not use boundary condition.
+            const auto v41 = sys.position(1) - sys.position(4); // B -> C
+            BOOST_TEST_REQUIRE(mjolnir::math::length(v41) == r,
+                               boost::test_tools::tolerance(1e-3));
+
+            const auto v46 = sys.position(6) - sys.position(4); // B -> S
+            const auto v35 = sys.position(5) - sys.position(3); // B-1 -> B+1
+            const auto v20 = sys.position(0) - sys.position(2); // C+1 -> C-1
+
+            const auto dot1 = mjolnir::math::dot_product(v41, v46) *
+                              mjolnir::math::rlength(v41) *
+                              mjolnir::math::rlength(v46);
+            const auto cos1 = mjolnir::math::clamp<real_type>(dot1, -1, 1);
+            BOOST_TEST_REQUIRE(std::acos(cos1) == theta1,
+                               boost::test_tools::tolerance(1e-3));
+
+            const auto dot2 = mjolnir::math::dot_product(v41, v35) *
+                              mjolnir::math::rlength(v41) *
+                              mjolnir::math::rlength(v35);
+            const auto cos2 = mjolnir::math::clamp<real_type>(dot2, -1, 1);
+            BOOST_TEST_REQUIRE(std::acos(cos2) == theta2,
+                               boost::test_tools::tolerance(1e-3));
+
+            const auto dot3 = mjolnir::math::dot_product(v41, v20) *
+                              mjolnir::math::rlength(v41) *
+                              mjolnir::math::rlength(v20);
+            const auto cos3 = mjolnir::math::clamp<real_type>(dot3, -1, 1);
+            BOOST_TEST_REQUIRE(std::acos(cos3) == theta3,
+                               boost::test_tools::tolerance(1e-3));
+        }
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
+        }
+        system_type ref_sys = sys;
+        interaction.initialize(sys, topol);
+
+        constexpr real_type tol = 1e-4;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+
+    } // theta3
+    } // theta2
+    } // theta1
+    } // rbp
+}

--- a/test/core/test_rectangular_box_interaction.cpp
+++ b/test/core/test_rectangular_box_interaction.cpp
@@ -151,3 +151,77 @@ BOOST_AUTO_TEST_CASE(PositionRestraint_Harmonic)
 
     }
 }
+
+BOOST_AUTO_TEST_CASE(PositionRestraint_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_recutangular_box_interaction.log");
+
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::ExcludedVolumeWallPotential<real_type>;
+    using interaction_type = mjolnir::RectangularBoxInteraction<traits_type, potential_type>;
+
+    coordinate_type lower( 0.0,  0.0,  0.0);
+    coordinate_type upper(10.0, 10.0, 10.0);
+
+    interaction_type interaction(lower, upper, /*margin = */0.5,
+        potential_type(/*epsilon = */1.0, /* cutoff = */2.0, {
+            {0, 1.0}, {1, 1.0}
+        }));
+
+    system_type sys(2, boundary_type{});
+
+    sys.at(0).mass  = 1.0;
+    sys.at(1).mass  = 1.0;
+    sys.at(0).rmass = 1.0;
+    sys.at(1).rmass = 1.0;
+
+    sys.at(0).position = coordinate_type( 1.0,  9.0,  1.0);
+    sys.at(1).position = coordinate_type( 9.0,  1.0,  9.0);
+    sys.at(0).velocity = coordinate_type( 0.0,  0.0,  0.0);
+    sys.at(1).velocity = coordinate_type( 0.0,  0.0,  0.0);
+    sys.at(0).force    = coordinate_type( 0.0,  0.0,  0.0);
+    sys.at(1).force    = coordinate_type( 0.0,  0.0,  0.0);
+
+    sys.at(0).name  = "X";
+    sys.at(1).name  = "X";
+    sys.at(0).group = "NONE";
+    sys.at(1).group = "NONE";
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+    std::normal_distribution<real_type> gauss(0.0, 1.0);
+
+    for(int i = 0; i < 10000; ++i)
+    {
+        sys.at(0).position = coordinate_type( 1.0,  9.0,  1.0);
+        sys.at(1).position = coordinate_type( 9.0,  1.0,  9.0);
+
+        // move particles a bit, randomly. and reset forces.
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coordinate_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coordinate_type(0.0, 0.0, 0.0);
+        }
+        interaction.initialize(sys);
+
+        system_type ref_sys = sys;
+        constexpr real_type tol = 1e-3;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_bond_angle_interaction.cpp
+++ b/test/omp/test_omp_bond_angle_interaction.cpp
@@ -126,7 +126,93 @@ BOOST_AUTO_TEST_CASE(omp_BondAngle)
                        boost::test_tools::tolerance(tol));
         }
 
+        // check the energies are the same
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(omp_BondAngle_calc_force_and_energy)
+{
+    constexpr double tol = 1e-8;
+    mjolnir::LoggerManager::set_default_logger("test_omp_bond_angle_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::HarmonicPotential<real_type>;
+    using interaction_type = mjolnir::BondAngleInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type   potential(/* k = */100.0, /* native angle = */ 3.1415 * 0.5);
+        interaction_type interaction(/*topol = */"none", {
+                {std::array<std::size_t, 3>{{0, 1, 2}}, potential},
+                {std::array<std::size_t, 3>{{1, 2, 3}}, potential},
+                {std::array<std::size_t, 3>{{2, 3, 4}}, potential},
+                {std::array<std::size_t, 3>{{3, 4, 5}}, potential},
+                {std::array<std::size_t, 3>{{4, 5, 6}}, potential},
+                {std::array<std::size_t, 3>{{5, 6, 7}}, potential},
+                {std::array<std::size_t, 3>{{6, 7, 8}}, potential},
+                {std::array<std::size_t, 3>{{7, 8, 9}}, potential}
+            });
+
+        rng_type    rng(123456789);
+        system_type sys(10, boundary_type{});
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        sys.position(0) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  0.0, 0.0);
+        sys.position(1) = mjolnir::math::make_coordinate<coordinate_type>( 5.0,  0.0, 0.0);
+        sys.position(2) = mjolnir::math::make_coordinate<coordinate_type>( 5.0,  5.0, 0.0);
+        sys.position(3) = mjolnir::math::make_coordinate<coordinate_type>(10.0,  5.0, 0.0);
+        sys.position(4) = mjolnir::math::make_coordinate<coordinate_type>(10.0, 10.0, 0.0);
+        sys.position(5) = mjolnir::math::make_coordinate<coordinate_type>(15.0, 10.0, 0.0);
+        sys.position(6) = mjolnir::math::make_coordinate<coordinate_type>(15.0, 15.0, 0.0);
+        sys.position(7) = mjolnir::math::make_coordinate<coordinate_type>(20.0, 15.0, 0.0);
+        sys.position(8) = mjolnir::math::make_coordinate<coordinate_type>(20.0, 20.0, 0.0);
+        sys.position(9) = mjolnir::math::make_coordinate<coordinate_type>(25.0, 20.0, 0.0);
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/omp/test_omp_bond_length_gocontact_interaction.cpp
+++ b/test/omp/test_omp_bond_length_gocontact_interaction.cpp
@@ -124,3 +124,79 @@ BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force_and_energy)
+{
+    constexpr double tol = 1e-8;
+    mjolnir::LoggerManager::set_default_logger("test_omp_bond_length_gocontact_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::GoContactPotential<real_type>;
+    using interaction_type = mjolnir::BondLengthInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type   potential(/* k = */1.0, /* native length = */ 5.0);
+        interaction_type interaction(/*topol = */"none", {
+                {std::array<std::size_t, 2>{{0, 1}}, potential},
+                {std::array<std::size_t, 2>{{1, 2}}, potential},
+                {std::array<std::size_t, 2>{{2, 3}}, potential},
+                {std::array<std::size_t, 2>{{3, 4}}, potential},
+                {std::array<std::size_t, 2>{{4, 5}}, potential},
+                {std::array<std::size_t, 2>{{5, 6}}, potential},
+                {std::array<std::size_t, 2>{{6, 7}}, potential},
+                {std::array<std::size_t, 2>{{7, 8}}, potential},
+                {std::array<std::size_t, 2>{{8, 9}}, potential}
+            });
+
+        rng_type    rng(123456789);
+        system_type sys(10, boundary_type{});
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i*5.0, 0.0, 0.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        auto ref_sys = sys;
+
+        interaction.initialize(sys);
+
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_contact_interaction.cpp
+++ b/test/omp/test_omp_contact_interaction.cpp
@@ -123,3 +123,79 @@ BOOST_AUTO_TEST_CASE(omp_Contact_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_Contact_calc_force_and_energy)
+{
+    constexpr double tol = 1e-8;
+
+    mjolnir::LoggerManager::set_default_logger("test_omp_contact_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::HarmonicPotential<real_type>;
+    using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type   potential(/* k = */100.0, /* native length = */ 5.0);
+        interaction_type interaction(/*topol = */"none", {
+                {std::array<std::size_t, 2>{{0, 1}}, potential},
+                {std::array<std::size_t, 2>{{1, 2}}, potential},
+                {std::array<std::size_t, 2>{{2, 3}}, potential},
+                {std::array<std::size_t, 2>{{3, 4}}, potential},
+                {std::array<std::size_t, 2>{{4, 5}}, potential},
+                {std::array<std::size_t, 2>{{5, 6}}, potential},
+                {std::array<std::size_t, 2>{{6, 7}}, potential},
+                {std::array<std::size_t, 2>{{7, 8}}, potential},
+                {std::array<std::size_t, 2>{{8, 9}}, potential}
+            });
+
+        rng_type    rng(123456789);
+        system_type sys(10, boundary_type{});
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i*5.0, 0.0, 0.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_dihedral_angle_interaction.cpp
+++ b/test/omp/test_omp_dihedral_angle_interaction.cpp
@@ -129,3 +129,88 @@ BOOST_AUTO_TEST_CASE(omp_DihedralAngle_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_DihedralAngle_calc_force_and_energy)
+{
+    constexpr double tol = 1e-8;
+    mjolnir::LoggerManager::set_default_logger("test_omp_dihedral_angle_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::PeriodicGaussianPotential<real_type>;
+    using interaction_type = mjolnir::DihedralAngleInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type   potential(/* k = */-100.0, /*sigma = */ 3.1415 * 0.5,
+                                   /* native angle = */ -3.1415 * 0.5);
+        interaction_type interaction(/*topol = */"none", {
+                {std::array<std::size_t, 4>{{0, 1, 2, 3}}, potential},
+                {std::array<std::size_t, 4>{{1, 2, 3, 4}}, potential},
+                {std::array<std::size_t, 4>{{2, 3, 4, 5}}, potential},
+                {std::array<std::size_t, 4>{{3, 4, 5, 6}}, potential},
+                {std::array<std::size_t, 4>{{4, 5, 6, 7}}, potential},
+                {std::array<std::size_t, 4>{{5, 6, 7, 8}}, potential},
+                {std::array<std::size_t, 4>{{6, 7, 8, 9}}, potential}
+            });
+
+        rng_type    rng(123456789);
+        system_type sys(10, boundary_type{});
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        sys.position(0) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  0.0,  0.0);
+        sys.position(1) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  5.0,  0.0);
+        sys.position(2) = mjolnir::math::make_coordinate<coordinate_type>( 5.0,  5.0,  0.0);
+        sys.position(3) = mjolnir::math::make_coordinate<coordinate_type>( 5.0,  5.0,  5.0);
+        sys.position(4) = mjolnir::math::make_coordinate<coordinate_type>( 5.0, 10.0,  5.0);
+        sys.position(5) = mjolnir::math::make_coordinate<coordinate_type>(10.0, 10.0,  5.0);
+        sys.position(6) = mjolnir::math::make_coordinate<coordinate_type>(10.0, 10.0, 10.0);
+        sys.position(7) = mjolnir::math::make_coordinate<coordinate_type>(10.0, 15.0, 10.0);
+        sys.position(8) = mjolnir::math::make_coordinate<coordinate_type>(15.0, 15.0, 10.0);
+        sys.position(9) = mjolnir::math::make_coordinate<coordinate_type>(15.0, 15.0, 15.0);
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_external_distance_interaction.cpp
+++ b/test/omp/test_omp_external_distance_interaction.cpp
@@ -138,3 +138,75 @@ BOOST_AUTO_TEST_CASE(omp_ExternalDistacne_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_ExternalDistance_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger(
+            "test_omp_external_distance_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coordinate_type  = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::LennardJonesWallPotential<real_type>;
+    using shape_type       = mjolnir::AxisAlignedPlane<traits_type, mjolnir::PositiveZDirection<traits_type>>;
+    using interaction_type = mjolnir::ExternalDistanceInteraction<traits_type, potential_type, shape_type>;
+
+    interaction_type interaction(shape_type(0.0, 0.5),
+        potential_type(/* cutoff = */2.0, {
+            {0, {1.0, 1.0}}, {1, {1.0, 1.0}}
+        }));
+
+    system_type sys(2, boundary_type{});
+
+    sys.at(0).mass  = 1.0;
+    sys.at(1).mass  = 1.0;
+    sys.at(0).rmass = 1.0;
+    sys.at(1).rmass = 1.0;
+
+    sys.at(0).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(1).position = coordinate_type( 0.0, 0.0, 1.0);
+    sys.at(0).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).velocity = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(0).force    = coordinate_type( 0.0, 0.0, 0.0);
+    sys.at(1).force    = coordinate_type( 0.0, 0.0, 0.0);
+
+    sys.at(0).name  = "X";
+    sys.at(1).name  = "X";
+    sys.at(0).group = "NONE";
+    sys.at(1).group = "NONE";
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+    std::normal_distribution<real_type> gauss(0.0, 1.0);
+
+    for(int i = 0; i < 10000; ++i)
+    {
+        sys.at(0).position = coordinate_type(0.0, 0.0, 1.0);
+        sys.at(1).position = coordinate_type(0.0, 0.0, 1.0);
+
+        // move particles a bit, randomly. and reset forces.
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.position(idx) += coordinate_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
+            sys.force(idx)     = coordinate_type(0.0, 0.0, 0.0);
+        }
+
+        system_type ref_sys = sys;
+
+        constexpr real_type tol = 1e-4;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_global_debye_huckel_interaction.cpp
+++ b/test/omp/test_omp_global_debye_huckel_interaction.cpp
@@ -142,3 +142,102 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_DebyeHuckel_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_GlobalPair_DebyeHuckel_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_global_pair_debye_huckel_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::DebyeHuckelPotential<traits_type>;
+    using parameter_type   = typename potential_type::parameter_type;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::GlobalPairInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    const std::size_t N_particle = 64;
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        std::vector<std::pair<std::size_t, parameter_type>> parameters(N_particle);
+        for(std::size_t i=0; i<N_particle; ++i)
+        {
+            parameters[i] = std::make_pair(i, parameter_type{1.0});
+        }
+
+        potential_type potential(potential_type::default_cutoff(), parameters, {},
+            typename potential_type::ignore_molecule_type("Nothing"),
+            typename potential_type::ignore_group_type   ({}));
+
+        rng_type    rng(123456789);
+        system_type sys(N_particle, boundary_type{});
+        topology_type topol(N_particle);
+        topol.construct_molecules();
+
+        sys.attribute("temperature")    = 300.0;
+        sys.attribute("ionic_strength") =   0.2;
+        potential.update(sys, topol);
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto i_x = i % 4;
+            const auto i_y = i / 4;
+            const auto i_z = i / 16;
+
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i_x*2.0, i_y*2.0, i_z*2.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        interaction.initialize(sys, topol);
+
+        system_type ref_sys = sys;
+
+        constexpr real_type tol = 1e-4;
+
+        // calculate forces with openmp
+        sys.preprocess_forces();
+        const auto energy = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_global_excluded_volume_interaction.cpp
+++ b/test/omp/test_omp_global_excluded_volume_interaction.cpp
@@ -138,3 +138,99 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_global_pair_excluded_volume_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::ExcludedVolumePotential<traits_type>;
+    using parameter_type   = typename potential_type::parameter_type;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::GlobalPairInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    const std::size_t N_particle = 64;
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        std::vector<std::pair<std::size_t, parameter_type>> parameters(N_particle);
+        for(std::size_t i=0; i<N_particle; ++i)
+        {
+            parameters[i] = std::make_pair(i, parameter_type{1.0});
+        }
+
+        potential_type potential(1.0, potential_type::default_cutoff(), parameters, {},
+            typename potential_type::ignore_molecule_type("Nothing"),
+            typename potential_type::ignore_group_type   ({})
+            );
+
+        rng_type    rng(123456789);
+        system_type sys(N_particle, boundary_type{});
+        topology_type topol(N_particle);
+        topol.construct_molecules();
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto i_x = i % 4;
+            const auto i_y = i / 4;
+            const auto i_z = i / 16;
+
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i_x*2.0, i_y*2.0, i_z*2.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        potential.update(sys, topol);
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        interaction.initialize(sys, topol);
+
+        constexpr double tol = 1e-4;
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        sys.preprocess_forces();
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+
+    }
+}

--- a/test/omp/test_omp_global_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_lennard_jones_interaction.cpp
@@ -138,3 +138,98 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_LennardJones_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_GlobalPair_LennardJones_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_global_pair_lennard_jones_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::LennardJonesPotential<traits_type>;
+    using parameter_type   = typename potential_type::parameter_type;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::GlobalPairInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    const std::size_t N_particle = 64;
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        std::vector<std::pair<std::size_t, parameter_type>> parameters(N_particle);
+        for(std::size_t i=0; i<N_particle; ++i)
+        {
+            parameters[i] = std::make_pair(i, parameter_type{1.0, 1.0});
+        }
+
+        potential_type potential(potential_type::default_cutoff(), parameters, {},
+                typename potential_type::ignore_molecule_type("Nothing"),
+                typename potential_type::ignore_group_type({}));
+
+        rng_type    rng(123456789);
+        system_type sys(N_particle, boundary_type{});
+        topology_type topol(N_particle);
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto i_x = i % 4;
+            const auto i_y = i / 4;
+            const auto i_z = i / 16;
+
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i_x*2.0, i_y*2.0, i_z*2.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+        potential.update(sys, topol);
+
+        partition_type celllist;
+
+        topol.construct_molecules();
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        interaction.initialize(sys, topol);
+
+        constexpr double tol = 1e-4;
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        sys.preprocess_forces();
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_global_pdns_interaction.cpp
+++ b/test/omp/test_omp_global_pdns_interaction.cpp
@@ -170,3 +170,120 @@ BOOST_AUTO_TEST_CASE(omp_PDNS_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_PDNS_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_pdns_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::ProteinDNANonSpecificPotential<traits_type>;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::ProteinDNANonSpecificInteraction<traits_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    // o 0     5 o--o 6  |
+    //  \       /        |
+    //   o 1   o 7       |
+    //  /       \        |
+    // o 2     8 o--o 9  |
+    //  \       /        |
+    //   o 3   o 10      |
+    //  /       \        |
+    // o 4    11 o--o 12 |
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type potential(1.0, 0.1, 5.0,
+            std::vector<typename potential_type::contact_parameter_type>{
+                typename potential_type::contact_parameter_type{1, 0, 2, 6.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 0.0, 0.0},
+                typename potential_type::contact_parameter_type{2, 1, 3, 6.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 0.0, 0.0},
+                typename potential_type::contact_parameter_type{3, 2, 4, 6.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 0.0, 0.0}
+            },
+            std::vector<typename potential_type::dna_index_type>{
+                typename potential_type::dna_index_type{ 7, 8},
+                typename potential_type::dna_index_type{10,11}
+            },
+            {},
+            typename potential_type::ignore_molecule_type("Nothing"),
+            typename potential_type::ignore_group_type({}));
+
+        rng_type    rng(123456789);
+        system_type sys(13, boundary_type{});
+        topology_type topol(13);
+        sys.position( 0) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  3.3, 0.0);
+        sys.position( 1) = mjolnir::math::make_coordinate<coordinate_type>( 1.9,  1.6, 0.0);
+        sys.position( 2) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  0.0, 0.0);
+        sys.position( 3) = mjolnir::math::make_coordinate<coordinate_type>( 1.9, -1.6, 0.0);
+        sys.position( 4) = mjolnir::math::make_coordinate<coordinate_type>( 0.0, -3.3, 0.0);
+        sys.position( 5) = mjolnir::math::make_coordinate<coordinate_type>( 8.8,  3.3, 0.0);
+        sys.position( 6) = mjolnir::math::make_coordinate<coordinate_type>(12.0,  3.3, 0.0);
+        sys.position( 7) = mjolnir::math::make_coordinate<coordinate_type>( 6.9,  1.6, 0.0);
+        sys.position( 8) = mjolnir::math::make_coordinate<coordinate_type>( 8.8,  0.0, 0.0);
+        sys.position( 9) = mjolnir::math::make_coordinate<coordinate_type>(12.0,  0.0, 0.0);
+        sys.position(10) = mjolnir::math::make_coordinate<coordinate_type>( 6.9, -1.6, 0.0);
+        sys.position(11) = mjolnir::math::make_coordinate<coordinate_type>( 8.8, -3.3, 0.0);
+        sys.position(12) = mjolnir::math::make_coordinate<coordinate_type>(12.0, -3.3, 0.0);
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        topol.construct_molecules();
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+        potential.update(sys, topol);
+
+        partition_type celllist;
+        topol.construct_molecules();
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        interaction.initialize(sys, topol);
+
+        constexpr double tol = 1e-4;
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        sys.preprocess_forces();
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_global_pwmcos_interaction.cpp
+++ b/test/omp/test_omp_global_pwmcos_interaction.cpp
@@ -177,3 +177,131 @@ BOOST_AUTO_TEST_CASE(omp_PWMcos_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_PWMcos_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_pdns_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::PWMcosPotential<traits_type>;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::PWMcosInteraction<traits_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    //         5  6
+    //         o--o   |
+    //             \ 7|
+    // o 0          o |
+    //  \      8  9/  |
+    //   o 1   o--o   |
+    //  /          \10|
+    // o 2          o |
+    //  \     11 12/  |
+    //   o 3   o--o   |
+    //  /          \13|
+    // o 4          o |
+    //        14 15/  |
+    //         o--o   |
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type potential(1.0, 0.1, 1.0, 0.0, 5.0,
+            std::vector<typename potential_type::contact_parameter_type>{
+                typename potential_type::contact_parameter_type{1, 0, 2, 6.0, 0.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 3.14 * 0.667, 0.0, {{1.0, 1.0, 1.0, 1.0}} },
+                typename potential_type::contact_parameter_type{2, 1, 3, 6.0, 0.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 3.14 * 0.667, 0.0, {{1.0, 1.0, 1.0, 1.0}} },
+                typename potential_type::contact_parameter_type{3, 2, 4, 6.0, 0.0, 5.0, 3.14 * 0.5, 3.14 * 0.667, 3.14 * 0.667, 0.0, {{1.0, 1.0, 1.0, 1.0}} }
+            },
+            std::vector<typename potential_type::dna_parameter_type>{
+                typename potential_type::dna_parameter_type{potential_type::base_kind::A,  8,  9,  5, 11},
+                typename potential_type::dna_parameter_type{potential_type::base_kind::A, 11, 15,  8, 14},
+            },
+            {},
+            typename potential_type::ignore_molecule_type("Nothing"),
+            typename potential_type::ignore_group_type({}));
+
+        rng_type      rng(123456789);
+        system_type   sys(16, boundary_type{});
+        topology_type topol(16);
+        topol.construct_molecules();
+
+        sys.position( 0) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  3.3, 0.0);
+        sys.position( 1) = mjolnir::math::make_coordinate<coordinate_type>( 1.9,  1.6, 0.0);
+        sys.position( 2) = mjolnir::math::make_coordinate<coordinate_type>( 0.0,  0.0, 0.0);
+        sys.position( 3) = mjolnir::math::make_coordinate<coordinate_type>( 1.9, -1.6, 0.0);
+        sys.position( 4) = mjolnir::math::make_coordinate<coordinate_type>( 0.0, -3.3, 0.0);
+
+        sys.position( 5) = mjolnir::math::make_coordinate<coordinate_type>( 6.9,  5.0, 0.0);
+        sys.position( 6) = mjolnir::math::make_coordinate<coordinate_type>( 8.8,  5.0, 0.0);
+        sys.position( 7) = mjolnir::math::make_coordinate<coordinate_type>(12.0,  3.3, 0.0);
+        sys.position( 8) = mjolnir::math::make_coordinate<coordinate_type>( 6.9,  1.6, 0.0);
+        sys.position( 9) = mjolnir::math::make_coordinate<coordinate_type>( 8.8,  1.6, 0.0);
+        sys.position(10) = mjolnir::math::make_coordinate<coordinate_type>(12.0,  0.0, 0.0);
+        sys.position(11) = mjolnir::math::make_coordinate<coordinate_type>( 6.9, -1.6, 0.0);
+        sys.position(12) = mjolnir::math::make_coordinate<coordinate_type>( 8.8, -1.6, 0.0);
+        sys.position(13) = mjolnir::math::make_coordinate<coordinate_type>(12.0, -3.3, 0.0);
+        sys.position(14) = mjolnir::math::make_coordinate<coordinate_type>( 6.9, -5.0, 0.0);
+        sys.position(15) = mjolnir::math::make_coordinate<coordinate_type>( 8.8, -5.0, 0.0);
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+        potential.update(sys, topol);
+
+        partition_type celllist;
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+        interaction    .initialize(sys, topol);
+
+        system_type ref_sys = sys;
+
+        constexpr real_type tol = 1e-4;
+
+        // calculate forces with openmp
+        sys.preprocess_forces();
+        const auto energy = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+
+    }
+}

--- a/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
@@ -131,3 +131,91 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_omp_global_pair_uniform_lennard_jones_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using topology_type    = mjolnir::Topology;
+    using potential_type   = mjolnir::UniformLennardJonesPotential<traits_type>;
+    using partition_type   = mjolnir::UnlimitedGridCellList<traits_type, potential_type>;
+    using interaction_type = mjolnir::GlobalPairInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << max_number_of_threads);
+
+    const std::size_t N_particle = 64;
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type potential(1.0, 1.0, potential_type::default_cutoff(), {}, {},
+            typename potential_type::ignore_molecule_type("Nothing"),
+            typename potential_type::ignore_group_type({}));
+
+        rng_type    rng(123456789);
+        system_type sys(N_particle, boundary_type{});
+        topology_type topol(N_particle);
+        topol.construct_molecules();
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto i_x = i % 4;
+            const auto i_y = i / 4;
+            const auto i_z = i / 16;
+
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i_x*2.0, i_y*2.0, i_z*2.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+        potential.update(sys, topol);
+
+        partition_type celllist;
+
+        interaction_type interaction(std::move(potential),
+            mjolnir::SpatialPartition<traits_type, potential_type>(
+                mjolnir::make_unique<partition_type>()));
+
+        interaction.initialize(sys, topol);
+
+        constexpr double tol = 1e-4;
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+
+        ref_sys.preprocess_forces();
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        sys.preprocess_forces();
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/omp/test_omp_gocontact_interaction.cpp
+++ b/test/omp/test_omp_gocontact_interaction.cpp
@@ -126,3 +126,79 @@ BOOST_AUTO_TEST_CASE(omp_Contact_GoContact_calc_force)
                    boost::test_tools::tolerance(tol));
     }
 }
+
+BOOST_AUTO_TEST_CASE(omp_Contact_GoContact_calc_force_and_energy)
+{
+    constexpr double tol = 1e-8;
+
+    mjolnir::LoggerManager::set_default_logger("test_omp_gocontact_interaction.log");
+
+    using traits_type      = mjolnir::OpenMPSimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = typename traits_type::real_type;
+    using coordinate_type  = typename traits_type::coordinate_type;
+    using boundary_type    = typename traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::GoContactPotential<real_type>;
+    using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
+    using rng_type         = mjolnir::RandomNumberGenerator<traits_type>;
+
+    const int max_number_of_threads = omp_get_max_threads();
+    BOOST_TEST_WARN(max_number_of_threads > 2);
+    BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+    for(int num_thread=1; num_thread<=max_number_of_threads; ++num_thread)
+    {
+        omp_set_num_threads(num_thread);
+        BOOST_TEST_MESSAGE("maximum number of threads = " << omp_get_max_threads());
+
+        potential_type   potential(/* k = */1.0, /* native length = */ 5.0);
+        interaction_type interaction(/*topol = */"none", {
+                {std::array<std::size_t, 2>{{0, 1}}, potential},
+                {std::array<std::size_t, 2>{{1, 2}}, potential},
+                {std::array<std::size_t, 2>{{2, 3}}, potential},
+                {std::array<std::size_t, 2>{{3, 4}}, potential},
+                {std::array<std::size_t, 2>{{4, 5}}, potential},
+                {std::array<std::size_t, 2>{{5, 6}}, potential},
+                {std::array<std::size_t, 2>{{6, 7}}, potential},
+                {std::array<std::size_t, 2>{{7, 8}}, potential},
+                {std::array<std::size_t, 2>{{8, 9}}, potential}
+            });
+
+        rng_type    rng(123456789);
+        system_type sys(10, boundary_type{});
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.mass(i)     = 1.0;
+            sys.position(i) = mjolnir::math::make_coordinate<coordinate_type>(i*3.0, i*3.0, i*3.0);
+            sys.velocity(i) = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.force(i)    = mjolnir::math::make_coordinate<coordinate_type>(0, 0, 0);
+            sys.name(i)     = "X";
+            sys.group(i)    = "TEST";
+        }
+        // add perturbation
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            mjolnir::math::X(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Y(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+            mjolnir::math::Z(sys.position(i)) += rng.uniform_real(-0.1, 0.1);
+        }
+
+        auto ref_sys = sys;
+
+        // calculate forces with openmp
+        const auto ref_ene = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        ref_sys.postprocess_forces();
+
+        const auto ene = interaction.calc_force_and_energy(sys);
+        sys.postprocess_forces();
+
+        BOOST_TEST(ene == ref_ene, boost::test_tools::tolerance(tol));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            BOOST_TEST(mjolnir::math::X(ref_sys.force(i)) == mjolnir::math::X(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(ref_sys.force(i)) == mjolnir::math::Y(sys.force(i)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(ref_sys.force(i)) == mjolnir::math::Z(sys.force(i)), boost::test_tools::tolerance(tol));
+        }
+    }
+}


### PR DESCRIPTION
- To speedup multiple basin forcefield, add `calc_force_and_energy` method to interactions.
- Reduce operations in GoContact and L-J force/energy calculation
  - It changes the pattern of numerical errors, so it changes the trajectory after several steps if the force field contains `GoPotential`.