### PR TITLE
enable to pass list of offset to input.

### DIFF
--- a/test/core/test_read_index_offset.cpp
+++ b/test/core/test_read_index_offset.cpp
@@ -56,6 +56,42 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(read_index_offset_local_potential, T, test_types)
     }
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(read_index_offset_list_local_potential, T, test_types)
+{
+    mjolnir::LoggerManager::set_default_logger("test_read_index_offset.log");
+
+    using real_type = T;
+    {
+        using namespace toml::literals;
+        const auto v = u8R"(
+            parameters = [
+                {indices = [1, 2],                    k = 3.14, v0 = 2.71},
+                {indices = [1, 2], offset =  [1, -1], k = 3.14, v0 = 2.71},
+                {indices = [1, 2], offset =  [-1, 1], k = 3.14, v0 = 2.71},
+            ]
+        )"_toml;
+
+        const auto g = mjolnir::read_local_potential<2,
+            mjolnir::HarmonicPotential<real_type>>(v);
+
+        BOOST_TEST(g.size() == 3u);
+        BOOST_TEST(g.at(0).first[0] == 1u);
+        BOOST_TEST(g.at(0).first[1] == 2u);
+
+        BOOST_TEST(g.at(1).first[0] == 2u);
+        BOOST_TEST(g.at(1).first[1] == 1u);
+
+        BOOST_TEST(g.at(2).first[0] == 0u);
+        BOOST_TEST(g.at(2).first[1] == 3u);
+
+        BOOST_TEST(g.at(0).second.k()  == real_type(3.14));
+        BOOST_TEST(g.at(0).second.v0() == real_type(2.71));
+        BOOST_TEST(g.at(1).second.k()  == real_type(3.14));
+        BOOST_TEST(g.at(1).second.v0() == real_type(2.71));
+        BOOST_TEST(g.at(2).second.k()  == real_type(3.14));
+        BOOST_TEST(g.at(2).second.v0() == real_type(2.71));
+    }
+}
 BOOST_AUTO_TEST_CASE_TEMPLATE(read_index_offset_global_potential, T, test_types)
 {
     mjolnir::LoggerManager::set_default_logger("test_read_index_offset.log");


### PR DESCRIPTION
This change is only for local potential.
- Offset becomes to accept list, and if get the list, each element of the list is added to the corresponding element of the indices list.
For example, 
```
...
{indices = [ 0, 1], ... , offset = [ 1, 2]},
...
```
from the above file, indices are finally interpreted to `[ 1, 3]`.

- If the size of a given offset list don't match that of the indices list, the reading process raises a runtime error.