### PR TITLE
feat: enable reduce_margin to return bool

### DIFF
--- a/mjolnir/core/NaivePairCalculation.hpp
+++ b/mjolnir/core/NaivePairCalculation.hpp
@@ -48,10 +48,10 @@ class NaivePairCalculation final : public SpatialPartitionBase<traitsT, Potentia
     {
         return false;
     }
-    void scale_margin(neighbor_list_type&, const real_type,
+    bool scale_margin(neighbor_list_type&, const real_type,
                       const system_type&, const potential_type&) override
     {
-        return;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return std::numeric_limits<real_type>::infinity();}

--- a/mjolnir/core/NaivePairCalculation.hpp
+++ b/mjolnir/core/NaivePairCalculation.hpp
@@ -43,10 +43,10 @@ class NaivePairCalculation final : public SpatialPartitionBase<traitsT, Potentia
     void make  (neighbor_list_type& neighbor,
                 const system_type& sys, const potential_type& pot) override;
 
-    void reduce_margin(neighbor_list_type&, const real_type,
+    bool reduce_margin(neighbor_list_type&, const real_type,
                        const system_type&, const potential_type&) override
     {
-        return;
+        return false;
     }
     void scale_margin(neighbor_list_type&, const real_type,
                       const system_type&, const potential_type&) override

--- a/mjolnir/core/PeriodicGridCellList.hpp
+++ b/mjolnir/core/PeriodicGridCellList.hpp
@@ -67,15 +67,16 @@ class PeriodicGridCellList final : public SpatialPartitionBase<traitsT, Potentia
     void make  (neighbor_list_type& neighbors,
                 const system_type& sys, const potential_type& pot) override;
 
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
                        const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override

--- a/mjolnir/core/PeriodicGridCellList.hpp
+++ b/mjolnir/core/PeriodicGridCellList.hpp
@@ -78,15 +78,16 @@ class PeriodicGridCellList final : public SpatialPartitionBase<traitsT, Potentia
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/core/SpatialPartitionBase.hpp
+++ b/mjolnir/core/SpatialPartitionBase.hpp
@@ -119,11 +119,10 @@ class SpatialPartition
     {
         return partition_->reduce_margin(neighbors_, dmargin, sys, pot);
     }
-    void scale_margin(const real_type scale, const system_type& sys,
+    bool scale_margin(const real_type scale, const system_type& sys,
                       const potential_type& pot)
     {
-        partition_->scale_margin(neighbors_, scale, sys, pot);
-        return ;
+        return partition_->scale_margin(neighbors_, scale, sys, pot);
     }
 
     real_type cutoff() const noexcept {return partition_->cutoff();}

--- a/mjolnir/core/SpatialPartitionBase.hpp
+++ b/mjolnir/core/SpatialPartitionBase.hpp
@@ -48,7 +48,7 @@ class SpatialPartitionBase
     virtual void make  (neighbor_list_type&,
             const system_type&, const potential_type&) = 0;
 
-    virtual void reduce_margin(neighbor_list_type&, const real_type,
+    virtual bool reduce_margin(neighbor_list_type&, const real_type,
             const system_type&, const potential_type&) = 0;
 
     virtual void scale_margin(neighbor_list_type&, const real_type,
@@ -112,11 +112,12 @@ class SpatialPartition
         partition_->make(neighbors_, sys, pot);
         return ;
     }
-    void reduce_margin(const real_type dmargin, const system_type& sys,
+
+    // reduce_margin return true if neighbour list is updated
+    bool reduce_margin(const real_type dmargin, const system_type& sys,
                        const potential_type& pot)
     {
-        partition_->reduce_margin(neighbors_, dmargin, sys, pot);
-        return ;
+        return partition_->reduce_margin(neighbors_, dmargin, sys, pot);
     }
     void scale_margin(const real_type scale, const system_type& sys,
                       const potential_type& pot)

--- a/mjolnir/core/SpatialPartitionBase.hpp
+++ b/mjolnir/core/SpatialPartitionBase.hpp
@@ -51,7 +51,7 @@ class SpatialPartitionBase
     virtual bool reduce_margin(neighbor_list_type&, const real_type,
             const system_type&, const potential_type&) = 0;
 
-    virtual void scale_margin(neighbor_list_type&, const real_type,
+    virtual bool scale_margin(neighbor_list_type&, const real_type,
             const system_type&, const potential_type&) = 0;
 
     virtual real_type cutoff() const noexcept = 0;

--- a/mjolnir/core/UnlimitedGridCellList.hpp
+++ b/mjolnir/core/UnlimitedGridCellList.hpp
@@ -67,15 +67,16 @@ class UnlimitedGridCellList final : public SpatialPartitionBase<traitsT, Potenti
     void make(neighbor_list_type& neighbors,
               const system_type& sys, const potential_type& pot) override;
 
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
                        const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override

--- a/mjolnir/core/UnlimitedGridCellList.hpp
+++ b/mjolnir/core/UnlimitedGridCellList.hpp
@@ -78,15 +78,16 @@ class UnlimitedGridCellList final : public SpatialPartitionBase<traitsT, Potenti
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/core/VerletList.hpp
+++ b/mjolnir/core/VerletList.hpp
@@ -62,15 +62,16 @@ class VerletList final : public SpatialPartitionBase<traitsT, PotentialT>
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/core/VerletList.hpp
+++ b/mjolnir/core/VerletList.hpp
@@ -51,15 +51,16 @@ class VerletList final : public SpatialPartitionBase<traitsT, PotentialT>
     void make  (neighbor_list_type& neighbors,
                 const system_type& sys, const potential_type& pot) override;
 
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
                        const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override

--- a/mjolnir/core/ZorderRTree.hpp
+++ b/mjolnir/core/ZorderRTree.hpp
@@ -87,15 +87,16 @@ class ZorderRTree final : public SpatialPartitionBase<traitsT, PotentialT>
     void make(neighbor_list_type& neighbors,
               const system_type& sys, const potential_type& pot) override;
 
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
                        const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override

--- a/mjolnir/core/ZorderRTree.hpp
+++ b/mjolnir/core/ZorderRTree.hpp
@@ -98,15 +98,16 @@ class ZorderRTree final : public SpatialPartitionBase<traitsT, PotentialT>
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
                 const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/omp/PeriodicGridCellList.hpp
+++ b/mjolnir/omp/PeriodicGridCellList.hpp
@@ -341,15 +341,16 @@ class PeriodicGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         return ;
     }
 
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
         const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
         if(this->current_margin_ < 0)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
         const system_type& sys, const potential_type& pot) override

--- a/mjolnir/omp/PeriodicGridCellList.hpp
+++ b/mjolnir/omp/PeriodicGridCellList.hpp
@@ -352,15 +352,16 @@ class PeriodicGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
         const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0.)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/omp/UnlimitedGridCellList.hpp
+++ b/mjolnir/omp/UnlimitedGridCellList.hpp
@@ -320,15 +320,16 @@ class UnlimitedGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         }
         return false;
     }
-    void scale_margin(neighbor_list_type& neighbors, const real_type scale,
+    bool scale_margin(neighbor_list_type& neighbors, const real_type scale,
         const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ = (cutoff_ + current_margin_) * scale - cutoff_;
         if(this->current_margin_ < 0.)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
 
     real_type cutoff() const noexcept override {return this->cutoff_;}

--- a/mjolnir/omp/UnlimitedGridCellList.hpp
+++ b/mjolnir/omp/UnlimitedGridCellList.hpp
@@ -308,7 +308,7 @@ class UnlimitedGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
     }
 
     //XXX do NOT call this from `parallel` region.
-    void reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
+    bool reduce_margin(neighbor_list_type& neighbors, const real_type dmargin,
         const system_type& sys, const potential_type& pot) override
     {
         this->current_margin_ -= dmargin;
@@ -316,8 +316,9 @@ class UnlimitedGridCellList<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
         if(this->current_margin_ < 0.)
         {
             this->make(neighbors, sys, pot);
+            return true;
         }
-        return ;
+        return false;
     }
     void scale_margin(neighbor_list_type& neighbors, const real_type scale,
         const system_type& sys, const potential_type& pot) override


### PR DESCRIPTION
The global interaction which I'm implementing now (https://github.com/Mjolnir-MD/Mjolnir/pull/236) needs the information that the neighbor list is updated or not in the current simulation step.
The interaction, which is based on GlobalInteractionBase, calls reduce_margin of SpatialPartiion, so, in this PR, I enable this reduce_margin method can notify that information via returned bool value.