### PR TITLE
Throw out_of_range correctly

### DIFF
--- a/mjolnir/util/fixed_vector.hpp
+++ b/mjolnir/util/fixed_vector.hpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 #include <string>
 #include <mjolnir/util/string.hpp>
+#include <mjolnir/util/throw_exception.hpp>
 
 namespace mjolnir
 {
@@ -161,9 +162,8 @@ struct fixed_vector
     {
         if(size_ <= i)
         {
-            using namespace ::mjolnir::literals::string_literals;
-            std::out_of_range("fixed_vector::at("_s + std::to_string(i) + "): "
-                "index exceeds the current size (" + std::to_string(size_) + ")");
+            throw_exception<std::out_of_range>("fixed_vector::at(", i, "): "
+                "index exceeds the current size (", size_, ")");
         }
         return container_.at(i);
     }
@@ -171,9 +171,8 @@ struct fixed_vector
     {
         if(size_ <= i)
         {
-            using namespace ::mjolnir::literals::string_literals;
-            std::out_of_range("fixed_vector::at("_s + std::to_string(i) + "): "
-                "index exceeds the current size (" + std::to_string(size_) + ")");
+            throw_exception<std::out_of_range>("fixed_vector::at(", i, "): "
+                "index exceeds the current size (", size_, ")");
         }
         return container_.at(i);
     }

--- a/test/core/test_3spn2_base_base_interaction.cpp
+++ b/test/core/test_3spn2_base_base_interaction.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_numerical_diff,
     std::mt19937 mt(123456789);
     std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    for(const auto bases : {
+    for(const auto& bases : {
             std::vector<base_kind>{base_kind::A, base_kind::T},
             std::vector<base_kind>{base_kind::T, base_kind::A},
             std::vector<base_kind>{base_kind::C, base_kind::G},
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_numerical_diff,
     std::mt19937 mt(123456789);
     std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    for(const auto bases : {
+    for(const auto& bases : {
             std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::G, base_kind::G},
             std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::C, base_kind::C},
             std::vector<base_kind>{base_kind::T, base_kind::A, base_kind::G, base_kind::G},
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_energy_and_force,
     std::mt19937 mt(123456789);
     std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    for(const auto bases : {
+    for(const auto& bases : {
             std::vector<base_kind>{base_kind::A, base_kind::T},
             std::vector<base_kind>{base_kind::T, base_kind::A},
             std::vector<base_kind>{base_kind::C, base_kind::G},
@@ -1112,7 +1112,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force
     std::mt19937 mt(123456789);
     std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    for(const auto bases : {
+    for(const auto& bases : {
             std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::G, base_kind::G},
             std::vector<base_kind>{base_kind::A, base_kind::T, base_kind::C, base_kind::C},
             std::vector<base_kind>{base_kind::T, base_kind::A, base_kind::G, base_kind::G},

--- a/test/core/test_afm_fitting_interaction.cpp
+++ b/test/core/test_afm_fitting_interaction.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(AFMFitting_calc_force)
         const auto init = sys;
         interaction.initialize(init);
 
-        constexpr real_type tol = 1e-3;
+        constexpr real_type tol = 2e-3;
         constexpr real_type dr  = 1e-4;
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {


### PR DESCRIPTION
Currently, fixed_vector::at does not throw out_of_range.