### PR TITLE
avoid frequent memory allocations in neighborlist

### DIFF
--- a/mjolnir/core/NeighborList.hpp
+++ b/mjolnir/core/NeighborList.hpp
@@ -228,6 +228,16 @@ class NeighborList
         return ;
     }
 
+    void reserve(const std::size_t approx_neighbors,
+                 const std::size_t num_participants,
+                 const std::size_t num_particles)
+    {
+        neighbors_.reserve(approx_neighbors * num_participants);
+        ranges_.reserve(num_particles);
+    }
+
+    std::size_t num_neighbors() const noexcept {return neighbors_.size();}
+
     range_type operator[](const std::size_t i) const noexcept
     {
         return range_type{

--- a/mjolnir/core/PeriodicGridCellList.hpp
+++ b/mjolnir/core/PeriodicGridCellList.hpp
@@ -248,6 +248,14 @@ void PeriodicGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighbo
         // make the result consistent with NaivePairCalculation...
         std::sort(partner.begin(), partner.end());
         neighbors.add_list_for(i, partner.begin(), partner.end());
+
+        // approximate the memory usage and avoid frequent memory allocation.
+        // This block is just for efficiency, and does not affect on the result.
+        if(idx == 16)
+        {
+            neighbors.reserve(neighbors.num_neighbors() / 16,
+                              leading_participants.size(), sys.size());
+        }
     }
 
     this->current_margin_ = cutoff_ * margin_;

--- a/mjolnir/core/UnlimitedGridCellList.hpp
+++ b/mjolnir/core/UnlimitedGridCellList.hpp
@@ -237,6 +237,14 @@ void UnlimitedGridCellList<traitsT, potentialT>::make(neighbor_list_type& neighb
         // make the result consistent with NaivePairCalculation...
         std::sort(partner.begin(), partner.end());
         neighbors.add_list_for(i, partner.begin(), partner.end());
+
+        // approximate the memory usage and avoid frequent memory allocation.
+        // This block is just for efficiency, and does not affect on the result.
+        if(idx == 16)
+        {
+            neighbors.reserve(neighbors.num_neighbors() / 16,
+                              leading_participants.size(), sys.size());
+        }
     }
     this->current_margin_ = cutoff_ * margin_;
     return ;

--- a/mjolnir/omp/PeriodicGridCellList.hpp
+++ b/mjolnir/omp/PeriodicGridCellList.hpp
@@ -253,6 +253,14 @@ class PeriodicGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // make the result consistent with NaivePairCalculation...
             std::sort(partner.begin(), partner.end());
             neighbors.add_list_for(i, partner.begin(), partner.end());
+
+            // approximate the memory usage and avoid frequent memory allocation.
+            // This block is just for efficiency, and does not affect on the result.
+            if(idx == 16)
+            {
+                neighbors.reserve(neighbors.num_neighbors() / 16,
+                                  leading_participants.size(), sys.size());
+            }
         }
 
         this->current_margin_ = cutoff_ * margin_;

--- a/mjolnir/omp/UnlimitedGridCellList.hpp
+++ b/mjolnir/omp/UnlimitedGridCellList.hpp
@@ -229,6 +229,14 @@ class UnlimitedGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // make the result consistent with NaivePairCalculation...
             std::sort(partner.begin(), partner.end());
             neighbors.add_list_for(i, partner.begin(), partner.end());
+
+            // approximate the memory usage and avoid frequent memory allocation.
+            // This block is just for efficiency, and does not affect on the result.
+            if(idx == 16)
+            {
+                neighbors.reserve(neighbors.num_neighbors() / 16,
+                                  leading_participants.size(), sys.size());
+            }
         }
         this->current_margin_ = cutoff_ * margin_;
         return ;


### PR DESCRIPTION
Current implementation requires too many allocations and it slows down the simulation. It is only executed once, at the first step, but still it can impact on the total simulation time, especially for a short simulation. This PullReq reduces the allocation calls by approximating the total amount of memory region that would be used.