### PR TITLE
fix: remove message from bad_alloc construction in fixed_vector

### DIFF
--- a/mjolnir/util/fixed_vector.hpp
+++ b/mjolnir/util/fixed_vector.hpp
@@ -188,7 +188,7 @@ struct fixed_vector
     {
         if(N < sz)
         {
-            throw std::bad_alloc("fixed_vector::resize()");
+            throw std::bad_alloc();
         }
         size_ = sz;
     }
@@ -196,7 +196,7 @@ struct fixed_vector
     {
         if(N < sz)
         {
-            throw std::bad_alloc("fixed_vector::resize()");
+            throw std::bad_alloc();
         }
         if(size_ < sz)
         {


### PR DESCRIPTION
`bad_alloc` should be able to construct without memory, so it does not have region to store a string.