### PR TITLE
feat: enable to write save_interval in dcd file header

### DIFF
--- a/mjolnir/core/DCDObserver.hpp
+++ b/mjolnir/core/DCDObserver.hpp
@@ -36,11 +36,12 @@ class DCDObserver final : public ObserverBase<traitsT>
     }
     ~DCDObserver() override {}
 
-    void initialize(const std::size_t total_step, const real_type dt,
+    void initialize(const std::size_t total_step,
+                    const std::size_t save_interval, const real_type dt,
                     const system_type& sys, const forcefield_type& ff) override
     {
-        this->write_header(this->pos_name_, total_step, dt, sys, ff);
-        this->write_header(this->vel_name_, total_step, dt, sys, ff);
+        this->write_header(this->pos_name_, total_step, save_interval, dt, sys, ff);
+        this->write_header(this->vel_name_, total_step, save_interval, dt, sys, ff);
 
         // buffer to convert sys and dcd format
         this->buffer_x_.resize(sys.size());
@@ -115,8 +116,8 @@ class DCDObserver final : public ObserverBase<traitsT>
         return;
     }
 
-    void write_header(const std::string& fname,
-                      const std::size_t  total_step_sz, const real_type dt,
+    void write_header(const std::string& fname, const std::size_t total_step,
+                      const std::size_t  save_interval, const real_type dt,
                       const system_type& sys, const forcefield_type& ff) const
     {
         std::ofstream ofs(fname, std::ios::binary | std::ios::app);
@@ -138,11 +139,11 @@ class DCDObserver final : public ObserverBase<traitsT>
             const std::int32_t index_of_first(0);
             detail::write_as_bytes(ofs, index_of_first);
 
-            const std::int32_t save_interval(0);
-            detail::write_as_bytes(ofs, save_interval);
+            const std::int32_t save_interval_i32(save_interval);
+            detail::write_as_bytes(ofs, save_interval_i32);
 
-            const std::int32_t total_step(total_step_sz);
-            detail::write_as_bytes(ofs, total_step);
+            const std::int32_t total_step_i32(total_step);
+            detail::write_as_bytes(ofs, total_step_i32);
 
             const std::int32_t total_chains(ff->topology().number_of_molecules());
             detail::write_as_bytes(ofs, total_chains);

--- a/mjolnir/core/EnergyCalculationSimulator.hpp
+++ b/mjolnir/core/EnergyCalculationSimulator.hpp
@@ -73,7 +73,8 @@ inline void EnergyCalculationSimulator<traitsT>::initialize()
 
     this->ff_->initialize(this->sys_);
 
-    this->obs_.initialize(this->total_step_, 0.0, this->sys_, this->ff_);
+    // Since neither save_step nor delta_t are not saved, we add some dummy value.
+    this->obs_.initialize(this->total_step_, 1, 1.0, this->sys_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -32,7 +32,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
     }
     ~EnergyObserver() override {}
 
-    void initialize(const std::size_t, const real_type,
+    void initialize(const std::size_t, const std::size_t, const real_type,
                     const system_type& sys, const forcefield_type& ff) override
     {
         using phys_constants = physics::constants<real_type>;

--- a/mjolnir/core/MolecularDynamicsSimulator.hpp
+++ b/mjolnir/core/MolecularDynamicsSimulator.hpp
@@ -75,8 +75,8 @@ void MolecularDynamicsSimulator<traitsT, integratorT>::initialize()
     this->ff_->initialize(this->system_);
     this->integrator_.initialize(this->system_, this->ff_, this->rng_);
 
-    observers_.initialize(this->total_step_, this->integrator_.delta_t(),
-                          this->system_, this->ff_);
+    observers_.initialize(this->total_step_, this->save_step_,
+                          this->integrator_.delta_t(), this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/ObserverBase.hpp
+++ b/mjolnir/core/ObserverBase.hpp
@@ -23,7 +23,8 @@ class ObserverBase
     virtual ~ObserverBase() {}
 
     // open files, write header and so on.
-    virtual void initialize(const std::size_t total_step, const real_type dt,
+    virtual void initialize(const std::size_t total_step,
+                            const std::size_t save_interval, const real_type dt,
                             const system_type&, const forcefield_type&) = 0;
     // call if system or forcefield is changed.
     virtual void update    (const std::size_t step,       const real_type dt,

--- a/mjolnir/core/ObserverContainer.hpp
+++ b/mjolnir/core/ObserverContainer.hpp
@@ -38,12 +38,13 @@ class ObserverContainer
     ObserverContainer& operator=(ObserverContainer&&)      = default;
 
     // open files, write header and so on.
-    void initialize(const std::size_t total_step, const real_type dt,
+    void initialize(const std::size_t total_step,
+                    const std::size_t save_interval, const real_type dt,
                     const system_type& sys, const forcefield_type& ff)
     {
         for(const auto& obs : observers_)
         {
-            obs->initialize(total_step, dt, sys, ff);
+            obs->initialize(total_step, save_interval, dt, sys, ff);
         }
 
         this->progress_bar_.reset(total_step); // set total_step as 100%.

--- a/mjolnir/core/SimulatedAnnealingSimulator.hpp
+++ b/mjolnir/core/SimulatedAnnealingSimulator.hpp
@@ -113,8 +113,8 @@ SimulatedAnnealingSimulator<traitsT, integratorT, scheduleT>::initialize()
     this->ff_->initialize(this->system_);
     this->integrator_.initialize(this->system_, this->ff_, this->rng_);
 
-    observers_.initialize(this->total_step_, this->integrator_.delta_t(),
-                          this->system_, this->ff_);
+    observers_.initialize(this->total_step_, this->total_step_,
+                          this->integrator_.delta_t(), this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/SteepestDescentSimulator.hpp
+++ b/mjolnir/core/SteepestDescentSimulator.hpp
@@ -68,8 +68,8 @@ inline void SteepestDescentSimulator<traitsT>::initialize()
     // here, steepest_descent method has no physical `time`.
     // There is nothing we can except filling it with zero or something
     // that works as a marker.
-    this->observers_.initialize(this->step_limit_, /* dt */ real_type(0.0),
-                                this->system_, this->ff_);
+    this->observers_.initialize(this->step_limit_, this->save_step_,
+       /* there is no dt, so */ h_, this->system_, this->ff_);
     return;
 }
 

--- a/mjolnir/core/SwitchingForceFieldSimulator.hpp
+++ b/mjolnir/core/SwitchingForceFieldSimulator.hpp
@@ -137,8 +137,8 @@ inline void SwitchingForceFieldSimulator<traitsT, integratorT>::initialize()
     ff->initialize(this->system_);
     this->integrator_.initialize(this->system_, ff, this->rng_);
 
-    observers_.initialize(this->total_step_, this->integrator_.delta_t(),
-                          this->system_, ff);
+    observers_.initialize(this->total_step_, this->save_step_,
+                          this->integrator_.delta_t(), this->system_, ff);
 
     return;
 }

--- a/mjolnir/core/TRRObserver.hpp
+++ b/mjolnir/core/TRRObserver.hpp
@@ -40,7 +40,7 @@ class TRRObserver final : public ObserverBase<traitsT>
     }
     ~TRRObserver() override {}
 
-    void initialize(const std::size_t,  const real_type,
+    void initialize(const std::size_t,  const std::size_t, const real_type,
                     const system_type&, const forcefield_type&) override
     {
         MJOLNIR_GET_DEFAULT_LOGGER();

--- a/mjolnir/core/XYZObserver.hpp
+++ b/mjolnir/core/XYZObserver.hpp
@@ -32,7 +32,7 @@ class XYZObserver final : public ObserverBase<traitsT>
     }
     ~XYZObserver() override {}
 
-    void initialize(const std::size_t,  const real_type,
+    void initialize(const std::size_t,  const std::size_t, const real_type,
                     const system_type&, const forcefield_type&) override
     {
         // do nothing.


### PR DESCRIPTION
fixes #289 .

Since other file format does not require save step interval, it currently output a dummy value, 0. But there exist some tool that requires the value and a dummy value will cause a problem in that case.