### PR TITLE
fix: make error message concise

### DIFF
--- a/mjolnir/core/DCDLoader.hpp
+++ b/mjolnir/core/DCDLoader.hpp
@@ -129,6 +129,12 @@ class DCDLoader final : public LoaderBase<traitsT>
         MJOLNIR_GET_DEFAULT_LOGGER();
         MJOLNIR_LOG_FUNCTION();
 
+        file_.peek();
+        if(file_.eof())
+        {
+            return false;
+        }
+
         this->read_unitcell_if_needed(sys.boundary());
         {
             const auto block_beg = detail::read_bytes_as<std::int32_t>(file_);

--- a/mjolnir/core/DCDLoader.hpp
+++ b/mjolnir/core/DCDLoader.hpp
@@ -141,7 +141,9 @@ class DCDLoader final : public LoaderBase<traitsT>
             if(block_beg != block_end)
             {
                 MJOLNIR_LOG_WARN("DCD file ", filename_, " seems to be broken.");
-                MJOLNIR_LOG_WARN("Size of the coordinate block is inconsistent");
+                MJOLNIR_LOG_WARN("Size of the X coordinate block is inconsistent."
+                                 " Block header says there are ", block_beg,
+                  " bytes, and the block footer says ", block_end, " bytes.");
                 return false;
             }
         }
@@ -156,7 +158,9 @@ class DCDLoader final : public LoaderBase<traitsT>
             if(block_beg != block_end)
             {
                 MJOLNIR_LOG_WARN("DCD file ", filename_, " seems to be broken.");
-                MJOLNIR_LOG_WARN("Size of the coordinate block is inconsistent");
+                MJOLNIR_LOG_WARN("Size of the Y coordinate block is inconsistent."
+                                 " Block header says there are ", block_beg,
+                  " bytes, and the block footer says ", block_end, " bytes.");
                 return false;
             }
         }
@@ -171,7 +175,10 @@ class DCDLoader final : public LoaderBase<traitsT>
             if(block_beg != block_end)
             {
                 MJOLNIR_LOG_WARN("DCD file ", filename_, " seems to be broken.");
-                MJOLNIR_LOG_WARN("Size of the coordinate block is inconsistent");
+                MJOLNIR_LOG_WARN("Size of the Z coordinate block is inconsistent."
+                                 " Block header says there are ", block_beg,
+                  " bytes, and the block footer says ", block_end, " bytes.");
+
                 return false;
             }
         }

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -341,11 +341,49 @@ read_energy_calculation_simulator(
     }
 
     // clear all parameters once
+    bool position_found = false;
+    bool velocity_found = false;
     for(std::size_t i=0; i<sys.size(); ++i)
     {
         const auto& p = particles.at(i);
-        // position(pos), velocity(vel) are ignored here
-        check_keys_available(p, {"m"_s, "mass"_s, "name"_s, "group"_s});
+        check_keys_available(p, {"m"_s, "mass"_s, "pos"_s, "position"_s,
+                "vel"_s, "velocity"_s, "name"_s, "group"_s});
+
+        if( ! position_found)
+        {
+            for(const auto key : {"pos"_s, "position"_s})
+            {
+                if( ! p.contains(key))
+                {
+                    continue;
+                }
+                const auto err_msg = toml::format_error("unused value \""_s +
+                    key + "\" found. this will never be used."_s, p.at(key),
+                    "this will be ignored because trajectory file is given");
+
+                // workaround to skip auto-added [error].
+                MJOLNIR_LOG_WARN(err_msg.substr(err_msg.find("unused")));
+                position_found = true;
+            }
+        }
+
+        if( ! velocity_found )
+        {
+            for(const auto key : {"vel"_s, "velocity"_s})
+            {
+                if( ! p.contains(key))
+                {
+                    continue;
+                }
+                const auto err_msg = toml::format_error("unused value \""_s +
+                    key + "\" found. this will never be used."_s, p.at(key),
+                    "this will be ignored because trajectory file is given");
+
+                // workaround to skip auto-added [error].
+                MJOLNIR_LOG_WARN(err_msg.substr(err_msg.find("unused")));
+                position_found = true;
+            }
+        }
 
         if(p.as_table().count("m") == 1)
         {


### PR DESCRIPTION
Some of the error messages shown in the following cases are improved.
- Warning about explicitly initialized positions and velocities in `EnergyCalculation` simulator which overwrite the system coordinates by a state loaded from a specified file
- Warning about inconsistent block in a DCD file
- Suppress incorrect warnings that appears when `DCDLoader` reaches to the end of a file