### PR TITLE
feat: calculate virial

### DIFF
--- a/mjolnir/core/BAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/BAOABLangevinIntegrator.hpp
@@ -22,6 +22,7 @@ class BAOABLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -125,6 +126,7 @@ void BAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;
@@ -161,6 +163,7 @@ BAOABLangevinIntegrator<traitsT>::step(
         // collect largest displacement
         largest_disp2 = std::max(largest_disp2, math::length_sq(dp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/BAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/BAOABLangevinIntegrator.hpp
@@ -126,7 +126,7 @@ void BAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
-        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;

--- a/mjolnir/core/BoundaryCondition.hpp
+++ b/mjolnir/core/BoundaryCondition.hpp
@@ -30,6 +30,12 @@ struct UnlimitedBoundary
         return r;
     }
 
+    // transpose `target` with respect to ref to make it the nearest pair
+    coordinate_type transpose(coordinate_type target, const coordinate_type& /*ref*/) const noexcept
+    {
+        return target;
+    }
+
     void set_boundary(const coordinate_type&, const coordinate_type&) noexcept {assert(false);}
     void set_lower_bound(const coordinate_type&) noexcept {assert(false);}
     void set_upper_bound(const coordinate_type&) noexcept {assert(false);}
@@ -94,6 +100,13 @@ struct CuboidalPeriodicBoundary
         else if(math::Z(pos) >= math::Z(upper_)) {math::Z(pos) -= math::Z(width_);}
         return pos;
     }
+
+    // transpose `target` with respect to ref to make it the nearest pair
+    coordinate_type transpose(coordinate_type target, const coordinate_type& ref) const noexcept
+    {
+        return ref + this->adjust_direction(ref, target);
+    }
+
 
     coordinate_type const& lower_bound() const noexcept {return lower_;}
     coordinate_type const& upper_bound() const noexcept {return upper_;}

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -45,11 +45,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         ff->format_energy_name(names); // write into it
         ofs << names;
 
-        ofs << " kinetic_energy";
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << "             Pxx             Pyy             Pzz";
-        }
+        ofs << " kinetic_energy             Pxx             Pyy             Pzz";
         for(const auto& attr : sys.attributes())
         {
             ofs << " attribute:" << attr.first;
@@ -69,11 +65,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         ff->format_energy_name(names); // write into it
         ofs << names;
 
-        ofs << " kinetic_energy";
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << "             Pxx             Pyy             Pzz";
-        }
+        ofs << " kinetic_energy             Pxx             Pyy             Pzz";
         for(const auto& attr : sys.attributes())
         {
             ofs << " attribute:" << attr.first;
@@ -107,17 +99,14 @@ class EnergyObserver final : public ObserverBase<traitsT>
                 is_cuboidal_periodic_boundary<boundary_type>{});
 
         ofs << std::setw(14) << std::right << std::fixed << Ek;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Px;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Py;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Pz;
         if(!is_finite(Ek))
         {
             MJOLNIR_GET_DEFAULT_LOGGER();
             MJOLNIR_LOG_ERROR("kinetic energy becomes NaN.");
             is_ok = false;
-        }
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Px;
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Py;
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Pz;
         }
 
         for(const auto& attr : sys.attributes())
@@ -149,16 +138,16 @@ class EnergyObserver final : public ObserverBase<traitsT>
   private:
 
     std::tuple<real_type, real_type, real_type, real_type>
-    calc_energy_and_pressure(const system_type& sys, std::true_type)
+    calc_energy_and_pressure(const system_type& sys)
     {
         const auto cell_width = sys.boundary().width();
         const auto volume = math::X(cell_width) * math::Y(cell_width) * math::Z(cell_width);
         const auto rvolume = real_type(1) / volume;
 
         real_type Ek(0);
-        real_type Px(0);
-        real_type Py(0);
-        real_type Pz(0);
+        real_type Px(sys.virial()(0, 0));
+        real_type Py(sys.virial()(1, 1));
+        real_type Pz(sys.virial()(2, 2));
 
         for(std::size_t i=0; i<sys.size(); ++i)
         {
@@ -168,30 +157,15 @@ class EnergyObserver final : public ObserverBase<traitsT>
             const auto& f = sys.force(i);
 
             Ek += math::length_sq(v) * m;
-            Px += m * math::X(v) * math::X(v) + math::X(f) * math::X(r);
-            Py += m * math::Y(v) * math::Y(v) + math::Y(f) * math::Y(r);
-            Pz += m * math::Z(v) * math::Z(v) + math::Z(f) * math::Z(r);
+            Px += m * math::X(v) * math::X(v);
+            Py += m * math::Y(v) * math::Y(v);
+            Pz += m * math::Z(v) * math::Z(v);
         }
         Ek *= 0.5;
         Px *= rvolume;
         Py *= rvolume;
         Pz *= rvolume;
-
         return std::make_tuple(Ek, Px, Py, Pz);
-    }
-
-    std::tuple<real_type, real_type, real_type, real_type>
-    calc_energy_and_pressure(const system_type& sys, std::false_type)
-    {
-        real_type Ek(0);
-        for(std::size_t i=0; i<sys.size(); ++i)
-        {
-            const auto  m = sys.mass(i);
-            const auto& v = sys.velocity(i);
-            Ek += math::length_sq(v) * m;
-        }
-        Ek *= 0.5;
-        return std::make_tuple(Ek, real_type(0.0), real_type(0.0), real_type(0.0));
     }
 
     void clear_file(const std::string& fname) const

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -95,8 +95,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         }
 
         real_type Ek(0), Px(0), Py(0), Pz(0);
-        std::tie(Ek, Px, Py, Pz) = this->calc_energy_and_pressure(sys,
-                is_cuboidal_periodic_boundary<boundary_type>{});
+        std::tie(Ek, Px, Py, Pz) = this->calc_energy_and_pressure(sys);
 
         ofs << std::setw(14) << std::right << std::fixed << Ek;
         ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Px;
@@ -152,9 +151,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         for(std::size_t i=0; i<sys.size(); ++i)
         {
             const auto  m = sys.mass(i);
-            const auto& r = sys.position(i);
             const auto& v = sys.velocity(i);
-            const auto& f = sys.force(i);
 
             Ek += math::length_sq(v) * m;
             Px += m * math::X(v) * math::X(v);

--- a/mjolnir/core/GJFNVTLangevinIntegrator.hpp
+++ b/mjolnir/core/GJFNVTLangevinIntegrator.hpp
@@ -62,6 +62,7 @@ class GJFNVTLangevinIntegrator
             {
                 sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
             }
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
             ff->calc_force(sys);
         }
         return;
@@ -165,6 +166,7 @@ GJFNVTLangevinIntegrator<traitsT>::step(const real_type time,
         // collect largest displacement
         largest_disp2 = std::max(largest_disp2, math::length_sq(dp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/GJFNVTLangevinIntegrator.hpp
+++ b/mjolnir/core/GJFNVTLangevinIntegrator.hpp
@@ -22,6 +22,7 @@ class GJFNVTLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;

--- a/mjolnir/core/MsgPackLoader.hpp
+++ b/mjolnir/core/MsgPackLoader.hpp
@@ -223,6 +223,29 @@ class MsgPackLoader
         sys.force_initialized() = true;
 
         // -----------------------------------------------------------------------
+        // load virial
+
+        this->check_msgpack_key(file, filename, "virial");
+        {
+            const auto tag = detail::read_bytes_as<std::uint8_t>(file);
+            if(tag != 0x99)
+            {
+                throw_exception<std::runtime_error>("[error] mjolnir::MsgPackLoader:"
+                        "expected tag 0x99, but got ", std::hex, std::uint32_t(tag));
+            }
+            auto& vir = sys.virial();
+            vir(0, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(0, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(0, 2) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 2) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 2) = this->from_msgpack<real_type>(file, filename);
+        }
+
+        // -----------------------------------------------------------------------
         // load attributes
 
         this->check_msgpack_key(file, filename, "attributes");

--- a/mjolnir/core/MsgPackSaver.hpp
+++ b/mjolnir/core/MsgPackSaver.hpp
@@ -28,6 +28,7 @@ namespace mjolnir
 //             "group"   : string,
 //         }, ...
 //     ]
+//     "virial"       : [real; 9]
 //     "attributres"  : map<N>{"temperature": real, ...},
 // }
 //
@@ -142,6 +143,12 @@ class MsgPackSaver
         }
 
         // ---------------------------------------------------------------------
+        // write virial of the current state
+
+        to_msgpack("virial");
+        to_msgpack(sys.virial());
+
+        // ---------------------------------------------------------------------
         // write attributes list
 
         to_msgpack("attributes");
@@ -224,7 +231,7 @@ class MsgPackSaver
     void to_msgpack(const coordinate_type& v)
     {
         // [float, float, float]
-        // fixmap (3)
+        // fixarray (3)
         // 0b'1001'0011
         // 0x    9    3
         constexpr std::uint8_t fixarray3_code = 0x93;
@@ -232,6 +239,26 @@ class MsgPackSaver
         to_msgpack(math::X(v));
         to_msgpack(math::Y(v));
         to_msgpack(math::Z(v));
+        return ;
+    }
+
+    void to_msgpack(const matrxi33_type& m)
+    {
+        // [float; 9]
+        // fixarray (9)
+        // 0b'1001'1001
+        // 0x    9    3
+        constexpr std::uint8_t fixarray9_code = 0x99;
+        buffer_.push_back(fixarray9_code);
+        to_msgpack(m(0, 0));
+        to_msgpack(m(0, 1));
+        to_msgpack(m(0, 2));
+        to_msgpack(m(1, 0));
+        to_msgpack(m(1, 1));
+        to_msgpack(m(1, 2));
+        to_msgpack(m(2, 0));
+        to_msgpack(m(2, 1));
+        to_msgpack(m(2, 2));
         return ;
     }
 

--- a/mjolnir/core/MsgPackSaver.hpp
+++ b/mjolnir/core/MsgPackSaver.hpp
@@ -42,6 +42,7 @@ class MsgPackSaver
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traits_type>;
     using attribute_type  = typename system_type::attribute_type;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -242,7 +243,7 @@ class MsgPackSaver
         return ;
     }
 
-    void to_msgpack(const matrxi33_type& m)
+    void to_msgpack(const matrix33_type& m)
     {
         // [float; 9]
         // fixarray (9)

--- a/mjolnir/core/System.hpp
+++ b/mjolnir/core/System.hpp
@@ -101,6 +101,10 @@ class System
     {
         return boundary_.adjust_position(dr);
     }
+    coordinate_type transpose(coordinate_type tgt, const coordinate_type& ref) const noexcept
+    {
+        return boundary_.transpose(tgt, ref);
+    }
 
     std::size_t size() const noexcept {return num_particles_;}
 

--- a/mjolnir/core/System.hpp
+++ b/mjolnir/core/System.hpp
@@ -22,6 +22,7 @@ class System
     using string_type     = std::string;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using boundary_type   = typename traits_type::boundary_type;
     using topology_type   = Topology;
     using attribute_type  = std::map<std::string, real_type>;
@@ -39,7 +40,7 @@ class System
 
     System(const std::size_t num_particles, const boundary_type& bound)
         : velocity_initialized_(false), force_initialized_(false),
-          boundary_(bound), attributes_(),
+          boundary_(bound), attributes_(), virial_(0,0,0, 0,0,0, 0,0,0),
           num_particles_(num_particles), masses_   (num_particles),
           rmasses_      (num_particles), positions_(num_particles),
           velocities_   (num_particles), forces_   (num_particles),
@@ -168,6 +169,9 @@ class System
     string_type const& group(std::size_t i) const noexcept {return groups_[i];}
     string_type&       group(std::size_t i)       noexcept {return groups_[i];}
 
+    matrix33_type&       virial()       noexcept {return virial_;}
+    matrix33_type const& virial() const noexcept {return virial_;}
+
     boundary_type&       boundary()       noexcept {return boundary_;}
     boundary_type const& boundary() const noexcept {return boundary_;}
 
@@ -191,6 +195,7 @@ class System
     bool           velocity_initialized_, force_initialized_;
     boundary_type  boundary_;
     attribute_type attributes_;
+    matrix33_type  virial_;
 
     std::size_t                  num_particles_;
     real_container_type          masses_;

--- a/mjolnir/core/UnderdampedLangevinIntegrator.hpp
+++ b/mjolnir/core/UnderdampedLangevinIntegrator.hpp
@@ -24,6 +24,7 @@ class UnderdampedLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -123,7 +124,7 @@ void UnderdampedLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
-        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
         // calculate force
         ff->calc_force(system);

--- a/mjolnir/core/UnderdampedLangevinIntegrator.hpp
+++ b/mjolnir/core/UnderdampedLangevinIntegrator.hpp
@@ -123,6 +123,7 @@ void UnderdampedLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
         // calculate force
         ff->calc_force(system);
@@ -170,6 +171,7 @@ UnderdampedLangevinIntegrator<traitsT>::step(
 
         largest_disp2 = std::max(largest_disp2, math::length_sq(displacement));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/VelocityVerletIntegrator.hpp
+++ b/mjolnir/core/VelocityVerletIntegrator.hpp
@@ -17,6 +17,7 @@ class VelocityVerletIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traitsT>;
@@ -73,7 +74,7 @@ void VelocityVerletIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
-        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;

--- a/mjolnir/core/VelocityVerletIntegrator.hpp
+++ b/mjolnir/core/VelocityVerletIntegrator.hpp
@@ -73,6 +73,7 @@ void VelocityVerletIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;
@@ -95,6 +96,7 @@ VelocityVerletIntegrator<traitsT>::step(
 
         largest_disp2 = std::max(largest_disp2, math::length_sq(disp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/gBAOABLangevinIntegrator.hpp
@@ -20,6 +20,7 @@ class gBAOABLangevinIntegrator
     using traits_type      = traitsT;
     using real_type        = typename traits_type::real_type;
     using coordinate_type  = typename traits_type::coordinate_type;
+    using matrix33_type    = typename traits_type::matrix33_type;
     using indices_type     = std::array<std::size_t, 2>;
     using system_type      = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
@@ -242,7 +243,7 @@ void gBAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
-        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
 

--- a/mjolnir/core/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/gBAOABLangevinIntegrator.hpp
@@ -242,6 +242,7 @@ void gBAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
 
@@ -324,6 +325,7 @@ gBAOABLangevinIntegrator<traitsT>::step(
         // reset force
         sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);
 

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -157,8 +157,12 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    sys.force(Bi) -= dU_rep * Bji_reg;
-                    sys.force(Bj) -= dU_rep * Bij_reg;
+                    const auto F = -dU_rep * Bji_reg;
+                    sys.force(Bi) += F;
+                    sys.force(Bj) -= F;
+
+                    // Bij = Bj - Bi
+                    sys.virial() += math::tensor_product(Bij, -F);
                 }
             }
 
@@ -245,6 +249,11 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
 
                 if(cos_dphi != real_type(-1.0))
                 {
+                    auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                     const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
 
                     // --------------------------------------------------------
@@ -263,10 +272,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                         const auto coef_Bi = dot_SBiBj * rlBij_sq;
                         const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                        sys.force(Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                        sys.force(Sj) += fSj;
+                        f_Si += fSi;
+                        f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                        f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                        f_Sj += fSj;
                     }
 
                     const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -287,9 +296,9 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                                          (cos_theta1 * BSi_reg - Bij_reg);
                         const auto fBj = (coef_rsin * rlBij) *
                                          (cos_theta1 * Bij_reg - BSi_reg);
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) -= (fSi + fBj);
-                        sys.force(Bj) += fBj;
+                        f_Si += fSi;
+                        f_Bi -= (fSi + fBj);
+                        f_Bj += fBj;
                     }
                     // --------------------------------------------------------
                     // calc theta2 term
@@ -307,9 +316,9 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                                          (cos_theta2 * Bji_reg - BSj_reg);
                         const auto fSj = (coef_rsin * rlSBj) *
                                          (cos_theta2 * BSj_reg - Bji_reg);
-                        sys.force(Bi) += fBi;
-                        sys.force(Bj) -= (fBi + fSj);
-                        sys.force(Sj) += fSj;
+                        f_Bi += fBi;
+                        f_Bj -= (fBi + fSj);
+                        f_Sj += fSj;
                     }
                     // --------------------------------------------------------
                     // calc distance
@@ -318,9 +327,19 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     {
                         // remember that F = -dU. Here `coef` = -dU.
                         const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                        sys.force(Bi) += coef * Bji_reg;
-                        sys.force(Bj) += coef * Bij_reg;
+                        f_Bi += coef * Bji_reg;
+                        f_Bj += coef * Bij_reg;
                     }
+
+                    sys.force(Si) += f_Si;
+                    sys.force(Bi) += f_Bi;
+                    sys.force(Bj) += f_Bj;
+                    sys.force(Sj) += f_Sj;
+
+                    sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                     math::tensor_product(                   rBi , f_Bi) +
+                                     math::tensor_product(             rBi + Bij,  f_Bj) +
+                                     math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
                 }
             }
 
@@ -381,6 +400,13 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
             const auto fSi_theta3 = real_type(-1) * fBi_theta3;
             const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+            auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
             // adjacent of Base j exists. its not the edge of the strand.
             if(Bj_next_exists)
             {
@@ -426,10 +452,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -443,17 +469,17 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                         const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                         const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                        sys.force(Si)      += fSi;
-                        sys.force(Bi)      -= (fSi + fBj5);
-                        sys.force(Bj_next) += fBj5;
+                        f_Si      += fSi;
+                        f_Bi      -= (fSi + fBj5);
+                        f_Bj_next += fBj5;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bi)      += coef * Bj5i_reg;
-                        sys.force(Bj_next) -= coef * Bj5i_reg;
+                        f_Bi      += coef * Bj5i_reg;
+                        f_Bj_next -= coef * Bj5i_reg;
                     }
                 }
             }
@@ -500,10 +526,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -516,20 +542,34 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
 
                         const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                         const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                        sys.force(Sj)      += fSj;
-                        sys.force(Bj)      -= (fSj + fBi3);
-                        sys.force(Bi_next) += fBi3;
+                        f_Sj      += fSj;
+                        f_Bj      -= (fSj + fBi3);
+                        f_Bi_next += fBi3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bj)      += coef * Bi3j_reg;
-                        sys.force(Bi_next) -= coef * Bi3j_reg;
+                        f_Bj      += coef * Bi3j_reg;
+                        f_Bi_next -= coef * Bi3j_reg;
                     }
                 }
             }
+
+            sys.force(Si)      += f_Si     ;
+            sys.force(Sj)      += f_Sj     ;
+            sys.force(Bi)      += f_Bi     ;
+            sys.force(Bj)      += f_Bj     ;
+            sys.force(Bi_next) += f_Bi_next;
+            sys.force(Bj_next) += f_Bj_next;
+
+            sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                             math::tensor_product(                   rBi , f_Bi) +
+                             math::tensor_product(              rBi + Bij, f_Bj) +
+                             math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                             math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                             math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
         }
     }
     return;
@@ -849,8 +889,11 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    sys.force(Bi) -= dU_rep * Bji_reg;
-                    sys.force(Bj) -= dU_rep * Bij_reg;
+                    const auto F = dU_rep * Bji_reg;
+                    sys.force(Bi) -= F;
+                    sys.force(Bj) += F;
+
+                    sys.virial() += math::tensor_product(Bij, -F); // (Bj - Bi) * Fj
                 }
             }
 
@@ -941,6 +984,11 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
 
                 if(cos_dphi != real_type(-1.0))
                 {
+                    auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                     // --------------------------------------------------------
                     // calc dihedral term
                     // -sin(dphi)/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
@@ -957,10 +1005,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                         const auto coef_Bi = dot_SBiBj * rlBij_sq;
                         const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                        sys.force(Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                        sys.force(Sj) += fSj;
+                        f_Si += fSi;
+                        f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                        f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                        f_Sj += fSj;
                     }
 
                     const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -981,9 +1029,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                                          (cos_theta1 * BSi_reg - Bij_reg);
                         const auto fBj = (coef_rsin * rlBij) *
                                          (cos_theta1 * Bij_reg - BSi_reg);
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) -= (fSi + fBj);
-                        sys.force(Bj) += fBj;
+                        f_Si += fSi;
+                        f_Bi -= (fSi + fBj);
+                        f_Bj += fBj;
                     }
                     // --------------------------------------------------------
                     // calc theta2 term
@@ -1001,9 +1049,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                                          (cos_theta2 * Bji_reg - BSj_reg);
                         const auto fSj = (coef_rsin * rlSBj) *
                                          (cos_theta2 * BSj_reg - Bji_reg);
-                        sys.force(Bi) += fBi;
-                        sys.force(Bj) -= (fBi + fSj);
-                        sys.force(Sj) += fSj;
+                        f_Bi += fBi;
+                        f_Bj -= (fBi + fSj);
+                        f_Sj += fSj;
                     }
                     // --------------------------------------------------------
                     // calc distance
@@ -1012,9 +1060,19 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     {
                         // remember that F = -dU. Here `coef` = -dU.
                         const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                        sys.force(Bi) += coef * Bji_reg;
-                        sys.force(Bj) += coef * Bij_reg;
+                        f_Bi += coef * Bji_reg;
+                        f_Bj += coef * Bij_reg;
                     }
+
+                    sys.force(Si) += f_Si;
+                    sys.force(Bi) += f_Bi;
+                    sys.force(Bj) += f_Bj;
+                    sys.force(Sj) += f_Sj;
+
+                    sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                     math::tensor_product(                   rBi , f_Bi) +
+                                     math::tensor_product(              rBi + Bij, f_Bj) +
+                                     math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
                 }
             }
 
@@ -1075,6 +1133,13 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
             const auto fSi_theta3 = real_type(-1) * fBi_theta3;
             const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+            auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
             // adjacent of Base j exists. its not the edge of the strand.
             if(Bj_next_exists)
             {
@@ -1122,10 +1187,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1139,17 +1204,17 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                         const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                         const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                        sys.force(Si)      += fSi;
-                        sys.force(Bi)      -= (fSi + fBj5);
-                        sys.force(Bj_next) += fBj5;
+                        f_Si      += fSi;
+                        f_Bi      -= (fSi + fBj5);
+                        f_Bj_next += fBj5;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bi)      += coef * Bj5i_reg;
-                        sys.force(Bj_next) -= coef * Bj5i_reg;
+                        f_Bi      += coef * Bj5i_reg;
+                        f_Bj_next -= coef * Bj5i_reg;
                     }
                 }
             }
@@ -1198,10 +1263,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1214,20 +1279,33 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
 
                         const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                         const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                        sys.force(Sj)      += fSj;
-                        sys.force(Bj)      -= (fSj + fBi3);
-                        sys.force(Bi_next) += fBi3;
+                        f_Sj      += fSj;
+                        f_Bj      -= (fSj + fBi3);
+                        f_Bi_next += fBi3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bj)      += coef * Bi3j_reg;
-                        sys.force(Bi_next) -= coef * Bi3j_reg;
+                        f_Bj      += coef * Bi3j_reg;
+                        f_Bi_next -= coef * Bi3j_reg;
                     }
                 }
             }
+            sys.force(Si)      += f_Si     ;
+            sys.force(Sj)      += f_Sj     ;
+            sys.force(Bi)      += f_Bi     ;
+            sys.force(Bj)      += f_Bj     ;
+            sys.force(Bi_next) += f_Bi_next;
+            sys.force(Bj_next) += f_Bj_next;
+
+            sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                             math::tensor_product(                   rBi , f_Bi) +
+                             math::tensor_product(              rBi + Bij, f_Bj) +
+                             math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                             math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                             math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
         }
     }
     return energy;

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -889,9 +889,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    const auto F = dU_rep * Bji_reg;
-                    sys.force(Bi) -= F;
-                    sys.force(Bj) += F;
+                    const auto F = -dU_rep * Bji_reg;
+                    sys.force(Bi) += F;
+                    sys.force(Bj) -= F;
 
                     sys.virial() += math::tensor_product(Bij, -F); // (Bj - Bi) * Fj
                 }

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
@@ -450,7 +450,7 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
             // purely repulsive. add the repulsive force to the system and quit.
             sys.force(Bi) += f_Bi;
             sys.force(Bj) += f_Bj;
-            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
+            sys.virial() += math::tensor_product(Bji, f_Bi); // (Bi - Bj) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
@@ -205,14 +205,18 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         const auto lBji    = lBji_sq * rlBji;      // |Bji|
         const auto Bji_reg = Bji * rlBji;          // Bji / |Bji|
 
+        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+
         // ====================================================================
         // calc repulsive part, which does not depend on angle term.
 
         const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
         if(dU_rep != real_type(0.0))
         {
-            sys.force(Bi) -= dU_rep * Bji_reg;
-            sys.force(Bj) += dU_rep * Bji_reg;
+            f_Bi -= dU_rep * Bji_reg;
+            f_Bj += dU_rep * Bji_reg;
         }
 
         // --------------------------------------------------------------------
@@ -242,7 +246,10 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         const auto f_theta = potential_.f(theta, theta_0);
         if(f_theta == real_type(0.0))
         {
-            // purely repulsive.
+            // purely repulsive. add the repulsive force to the system and quit.
+            sys.force(Bi) += f_Bi;
+            sys.force(Bj) += f_Bj;
+            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);
@@ -263,9 +270,9 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
             const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
             const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-            sys.force(Si) +=  fSi;
-            sys.force(Bi) -= (fSi + fBj);
-            sys.force(Bj) +=        fBj;
+            f_Si +=  fSi;
+            f_Bi -= (fSi + fBj);
+            f_Bj +=        fBj;
         }
 
         // --------------------------------------------------------------------
@@ -275,9 +282,17 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         if(U_dU_attr.second != real_type(0.0))
         {
             const auto coef = f_theta * U_dU_attr.second;
-            sys.force(Bi) -= coef * Bji_reg;
-            sys.force(Bj) += coef * Bji_reg;
+            f_Bi -= coef * Bji_reg;
+            f_Bj += coef * Bji_reg;
         }
+
+        sys.force(Bi) += f_Bi;
+        sys.force(Bj) += f_Bj;
+        sys.force(Si) += f_Si;
+
+        sys.virial() += math::tensor_product(rBi,       f_Bi) +
+                        math::tensor_product(rBi - Bji, f_Bj) +
+                        math::tensor_product(rBi - SBi, f_Si);
     }
     return ;
 }
@@ -389,14 +404,18 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         const auto lBji    = lBji_sq * rlBji;      // |Bji|
         const auto Bji_reg = Bji * rlBji;          // Bji / |Bji|
 
+        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+
         // ====================================================================
         // calc repulsive part, which does not depend on angle term.
 
         const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
         if(dU_rep != real_type(0.0))
         {
-            sys.force(Bi) -= dU_rep * Bji_reg;
-            sys.force(Bj) += dU_rep * Bji_reg;
+            f_Bi -= dU_rep * Bji_reg;
+            f_Bj += dU_rep * Bji_reg;
         }
         energy += potential_.U_rep(bs_kind, lBji);
 
@@ -427,7 +446,10 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         const auto f_theta = potential_.f(theta, theta_0);
         if(f_theta == real_type(0.0))
         {
-            // purely repulsive.
+            // purely repulsive. add the repulsive force to the system and quit.
+            sys.force(Bi) += f_Bi;
+            sys.force(Bj) += f_Bj;
+            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);
@@ -450,9 +472,9 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
             const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
             const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-            sys.force(Si) +=  fSi;
-            sys.force(Bi) -= (fSi + fBj);
-            sys.force(Bj) +=        fBj;
+            f_Si +=  fSi;
+            f_Bi -= (fSi + fBj);
+            f_Bj +=        fBj;
         }
 
         // --------------------------------------------------------------------
@@ -462,9 +484,17 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         if(U_dU_attr.second != real_type(0.0))
         {
             const auto coef = f_theta * U_dU_attr.second;
-            sys.force(Bi) -= coef * Bji_reg;
-            sys.force(Bj) += coef * Bji_reg;
+            f_Bi -= coef * Bji_reg;
+            f_Bj += coef * Bji_reg;
         }
+
+        sys.force(Bi) += f_Bi;
+        sys.force(Bj) += f_Bj;
+        sys.force(Si) += f_Si;
+
+        sys.virial() += math::tensor_product(rBi,       f_Bi) +
+                        math::tensor_product(rBi - Bji, f_Bj) +
+                        math::tensor_product(rBi - SBi, f_Si);
     }
     return energy;
 }

--- a/mjolnir/forcefield/MultipleBasin/MultipleBasinUnitBase.hpp
+++ b/mjolnir/forcefield/MultipleBasin/MultipleBasinUnitBase.hpp
@@ -33,6 +33,7 @@ class MultipleBasinUnitBase
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traits_type>;
     using topology_type   = Topology;
 

--- a/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
+++ b/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
@@ -225,8 +225,13 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
 
             const auto factor = coef * (e_pwm + shift);
 
-            auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
-            auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_Ca  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_S   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B5  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B3  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaN = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaC = math::make_coordinate<coordinate_type>(0, 0, 0);
 
             // ----------------------------------------------------------------
             // calculate direction term
@@ -258,9 +263,9 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlBS ) *
                                 ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
 
-                F_Ca         -= Fi;
-                F_B          += (Fi + Fk);
-                sys.force(S) -= Fk;
+                F_Ca -= Fi;
+                F_B  += (Fi + Fk);
+                F_S  -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -280,10 +285,10 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlB53) *
                                 ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
 
-                F_Ca          -= Fi;
-                F_B           += Fi;
-                sys.force(B5) += Fk;
-                sys.force(B3) -= Fk;
+                F_Ca -= Fi;
+                F_B  += Fi;
+                F_B5 += Fk;
+                F_B3 -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -303,17 +308,30 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlCCN) *
                                 ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
 
-                F_Ca           -= Fi;
-                F_B            += Fi;
-                sys.force(CaC) += Fk;
-                sys.force(CaN) -= Fk;
+                F_Ca  -= Fi;
+                F_B   += Fi;
+                F_CaC += Fk;
+                F_CaN -= Fk;
             }
 
             // ----------------------------------------------------------------
             // collect force on Ca and B
 
-            sys.force(Ca) += F_Ca;
-            sys.force(B ) += F_B ;
+            sys.force(Ca)  += F_Ca;
+            sys.force(B )  += F_B;
+            sys.force(S)   += F_S;
+            sys.force(B5)  += F_B5;
+            sys.force(B3)  += F_B3;
+            sys.force(CaN) += F_CaN;
+            sys.force(CaC) += F_CaC;
+
+            sys.virial() += math::tensor_product(              rCa,        F_Ca)
+                         +  math::tensor_product(sys.transpose(rB,   rCa), F_B)
+                         +  math::tensor_product(sys.transpose(rS,   rCa), F_S)
+                         +  math::tensor_product(sys.transpose(rB5,  rCa), F_B5)
+                         +  math::tensor_product(sys.transpose(rB3,  rCa), F_B3)
+                         +  math::tensor_product(sys.transpose(rCaN, rCa), F_CaN)
+                         +  math::tensor_product(sys.transpose(rCaC, rCa), F_CaC);
         }
     }
     return ;
@@ -546,8 +564,13 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
             energy += factor * f_df.first *
                       g_dg_1.first * g_dg_2.first * g_dg_3.first;
 
-            auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
-            auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_Ca  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_S   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B5  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B3  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaN = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaC = math::make_coordinate<coordinate_type>(0, 0, 0);
 
             // ----------------------------------------------------------------
             // calculate direction term
@@ -579,9 +602,9 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlBS ) *
                                 ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
 
-                F_Ca         -= Fi;
-                F_B          += (Fi + Fk);
-                sys.force(S) -= Fk;
+                F_Ca -= Fi;
+                F_B  += (Fi + Fk);
+                F_S  -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -601,10 +624,10 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlB53) *
                                 ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
 
-                F_Ca          -= Fi;
-                F_B           += Fi;
-                sys.force(B5) += Fk;
-                sys.force(B3) -= Fk;
+                F_Ca -= Fi;
+                F_B  += Fi;
+                F_B5 += Fk;
+                F_B3 -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -624,17 +647,30 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlCCN) *
                                 ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
 
-                F_Ca           -= Fi;
-                F_B            += Fi;
-                sys.force(CaC) += Fk;
-                sys.force(CaN) -= Fk;
+                F_Ca  -= Fi;
+                F_B   += Fi;
+                F_CaC += Fk;
+                F_CaN -= Fk;
             }
 
             // ----------------------------------------------------------------
             // collect force on Ca and B
 
-            sys.force(Ca) += F_Ca;
-            sys.force(B ) += F_B ;
+            sys.force(Ca)  += F_Ca;
+            sys.force(B )  += F_B ;
+            sys.force(S)   += F_S;
+            sys.force(B5)  += F_B5;
+            sys.force(B3)  += F_B3;
+            sys.force(CaN) += F_CaN;
+            sys.force(CaC) += F_CaC;
+
+            sys.virial() += math::tensor_product(              rCa,        F_Ca)
+                         +  math::tensor_product(sys.transpose(rB,   rCa), F_B)
+                         +  math::tensor_product(sys.transpose(rS,   rCa), F_S)
+                         +  math::tensor_product(sys.transpose(rB5,  rCa), F_B5)
+                         +  math::tensor_product(sys.transpose(rB3,  rCa), F_B3)
+                         +  math::tensor_product(sys.transpose(rCaN, rCa), F_CaN)
+                         +  math::tensor_product(sys.transpose(rCaC, rCa), F_CaC);
         }
     }
     return energy;

--- a/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
@@ -109,6 +109,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -194,6 +197,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/global/GlobalPairInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairInteraction.hpp
@@ -124,7 +124,7 @@ void GlobalPairInteraction<traitsT, potT>::calc_force(
             const auto  j     = ptnr.index;
             const auto& param = ptnr.parameter();
 
-            const auto rij =
+            const auto rij = // ri -> rj = rj - ri
                 sys.adjust_direction(sys.position(i), sys.position(j));
             const real_type l2 = math::length_sq(rij); // |rij|^2
             const real_type rl = math::rsqrt(l2);      // 1 / |rij|
@@ -137,6 +137,9 @@ void GlobalPairInteraction<traitsT, potT>::calc_force(
             const coordinate_type f = rij * (f_mag * rl);
             sys.force(i) += f;
             sys.force(j) -= f;
+
+            // (rj - ri) * Fj = (ri - rj) * Fi
+            sys.virial() += math::tensor_product(rij, -f);
         }
     }
     return ;
@@ -195,6 +198,9 @@ GlobalPairInteraction<traitsT, potT>::calc_force_and_energy(
             const coordinate_type f = rij * (f_mag * rl);
             sys.force(i) += f;
             sys.force(j) -= f;
+
+            // (rj - ri) * Fj = (ri - rj) * Fi
+            sys.virial() += math::tensor_product(rij, -f);
         }
     }
     return energy;

--- a/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
@@ -106,6 +106,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -184,6 +187,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/global/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairUniformLennardJonesInteraction.hpp
@@ -106,6 +106,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -184,6 +187,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/local/BondAngleInteraction.hpp
+++ b/mjolnir/forcefield/local/BondAngleInteraction.hpp
@@ -90,10 +90,15 @@ class BondAngleInteraction final : public LocalInteractionBase<traitsT>
                             (cos_theta * r_ij_reg - r_kj_reg);
             const auto Fk = (coef_inv_sin * inv_len_r_kj) *
                             (cos_theta * r_kj_reg - r_ij_reg);
+            const auto Fj = -Fi - Fk;
 
             sys.force(idxs[0]) += Fi;
-            sys.force(idxs[1]) -= (Fi + Fk);
+            sys.force(idxs[1]) += Fj;
             sys.force(idxs[2]) += Fk;
+
+            sys.virial() += math::tensor_product(p1 + r_ij, Fi) +
+                            math::tensor_product(p1,        Fj) +
+                            math::tensor_product(p1 + r_kj, Fk);
         }
         return energy;
     }
@@ -164,11 +169,11 @@ void BondAngleInteraction<traitsT, potentialT>::calc_force(
         const auto& p1 = sys.position(idxp.first[1]);
         const auto& p2 = sys.position(idxp.first[2]);
 
-        const auto r_ij         = sys.adjust_direction(p1, p0);
+        const auto r_ij         = sys.adjust_direction(p1, p0); // p1 -> p0
         const auto inv_len_r_ij = math::rlength(r_ij);
         const auto r_ij_reg     = r_ij * inv_len_r_ij;
 
-        const auto r_kj         = sys.adjust_direction(p1, p2);
+        const auto r_kj         = sys.adjust_direction(p1, p2); // p1 -> p2
         const auto inv_len_r_kj = math::rlength(r_kj);
         const auto r_kj_reg     = r_kj * inv_len_r_kj;
 
@@ -187,10 +192,15 @@ void BondAngleInteraction<traitsT, potentialT>::calc_force(
                         (cos_theta * r_ij_reg - r_kj_reg);
         const auto Fk = (coef_inv_sin * inv_len_r_kj) *
                         (cos_theta * r_kj_reg - r_ij_reg);
+        const auto Fj = -Fi - Fk;
 
         sys.force(idxs[0]) += Fi;
-        sys.force(idxs[1]) -= (Fi + Fk);
+        sys.force(idxs[1]) += Fj;
         sys.force(idxs[2]) += Fk;
+
+        sys.virial() += math::tensor_product(p1 + r_ij, Fi) +
+                        math::tensor_product(p1,        Fj) +
+                        math::tensor_product(p1 + r_kj, Fk);
     }
     return;
 }

--- a/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
@@ -70,6 +70,8 @@ class BondLengthInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -113,6 +115,8 @@ class BondLengthInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }

--- a/mjolnir/forcefield/local/BondLengthInteraction.hpp
+++ b/mjolnir/forcefield/local/BondLengthInteraction.hpp
@@ -115,7 +115,7 @@ void BondLengthInteraction<traitsT, potentialT>::calc_force(
         const std::size_t idx0 = idxp.first[0];
         const std::size_t idx1 = idxp.first[1];
 
-        const auto dpos =
+        const auto dpos = // from r0 -> r1 = r1 - r0
             sys.adjust_direction(sys.position(idx0), sys.position(idx1));
 
         const real_type len2 = math::length_sq(dpos); // l^2
@@ -126,6 +126,8 @@ void BondLengthInteraction<traitsT, potentialT>::calc_force(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return;
 }
@@ -167,6 +169,8 @@ BondLengthInteraction<traitsT, potentialT>::calc_force_and_energy(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return energy;
 }

--- a/mjolnir/forcefield/local/ContactInteraction.hpp
+++ b/mjolnir/forcefield/local/ContactInteraction.hpp
@@ -71,7 +71,7 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
             const std::size_t idx0 = idxp.first[0];
             const std::size_t idx1 = idxp.first[1];
 
-            const auto dpos =
+            const auto dpos = // r0 -> r1 = r1 - r0
                 sys.adjust_direction(sys.position(idx0), sys.position(idx1));
 
             const real_type len2 = math::length_sq(dpos); // l^2
@@ -83,6 +83,8 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
             const coordinate_type f = dpos * (force * rlen);
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }
@@ -223,6 +225,8 @@ void ContactInteraction<traitsT, potentialT>::calc_force(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return;
 }

--- a/mjolnir/forcefield/local/DihedralAngleInteraction.hpp
+++ b/mjolnir/forcefield/local/DihedralAngleInteraction.hpp
@@ -147,10 +147,18 @@ DihedralAngleInteraction<traitsT, pT>::calc_force(system_type& sys) const noexce
         const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
         const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+        const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+        const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
         sys.force(idx0) += Fi;
-        sys.force(idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-        sys.force(idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+        sys.force(idx1) += Fj;
+        sys.force(idx2) += Fk;
         sys.force(idx3) += Fl;
+
+        sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                        math::tensor_product(r_j,               Fj) +
+                        math::tensor_product(r_j + r_kj,        Fk) +
+                        math::tensor_product(r_j + r_kj + r_lk, Fl);
     }
     return;
 }
@@ -204,9 +212,9 @@ DihedralAngleInteraction<traitsT, pT>::calc_force_and_energy(system_type& sys) c
         const auto& r_k = sys.position(idx2);
         const auto& r_l = sys.position(idx3);
 
-        const coordinate_type r_ij = sys.adjust_direction(r_j, r_i);
-        const coordinate_type r_kj = sys.adjust_direction(r_j, r_k);
-        const coordinate_type r_lk = sys.adjust_direction(r_k, r_l);
+        const coordinate_type r_ij = sys.adjust_direction(r_j, r_i); // j->i
+        const coordinate_type r_kj = sys.adjust_direction(r_j, r_k); // j->k
+        const coordinate_type r_lk = sys.adjust_direction(r_k, r_l); // k->l
         const coordinate_type r_kl = real_type(-1.0) * r_lk;
 
         const real_type r_kj_lensq  = math::length_sq(r_kj);
@@ -235,10 +243,18 @@ DihedralAngleInteraction<traitsT, pT>::calc_force_and_energy(system_type& sys) c
         const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
         const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+        const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+        const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
         sys.force(idx0) += Fi;
-        sys.force(idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-        sys.force(idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+        sys.force(idx1) += Fj;
+        sys.force(idx2) += Fk;
         sys.force(idx3) += Fl;
+
+        sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                        math::tensor_product(r_j,               Fj) +
+                        math::tensor_product(r_j + r_kj,        Fk) +
+                        math::tensor_product(r_j + r_kj + r_lk, Fl);
     }
     return energy;
 }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -325,10 +325,10 @@ void DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() -= math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     -  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     -  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     -  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
     }
     return;
 }
@@ -535,10 +535,10 @@ DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() -= math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     -  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     -  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     -  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -325,10 +325,10 @@ void DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(Pi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(Pi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(Pi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(Pi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
     }
     return;
 }
@@ -535,10 +535,10 @@ DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(Pi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(Pi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(Pi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(Pi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -325,10 +325,10 @@ void DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() -= math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     -  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     -  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     -  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       -dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              -dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        -dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, -dU_dir_drCj);// Cj
     }
     return;
 }
@@ -535,10 +535,10 @@ DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() -= math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     -  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     -  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     -  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       -dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              -dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        -dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, -dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -324,6 +324,11 @@ void DirectionalContactInteraction<
         sys.force(Pi) -= dU_dir_drPi;
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
+
+        sys.virial() += math::tensor_product(Pi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(Pi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(Pi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(Pi + Pij + PjCj, dU_dir_drCj);// Cj
     }
     return;
 }
@@ -529,6 +534,11 @@ DirectionalContactInteraction<
         sys.force(Pi) -= dU_dir_drPi;
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
+
+        sys.virial() += math::tensor_product(Pi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(Pi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(Pi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(Pi + Pij + PjCj, dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/GoContactInteraction.hpp
+++ b/mjolnir/forcefield/local/GoContactInteraction.hpp
@@ -74,6 +74,8 @@ class ContactInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -122,6 +124,8 @@ class ContactInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }

--- a/mjolnir/omp/BondAngleInteraction.hpp
+++ b/mjolnir/omp/BondAngleInteraction.hpp
@@ -52,14 +52,15 @@ class BondAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             const std::size_t idx1 = idxp.first[1];
             const std::size_t idx2 = idxp.first[2];
 
-            const coordinate_type r_ij =
-                sys.adjust_direction(sys.position(idx1), sys.position(idx0));
+            const auto& p0 = sys.position(idx0);
+            const auto& p1 = sys.position(idx1);
+            const auto& p2 = sys.position(idx2);
 
+            const coordinate_type r_ij         = sys.adjust_direction(p1, p0);
             const real_type       inv_len_r_ij = math::rlength(r_ij);
             const coordinate_type r_ij_reg     = r_ij * inv_len_r_ij;
 
-            const coordinate_type r_kj =
-                sys.adjust_direction(sys.position(idx1), sys.position(idx2));
+            const coordinate_type r_kj = sys.adjust_direction(p1, p2);
 
             const real_type       inv_len_r_kj = math::rlength(r_kj);
             const coordinate_type r_kj_reg     = r_kj * inv_len_r_kj;
@@ -130,16 +131,15 @@ class BondAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             const std::size_t idx0 = idxp.first[0];
             const std::size_t idx1 = idxp.first[1];
             const std::size_t idx2 = idxp.first[2];
+            const auto& p0 = sys.position(idx0);
+            const auto& p1 = sys.position(idx1);
+            const auto& p2 = sys.position(idx2);
 
-            const coordinate_type r_ij =
-                sys.adjust_direction(sys.position(idx1), sys.position(idx0));
-
+            const coordinate_type r_ij         = sys.adjust_direction(p1, p0);
             const real_type       inv_len_r_ij = math::rlength(r_ij);
             const coordinate_type r_ij_reg     = r_ij * inv_len_r_ij;
 
-            const coordinate_type r_kj =
-                sys.adjust_direction(sys.position(idx1), sys.position(idx2));
-
+            const coordinate_type r_kj         = sys.adjust_direction(p1, p2);
             const real_type       inv_len_r_kj = math::rlength(r_kj);
             const coordinate_type r_kj_reg     = r_kj * inv_len_r_kj;
 

--- a/mjolnir/omp/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/omp/BondLengthGoContactInteraction.hpp
@@ -76,7 +76,7 @@ class BondLengthInteraction<
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -128,7 +128,7 @@ class BondLengthInteraction<
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/omp/BondLengthGoContactInteraction.hpp
@@ -75,6 +75,8 @@ class BondLengthInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -125,6 +127,8 @@ class BondLengthInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/BondLengthInteraction.hpp
+++ b/mjolnir/omp/BondLengthInteraction.hpp
@@ -62,6 +62,8 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             const coordinate_type f = dpos * (force * rlen);
             sys.force_thread(omp_get_thread_num(), idx0) -= f;
             sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -102,6 +104,8 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             const coordinate_type f = dpos * (force * rlen);
             sys.force_thread(omp_get_thread_num(), idx0) -= f;
             sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/BondLengthInteraction.hpp
+++ b/mjolnir/omp/BondLengthInteraction.hpp
@@ -60,8 +60,9 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // here, L^2 * (1 / L) = L.
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
 
             sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
@@ -102,8 +103,9 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             E += idxp.second.potential(len);
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
 
             sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }

--- a/mjolnir/omp/BondLengthInteraction.hpp
+++ b/mjolnir/omp/BondLengthInteraction.hpp
@@ -63,7 +63,7 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             sys.force_thread(omp_get_thread_num(), idx0) -= f;
             sys.force_thread(omp_get_thread_num(), idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -105,7 +105,7 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             sys.force_thread(omp_get_thread_num(), idx0) -= f;
             sys.force_thread(omp_get_thread_num(), idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/ContactInteraction.hpp
+++ b/mjolnir/omp/ContactInteraction.hpp
@@ -68,8 +68,12 @@ class ContactInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // here, L^2 * (1 / L) = L.
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) = math::tensor_product(dpos, f);
         }
         return;
     }
@@ -108,8 +112,12 @@ class ContactInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             E += idxp.second.potential(len);
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) = math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/DihedralAngleInteraction.hpp
+++ b/mjolnir/omp/DihedralAngleInteraction.hpp
@@ -89,12 +89,19 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
             const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
-            const auto thread_id = omp_get_thread_num();
+            const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+            const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
 
+            const auto thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) += Fi;
-            sys.force_thread(thread_id, idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-            sys.force_thread(thread_id, idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+            sys.force_thread(thread_id, idx1) += Fj;
+            sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
+
+            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                            math::tensor_product(r_j,               Fj) +
+                            math::tensor_product(r_j + r_kj,        Fk) +
+                            math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return;
     }
@@ -181,12 +188,20 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
             const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+            const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+            const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
             const auto thread_id = omp_get_thread_num();
 
             sys.force_thread(thread_id, idx0) += Fi;
-            sys.force_thread(thread_id, idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-            sys.force_thread(thread_id, idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+            sys.force_thread(thread_id, idx1) += Fj;
+            sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
+
+            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                            math::tensor_product(r_j,               Fj) +
+                            math::tensor_product(r_j + r_kj,        Fk) +
+                            math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return E;
     }

--- a/mjolnir/omp/DihedralAngleInteraction.hpp
+++ b/mjolnir/omp/DihedralAngleInteraction.hpp
@@ -98,10 +98,11 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
 
-            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
-                            math::tensor_product(r_j,               Fj) +
-                            math::tensor_product(r_j + r_kj,        Fk) +
-                            math::tensor_product(r_j + r_kj + r_lk, Fl);
+            sys.virial_thread(thread_id) +=
+                math::tensor_product(r_j + r_ij,        Fi) +
+                math::tensor_product(r_j,               Fj) +
+                math::tensor_product(r_j + r_kj,        Fk) +
+                math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return;
     }
@@ -198,10 +199,11 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
 
-            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
-                            math::tensor_product(r_j,               Fj) +
-                            math::tensor_product(r_j + r_kj,        Fk) +
-                            math::tensor_product(r_j + r_kj + r_lk, Fl);
+            sys.virial_thread(thread_id) +=
+                math::tensor_product(r_j + r_ij,        Fi) +
+                math::tensor_product(r_j,               Fj) +
+                math::tensor_product(r_j + r_kj,        Fk) +
+                math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return E;
     }

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -107,6 +107,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -195,6 +197,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -108,7 +108,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -198,7 +198,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairInteraction.hpp
+++ b/mjolnir/omp/GlobalPairInteraction.hpp
@@ -94,6 +94,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -148,6 +150,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairInteraction.hpp
+++ b/mjolnir/omp/GlobalPairInteraction.hpp
@@ -95,7 +95,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -151,7 +151,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -105,7 +105,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -186,7 +186,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -104,6 +104,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -183,6 +185,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -105,7 +105,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -186,7 +186,7 @@ class GlobalPairInteraction<
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
 
-                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -104,6 +104,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -183,6 +185,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_threads(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GoContactInteraction.hpp
+++ b/mjolnir/omp/GoContactInteraction.hpp
@@ -80,6 +80,8 @@ class ContactInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -133,6 +135,8 @@ class ContactInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/GoContactInteraction.hpp
+++ b/mjolnir/omp/GoContactInteraction.hpp
@@ -81,7 +81,7 @@ class ContactInteraction<
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -136,7 +136,7 @@ class ContactInteraction<
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
 
-            sys.virial_threads(thread_id) += math::tensor_product(dpos, f);
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/PWMcosInteraction.hpp
+++ b/mjolnir/omp/PWMcosInteraction.hpp
@@ -207,6 +207,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
                 auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
 
+                auto vir  = math::tensor_product(F_Ca, F_B); // zero matrix;
+
                 // ----------------------------------------------------------------
                 // calculate direction term
                 // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3)
@@ -240,6 +242,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_Ca         -= Fi;
                     F_B          += (Fi + Fk);
                     sys.force_thread(thread_id, S) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rS, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -263,6 +267,9 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B           += Fi;
                     sys.force_thread(thread_id, B5) += Fk;
                     sys.force_thread(thread_id, B3) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rB5, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rB3, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -286,6 +293,9 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B            += Fi;
                     sys.force_thread(thread_id, CaC) += Fk;
                     sys.force_thread(thread_id, CaN) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rCaC, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rCaN, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -293,6 +303,10 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 sys.force_thread(thread_id, Ca) += F_Ca;
                 sys.force_thread(thread_id, B ) += F_B ;
+
+                vir += math::tensor_product(rCa, F_Ca);
+                vir += math::tensor_product(rB , F_B);
+                sys.virial_thread(thread_id) += vir;
             }
         }
         return ;
@@ -526,6 +540,7 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
                 auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+                auto vir  = math::tensor_product(F_Ca, F_B); // zero matrix;
 
                 // ----------------------------------------------------------------
                 // calculate direction term
@@ -560,6 +575,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_Ca         -= Fi;
                     F_B          += (Fi + Fk);
                     sys.force_thread(thread_id, S) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rS, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -583,6 +600,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B           += Fi;
                     sys.force_thread(thread_id, B5) += Fk;
                     sys.force_thread(thread_id, B3) -= Fk;
+                    vir += math::tensor_product(sys.transpose(rB5, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rB3, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -606,6 +625,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B            += Fi;
                     sys.force_thread(thread_id, CaC) += Fk;
                     sys.force_thread(thread_id, CaN) -= Fk;
+                    vir += math::tensor_product(sys.transpose(rCaC, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rCaN, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -613,6 +634,10 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 sys.force_thread(thread_id, Ca) += F_Ca;
                 sys.force_thread(thread_id, B ) += F_B ;
+
+                vir += math::tensor_product(rCa, F_Ca);
+                vir += math::tensor_product(rB , F_B);
+                sys.virial_thread(thread_id) += vir;
             }
         }
         return energy;

--- a/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
+++ b/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
@@ -234,11 +234,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 sys.force_thread(thread_id, para.PN) += f_PN;
                 sys.force_thread(thread_id, para.PC) += f_PC;
 
-                sys.virial() += math::tensor_product(rP,       f_P)
-                             +  math::tensor_product(rP + rPD, f_D)
-                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
-                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
-                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
+                sys.virial_thread(thread_id) +=
+                    math::tensor_product(rP,       f_P) +
+                    math::tensor_product(rP + rPD, f_D) +
+                    math::tensor_product(sys.transpose(rS3, rP), f_S3) +
+                    math::tensor_product(sys.transpose(rPN, rP), f_PN) +
+                    math::tensor_product(sys.transpose(rPC, rP), f_PC) ;
             }
         }
         return;
@@ -488,11 +489,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 sys.force_thread(thread_id, para.PN) += f_PN;
                 sys.force_thread(thread_id, para.PC) += f_PC;
 
-                sys.virial() += math::tensor_product(rP,       f_P)
-                             +  math::tensor_product(rP + rPD, f_D)
-                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
-                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
-                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
+                sys.virial_thread(thread_id) +=
+                    math::tensor_product(rP,       f_P) +
+                    math::tensor_product(rP + rPD, f_D) +
+                    math::tensor_product(sys.transpose(rS3, rP), f_S3) +
+                    math::tensor_product(sys.transpose(rPN, rP), f_PN) +
+                    math::tensor_product(sys.transpose(rPC, rP), f_PC) ;
             }
         }
         return energy;

--- a/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
+++ b/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
@@ -165,6 +165,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 const auto k = para.k;
                 const auto thread_id = omp_get_thread_num();
 
+                auto f_P  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_D  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_S3 = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PN = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PC = math::make_coordinate<coordinate_type>(0,0,0);
+
                 // df(r) g(theta) g(phi)
                 if(g_dg_theta.first  != 0 && g_dg_phi.first  != 0)
                 {
@@ -174,8 +180,8 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                         f_df.second * g_dg_theta.first * g_dg_phi.first;
                     const auto F = -coef * rPD;
 
-                    sys.force_thread(thread_id, P) -= F;
-                    sys.force_thread(thread_id, D) += F;
+                    f_P -= F;
+                    f_D += F;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -195,10 +201,10 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P  = -coef_sin * rlPD  * (rPNC_reg - cosPNC * rPD_reg );
                     const auto F_PN = -coef_sin * rlPNC * (rPD_reg  - cosPNC * rPNC_reg);
 
-                    sys.force_thread(thread_id, D)       -= F_P;
-                    sys.force_thread(thread_id, P)       += F_P;
-                    sys.force_thread(thread_id, para.PN) += F_PN;
-                    sys.force_thread(thread_id, para.PC) -= F_PN;
+                    f_D  -= F_P;
+                    f_P  += F_P;
+                    f_PN += F_PN;
+                    f_PC -= F_PN;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -218,10 +224,21 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P = -coef_sin * rlPD  * (rS3D_reg - cosS3D * rPD_reg);
                     const auto F_S = -coef_sin * rlS3D * (rPD_reg  - cosS3D * rS3D_reg);
 
-                    sys.force_thread(thread_id, P)  += F_P;
-                    sys.force_thread(thread_id, D)  -= F_P + F_S;
-                    sys.force_thread(thread_id, S3) += F_S;
+                    f_P  += F_P;
+                    f_D  -= F_P + F_S;
+                    f_S3 += F_S;
                 }
+                sys.force_thread(thread_id, P)       += f_P;
+                sys.force_thread(thread_id, D)       += f_D;
+                sys.force_thread(thread_id, S3)      += f_S3;
+                sys.force_thread(thread_id, para.PN) += f_PN;
+                sys.force_thread(thread_id, para.PC) += f_PC;
+
+                sys.virial() += math::tensor_product(rP,       f_P)
+                             +  math::tensor_product(rP + rPD, f_D)
+                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
+                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
+                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
             }
         }
         return;
@@ -400,6 +417,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 const auto k = para.k;
                 const auto thread_id = omp_get_thread_num();
 
+                auto f_P  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_D  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_S3 = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PN = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PC = math::make_coordinate<coordinate_type>(0,0,0);
+
                 energy += k * f_df.first * g_dg_theta.first * g_dg_phi.first;
 
                 // df(r) g(theta) g(phi)
@@ -411,8 +434,8 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                         f_df.second * g_dg_theta.first * g_dg_phi.first;
                     const auto F = -coef * rPD;
 
-                    sys.force_thread(thread_id, P) -= F;
-                    sys.force_thread(thread_id, D) += F;
+                    f_P -= F;
+                    f_D += F;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -432,10 +455,10 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P  = -coef_sin * rlPD  * (rPNC_reg - cosPNC * rPD_reg );
                     const auto F_PN = -coef_sin * rlPNC * (rPD_reg  - cosPNC * rPNC_reg);
 
-                    sys.force_thread(thread_id, D)       -= F_P;
-                    sys.force_thread(thread_id, P)       += F_P;
-                    sys.force_thread(thread_id, para.PN) += F_PN;
-                    sys.force_thread(thread_id, para.PC) -= F_PN;
+                    f_D  -= F_P;
+                    f_P  += F_P;
+                    f_PN += F_PN;
+                    f_PC -= F_PN;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -455,10 +478,21 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P = -coef_sin * rlPD  * (rS3D_reg - cosS3D * rPD_reg);
                     const auto F_S = -coef_sin * rlS3D * (rPD_reg  - cosS3D * rS3D_reg);
 
-                    sys.force_thread(thread_id, P)  += F_P;
-                    sys.force_thread(thread_id, D)  -= F_P + F_S;
-                    sys.force_thread(thread_id, S3) += F_S;
+                    f_P  += F_P;
+                    f_D  -= F_P + F_S;
+                    f_S3 += F_S;
                 }
+                sys.force_thread(thread_id, P)       += f_P;
+                sys.force_thread(thread_id, D)       += f_D;
+                sys.force_thread(thread_id, S3)      += f_S3;
+                sys.force_thread(thread_id, para.PN) += f_PN;
+                sys.force_thread(thread_id, para.PC) += f_PC;
+
+                sys.virial() += math::tensor_product(rP,       f_P)
+                             +  math::tensor_product(rP + rPD, f_D)
+                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
+                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
+                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
             }
         }
         return energy;

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -15,6 +15,7 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     using traits_type     = OpenMPSimulatorTraits<realT, boundaryT>;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using boundary_type   = typename traits_type::boundary_type;
     using topology_type   = Topology;
     using attribute_type  = std::map<std::string, real_type>;
@@ -38,7 +39,11 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
 
     System(const std::size_t num_particles, const boundary_type& bound)
         : velocity_initialized_(false), force_initialized_(false),
-          boundary_(bound), attributes_(), num_particles_(num_particles),
+          boundary_(bound), attributes_(),
+          virial_(0,0,0, 0,0,0, 0,0,0),
+          virial_threads_(omp_get_max_threads(),
+                          matrix33_type(0,0,0, 0,0,0, 0,0,0)),
+          num_particles_(num_particles),
           masses_   (num_particles), rmasses_   (num_particles),
           positions_(num_particles), velocities_(num_particles),
           forces_main_(num_particles),
@@ -150,13 +155,38 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
         return forces_threads_[thread_num][particle_id];
     }
 
-    // Here, since we already allocate forces_threads_, we don't need anything
-    // in preprocess_forces() function. On the contrary, since all the forces
-    // will be calculated in different cores, we need to merge those
-    // thread-local forces by summing up those for each particle.
-    void preprocess_forces() noexcept { /*do nothing*/ }
+    matrix33_type&       virial()       noexcept {return virial_;}
+    matrix33_type const& virial() const noexcept {return virial_;}
+
+    matrix33_type&       virial_threads(std::size_t thread_num)       noexcept
+    {
+        return virial_threads_[thread_num];
+    }
+    matrix33_type const& virial_threads(std::size_t thread_num) const noexcept
+    {
+        return virial_threads_[thread_num];
+    }
+
+    void preprocess_forces()  noexcept
+    {
+        // Do nothing. We already allocated the thread local forces and virials
+        // with zero values. Also, in the end of each step, postprocess_forces
+        // zero-clears everything.
+    }
+
+    // Since all the forces will be calculated in different cores, we need to
+    // merge those thread-local forces by summing up those for each particle.
     void postprocess_forces() noexcept
     {
+        // sumup virial and zero-clear the thread local virials
+        virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t thread_id=0, max_threads=omp_get_max_threads();
+                thread_id < max_threads; ++thread_id)
+        {
+            virial_ += virial_threads_[thread_id];
+            virial_threads_[thread_id] = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        }
+
 #pragma omp parallel for
         for(std::size_t i=0; i<this->size(); ++i)
         {
@@ -205,6 +235,9 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     bool           velocity_initialized_, force_initialized_;
     boundary_type  boundary_;
     attribute_type attributes_;
+
+    matrix33_type  virial_;
+    std::vector<matrix33_type, cache_aligned_allocator<matrix33_type>> virial_threads_;
 
     std::size_t                  num_particles_;
     real_container_type          masses_;

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -187,7 +187,7 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     void postprocess_forces() noexcept
     {
         // sumup virial and zero-clear the thread local virials
-        virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+//         virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0); // allow non-parallelized stuff
         for(std::size_t thread_id=0, max_threads=omp_get_max_threads();
                 thread_id < max_threads; ++thread_id)
         {

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -93,9 +93,17 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     }
 
     coordinate_type adjust_direction(coordinate_type from, coordinate_type to) const noexcept
-    {return boundary_.adjust_direction(from, to);}
+    {
+        return boundary_.adjust_direction(from, to);
+    }
     coordinate_type  adjust_position(coordinate_type dr) const noexcept
-    {return boundary_.adjust_position(dr);}
+    {
+        return boundary_.adjust_position(dr);
+    }
+    coordinate_type transpose(coordinate_type tgt, const coordinate_type& ref) const noexcept
+    {
+        return boundary_.transpose(tgt, ref);
+    }
 
     std::size_t size() const noexcept {return num_particles_;}
 

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -166,11 +166,11 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     matrix33_type&       virial()       noexcept {return virial_;}
     matrix33_type const& virial() const noexcept {return virial_;}
 
-    matrix33_type&       virial_threads(std::size_t thread_num)       noexcept
+    matrix33_type&       virial_thread(std::size_t thread_num)       noexcept
     {
         return virial_threads_[thread_num];
     }
-    matrix33_type const& virial_threads(std::size_t thread_num) const noexcept
+    matrix33_type const& virial_thread(std::size_t thread_num) const noexcept
     {
         return virial_threads_[thread_num];
     }

--- a/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
@@ -132,11 +132,12 @@ class ThreeSPN2BaseBaseInteraction<
                     if(dU_rep != real_type(0))
                     {
                         // remember that F = -dU.
-                        sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                        sys.force_thread(thread_id, Bj) -= dU_rep * Bij_reg;
+                        const auto F = -dU_rep * Bji_reg
+                        sys.force_thread(thread_id, Bi) -= F;
+                        sys.force_thread(thread_id, Bj) += F;
 
-                        // Bij = Bj - Bi
-                        sys.virial_thread(thread_id) += math::tensor_product(Bij, -F);
+                        // Bij = Bi -> Bj = rBj - rBi
+                        sys.virial_thread(thread_id) += math::tensor_product(Bij, F);
                     }
                 }
 

--- a/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
@@ -125,10 +125,12 @@ class ThreeSPN2BaseStackingInteraction<
             const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
             if(dU_rep != real_type(0.0))
             {
-                sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                sys.force_thread(thread_id, Bj) += dU_rep * Bji_reg;
+                const auto f = dU_rep * Bji_reg;
+                sys.force_thread(thread_id, Bi) -= f;
+                sys.force_thread(thread_id, Bj) += f;
 
-                sys.virial_thread(thread_id) += math::tensor_product(Bij, -f);
+                // Bji = Bj -> Bi = Bi - Bj
+                sys.virial_thread(thread_id) += math::tensor_product(Bji, -f);
             }
 
             // --------------------------------------------------------------------
@@ -326,7 +328,7 @@ class ThreeSPN2BaseStackingInteraction<
                 sys.force_thread(thread_id, Bi) -= f;
                 sys.force_thread(thread_id, Bj) += f;
 
-                sys.virial_thread(thread_id) += math::tensor_product(Bij, -f);
+                sys.virial_thread(thread_id) += math::tensor_product(Bji, -f);
             }
 
             E += potential_.U_rep(bs_kind, lBji);

--- a/test/core/test_3spn2_base_base_interaction.cpp
+++ b/test/core/test_3spn2_base_base_interaction.cpp
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_numerical_diff,
     using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type         = traits_type::real_type;
     using coord_type        = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type     = traits_type::boundary_type;
     using system_type       = mjolnir::System<traits_type>;
     using topology_type     = mjolnir::Topology;
@@ -306,6 +307,34 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
         } // theta2
         } // theta1
         } // rbp
@@ -788,6 +817,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
         } // thetaCS_j
         } // thetaCS_i
         } // theta3

--- a/test/core/test_3spn2_base_base_interaction.cpp
+++ b/test/core/test_3spn2_base_base_interaction.cpp
@@ -1077,6 +1077,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_energy_and_force,
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             }
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+            }
         } // theta2
         } // theta1
         } // rbp
@@ -1479,6 +1483,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force
                 sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
                 sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
             }
+            using matrix33_type = typename traits_type::matrix33_type;
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+
             system_type ref_sys = sys;
 
             constexpr real_type tol = 1e-4;
@@ -1493,6 +1500,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force
                 BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
             }
         } // thetaCS_j
         } // thetaCS_i

--- a/test/core/test_3spn2_base_stacking_interaction.cpp
+++ b/test/core/test_3spn2_base_stacking_interaction.cpp
@@ -529,6 +529,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_en
             BOOST_TEST(mjolnir::math::Y(sys.force(2)) == 0.0);
             BOOST_TEST(mjolnir::math::Z(sys.force(2)) == 0.0);
 
+            using matrix33_type = typename traits_type::matrix33_type;
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+
             auto ref_sys = sys;
             constexpr real_type tol = 1e-4;
 
@@ -542,6 +545,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_en
                 BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
             }
         } // perturbation
         } // theta

--- a/test/core/test_3spn2_base_stacking_interaction.cpp
+++ b/test/core/test_3spn2_base_stacking_interaction.cpp
@@ -353,7 +353,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_en
     using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type        = traits_type::real_type;
     using coord_type       = traits_type::coordinate_type;
-    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type    = traits_type::boundary_type;
     using system_type      = mjolnir::System<traits_type>;
     using interaction_type = mjolnir::ThreeSPN2BaseStackingInteraction<traits_type>;

--- a/test/core/test_3spn2_base_stacking_interaction.cpp
+++ b/test/core/test_3spn2_base_stacking_interaction.cpp
@@ -308,6 +308,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
         } // perturbation
         } // theta
         } // r

--- a/test/core/test_bond_angle_interaction.cpp
+++ b/test/core/test_bond_angle_interaction.cpp
@@ -372,5 +372,9 @@ BOOST_AUTO_TEST_CASE(BondAngleInteraction_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_bond_angle_interaction.cpp
+++ b/test/core/test_bond_angle_interaction.cpp
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(BondAngleInteraction_numerical_diff)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_bond_angle_interaction.cpp
+++ b/test/core/test_bond_angle_interaction.cpp
@@ -279,6 +279,35 @@ BOOST_AUTO_TEST_CASE(BondAngleInteraction_numerical_diff)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 

--- a/test/core/test_bond_length_gocontact_interaction.cpp
+++ b/test/core/test_bond_length_gocontact_interaction.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(BondLengthGoContact_numerical_difference)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_bond_length_gocontact_interaction.cpp
+++ b/test/core/test_bond_length_gocontact_interaction.cpp
@@ -196,6 +196,34 @@ BOOST_AUTO_TEST_CASE(BondLengthGoContact_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 

--- a/test/core/test_bond_length_gocontact_interaction.cpp
+++ b/test/core/test_bond_length_gocontact_interaction.cpp
@@ -281,5 +281,9 @@ BOOST_AUTO_TEST_CASE(BondLengthGoContact_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_bond_length_interaction.cpp
+++ b/test/core/test_bond_length_interaction.cpp
@@ -317,5 +317,9 @@ BOOST_AUTO_TEST_CASE(BondLength_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_bond_length_interaction.cpp
+++ b/test/core/test_bond_length_interaction.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(BondLength_numerical_difference)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_bond_length_interaction.cpp
+++ b/test/core/test_bond_length_interaction.cpp
@@ -230,6 +230,36 @@ BOOST_AUTO_TEST_CASE(BondLength_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 

--- a/test/core/test_contact_gocontact_interaction.cpp
+++ b/test/core/test_contact_gocontact_interaction.cpp
@@ -205,6 +205,35 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 

--- a/test/core/test_contact_gocontact_interaction.cpp
+++ b/test/core/test_contact_gocontact_interaction.cpp
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_numerical_difference)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_contact_gocontact_interaction.cpp
+++ b/test/core/test_contact_gocontact_interaction.cpp
@@ -293,5 +293,9 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_contact_interaction.cpp
+++ b/test/core/test_contact_interaction.cpp
@@ -226,5 +226,9 @@ BOOST_AUTO_TEST_CASE(Contact_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_contact_interaction.cpp
+++ b/test/core/test_contact_interaction.cpp
@@ -26,8 +26,9 @@ BOOST_AUTO_TEST_CASE(Contact_numerical_difference)
 
     const real_type k(1.0);
     const real_type native(std::sqrt(3.0));
+    const real_type sigma(0.15);
 
-    potential_type   potential(k, native);
+    potential_type   potential(k, sigma, native);
     interaction_type interaction("none", {{ {{0,1}}, potential}});
 
     std::mt19937 mt(123456789);
@@ -150,7 +151,7 @@ BOOST_AUTO_TEST_CASE(Contact_numerical_difference)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
@@ -182,8 +183,9 @@ BOOST_AUTO_TEST_CASE(Contact_calc_force_and_energy)
 
     const real_type k(1.0);
     const real_type native(std::sqrt(3.0));
+    const real_type sigma(0.15);
 
-    potential_type   potential(k, native);
+    potential_type   potential(k, sigma, native);
     interaction_type interaction("none", {{ {{0,1}}, potential}});
 
     std::mt19937 mt(123456789);

--- a/test/core/test_contact_interaction.cpp
+++ b/test/core/test_contact_interaction.cpp
@@ -9,102 +9,220 @@
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/forcefield/local/ContactInteraction.hpp>
-#include <mjolnir/forcefield/local/GoContactPotential.hpp>
+#include <mjolnir/forcefield/local/GaussianPotential.hpp>
 #include <mjolnir/util/make_unique.hpp>
 
-BOOST_AUTO_TEST_CASE(Contact_calc_force)
+BOOST_AUTO_TEST_CASE(Contact_numerical_difference)
 {
-    mjolnir::LoggerManager::set_default_logger("test_contact_calc_force");
+    mjolnir::LoggerManager::set_default_logger("test_contact_interaction.log");
 
     using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type        = traits_type::real_type;
     using coord_type       = traits_type::coordinate_type;
     using boundary_type    = traits_type::boundary_type;
     using system_type      = mjolnir::System<traits_type>;
-    using potential_type   = mjolnir::GoContactPotential<real_type>;
+    using potential_type   = mjolnir::GaussianPotential<real_type>;
     using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
 
-    constexpr real_type tol = 1e-8;
-
-    auto normalize = [](const coord_type& v){return v / mjolnir::math::length(v);};
-
-    const real_type k(100.);
-    const real_type native(2.0);
+    const real_type k(1.0);
+    const real_type native(std::sqrt(3.0));
 
     potential_type   potential(k, native);
     interaction_type interaction("none", {{ {{0,1}}, potential}});
 
-    system_type sys(2, boundary_type{});
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    sys.at(0).mass = 1.0;
-    sys.at(1).mass = 1.0;
-    sys.at(0).rmass = 1.0;
-    sys.at(1).rmass = 1.0;
-
-    sys.at(0).position = coord_type(0,0,0);
-    sys.at(1).position = coord_type(0,0,0);
-    sys.at(0).velocity = coord_type(0,0,0);
-    sys.at(1).velocity = coord_type(0,0,0);
-    sys.at(0).force    = coord_type(0,0,0);
-    sys.at(1).force    = coord_type(0,0,0);
-
-    sys.at(0).name  = "X";
-    sys.at(1).name  = "X";
-    sys.at(0).group = "NONE";
-    sys.at(1).group = "NONE";
-
-    const real_type dr = 1e-3;
-    real_type dist = 1e0;
-    sys[1].position[0] = dist;
-
-    interaction.initialize(sys);
-
-    for(int i = 0; i < 2000; ++i)
+    for(std::size_t i = 0; i < 1000; ++i)
     {
-        sys[0].position = coord_type(0,0,0);
-        sys[1].position = coord_type(0,0,0);
-        sys[0].force    = coord_type(0,0,0);
-        sys[1].force    = coord_type(0,0,0);
-        sys[1].position[0] = dist;
+        system_type sys(2, boundary_type{});
 
-        interaction.reduce_margin(dr, sys);
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
 
-        const real_type deriv = potential.derivative(dist);
-        const real_type coef  = std::abs(deriv);
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
 
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        const auto init = sys;
+
+        constexpr real_type tol = 2e-4;
+        constexpr real_type dr  = 1e-5;
+        for(std::size_t idx=0; idx<2; ++idx)
+        {
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::X(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Y(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Z(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+        }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
         interaction.calc_force(sys);
 
-        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
-        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
-        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
-        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
-
-        // direction
-        if(dist < native) // repulsive
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            const real_type dir1 = mjolnir::math::dot_product(
-                normalize(sys[0].force), normalize(sys[0].position - sys[1].position));
-            const real_type dir2 = mjolnir::math::dot_product(
-                normalize(sys[1].force), normalize(sys[1].position - sys[0].position));
-
-            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
         }
-        else
-        {
-            const real_type dir1 = mjolnir::math::dot_product(
-                normalize(sys[0].force), normalize(sys[1].position - sys[0].position));
-            const real_type dir2 = mjolnir::math::dot_product(
-                normalize(sys[1].force), normalize(sys[0].position - sys[1].position));
 
-            BOOST_TEST(dir1 == 1e0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1e0, boost::test_tools::tolerance(tol));
-        }
-        BOOST_TEST(mjolnir::math::length(sys[0].force + sys[1].force) == 0.0,
-                   boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
 
-        dist += dr;
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
+BOOST_AUTO_TEST_CASE(Contact_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_contact_interaction.log");
 
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coord_type       = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::GaussianPotential<real_type>;
+    using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
+
+    const real_type k(1.0);
+    const real_type native(std::sqrt(3.0));
+
+    potential_type   potential(k, native);
+    interaction_type interaction("none", {{ {{0,1}}, potential}});
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t i = 0; i < 1000; ++i)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        constexpr real_type tol = 1e-4;
+        auto ref_sys = sys;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -381,5 +381,9 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_numerical_diff)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -279,6 +279,35 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_numerical_diff)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -282,6 +282,7 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_numerical_diff)
 
         // -----------------------------------------------------------------
         // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
 
         sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)

--- a/test/core/test_directional_contact_interaction.cpp
+++ b/test/core/test_directional_contact_interaction.cpp
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_numerical_diff)
                 matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
                 for(std::size_t idx=0; idx<sys.size(); ++idx)
                 {
-                    vir += math::tensor_product(sys.position(idx), sys.force(idx));
+                    vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
                 }
 
                 BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_directional_contact_interaction.cpp
+++ b/test/core/test_directional_contact_interaction.cpp
@@ -374,6 +374,10 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_calc_force_and_energy)
                     BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                     BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 }
+                for(std::size_t i=0; i<9; ++i)
+                {
+                    BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+                }
             }
         }
     }

--- a/test/core/test_directional_contact_interaction.cpp
+++ b/test/core/test_directional_contact_interaction.cpp
@@ -224,6 +224,33 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_numerical_diff)
                         }
                     }
                 }
+                // -----------------------------------------------------------------
+                // check virial
+
+                sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    sys.force(idx) = coord_type(0,0,0);
+                }
+                interaction.calc_force(sys);
+
+                matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    vir += math::tensor_product(sys.position(idx), sys.force(idx));
+                }
+
+                BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+                BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+                BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
             }
         }
     }

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -289,5 +289,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_force_and_energ
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -169,11 +169,12 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_limits)
         }
         // -----------------------------------------------------------------
         // check virial
+        using matrix33_type = typename traits::matrix33_type;
 
         sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            sys.force(idx) = coord_type(0,0,0);
+            sys.force(idx) = coordinate_type(0,0,0);
         }
         interaction.calc_force(sys);
 

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_limits)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -167,6 +167,34 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 

--- a/test/core/test_global_pair_interaction.cpp
+++ b/test/core/test_global_pair_interaction.cpp
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_global_pair_interaction.cpp
+++ b/test/core/test_global_pair_interaction.cpp
@@ -282,6 +282,36 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
+
     }
 }
 

--- a/test/core/test_global_pair_interaction.cpp
+++ b/test/core/test_global_pair_interaction.cpp
@@ -407,5 +407,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_global_pair_interaction.cpp
+++ b/test/core/test_global_pair_interaction.cpp
@@ -285,11 +285,12 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
 
         // -----------------------------------------------------------------
         // check virial
+        using matrix33_type = typename traits::matrix33_type;
 
         sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            sys.force(idx) = coord_type(0,0,0);
+            sys.force(idx) = coordinate_type(0,0,0);
         }
         interaction.calc_force(sys);
 

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -168,6 +168,34 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -291,5 +291,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -171,11 +171,12 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_limits)
 
         // -----------------------------------------------------------------
         // check virial
+        using matrix33_type = typename traits::matrix33_type;
 
         sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            sys.force(idx) = coord_type(0,0,0);
+            sys.force(idx) = coordinate_type(0,0,0);
         }
         interaction.calc_force(sys);
 

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_limits)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -167,6 +167,33 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -169,11 +169,12 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_limits)
         }
         // -----------------------------------------------------------------
         // check virial
+        using matrix33_type = typename traits::matrix33_type;
 
         sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            sys.force(idx) = coord_type(0,0,0);
+            sys.force(idx) = coordinate_type(0,0,0);
         }
         interaction.calc_force(sys);
 

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -288,5 +288,9 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_force_and_
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_limits)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_multiple_basin_forcefield.cpp
+++ b/test/core/test_multiple_basin_forcefield.cpp
@@ -161,6 +161,37 @@ BOOST_AUTO_TEST_CASE(MultipleBasin_2Basin_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
+
     }
 }
 

--- a/test/core/test_multiple_basin_forcefield.cpp
+++ b/test/core/test_multiple_basin_forcefield.cpp
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(MultipleBasin_2Basin_numerical_difference)
         {
             sys.force(idx) = coord_type(0,0,0);
         }
-        interaction.calc_force(sys);
+        forcefield.calc_force(sys);
 
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)

--- a/test/core/test_multiple_basin_forcefield.cpp
+++ b/test/core/test_multiple_basin_forcefield.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(MultipleBasin_2Basin_numerical_difference)
         matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
         for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
 
         BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));

--- a/test/core/test_pdns_interaction.cpp
+++ b/test/core/test_pdns_interaction.cpp
@@ -255,6 +255,35 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction)
                                    ", -dE/dr = " << -dE/dr);
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     } // theta2
     } // theta1
     } // rbp

--- a/test/core/test_pdns_interaction.cpp
+++ b/test/core/test_pdns_interaction.cpp
@@ -464,7 +464,10 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
-
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     } // theta2
     } // theta1
     } // rbp

--- a/test/core/test_pwmcos_interaction.cpp
+++ b/test/core/test_pwmcos_interaction.cpp
@@ -270,6 +270,35 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction)
                                    ", -dE/dr = " << -dE/dr);
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     } // theta3
     } // theta2
     } // theta1

--- a/test/core/test_pwmcos_interaction.cpp
+++ b/test/core/test_pwmcos_interaction.cpp
@@ -495,6 +495,10 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
 
     } // theta3
     } // theta2

--- a/test/omp/test_omp_bond_angle_interaction.cpp
+++ b/test/omp/test_omp_bond_angle_interaction.cpp
@@ -129,6 +129,12 @@ BOOST_AUTO_TEST_CASE(omp_BondAngle)
         // check the energies are the same
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_bond_length_gocontact_interaction.cpp
+++ b/test/omp/test_omp_bond_length_gocontact_interaction.cpp
@@ -122,6 +122,13 @@ BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_bond_length_interaction.cpp
+++ b/test/omp/test_omp_bond_length_interaction.cpp
@@ -119,6 +119,13 @@ BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_contact_interaction.cpp
+++ b/test/omp/test_omp_contact_interaction.cpp
@@ -121,6 +121,12 @@ BOOST_AUTO_TEST_CASE(omp_Contact_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_dihedral_angle_interaction.cpp
+++ b/test/omp/test_omp_dihedral_angle_interaction.cpp
@@ -127,6 +127,13 @@ BOOST_AUTO_TEST_CASE(omp_DihedralAngle_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_global_debye_huckel_interaction.cpp
+++ b/test/omp/test_omp_global_debye_huckel_interaction.cpp
@@ -140,6 +140,13 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_DebyeHuckel_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_global_excluded_volume_interaction.cpp
+++ b/test/omp/test_omp_global_excluded_volume_interaction.cpp
@@ -136,6 +136,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_lennard_jones_interaction.cpp
@@ -136,6 +136,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_LennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_pdns_interaction.cpp
+++ b/test/omp/test_omp_global_pdns_interaction.cpp
@@ -168,6 +168,12 @@ BOOST_AUTO_TEST_CASE(omp_PDNS_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_pwmcos_interaction.cpp
+++ b/test/omp/test_omp_global_pwmcos_interaction.cpp
@@ -175,6 +175,12 @@ BOOST_AUTO_TEST_CASE(omp_PWMcos_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
@@ -129,6 +129,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_gocontact_interaction.cpp
+++ b/test/omp/test_omp_gocontact_interaction.cpp
@@ -124,6 +124,12 @@ BOOST_AUTO_TEST_CASE(omp_Contact_GoContact_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_multiple_basin_forcefield.cpp
+++ b/test/omp/test_omp_multiple_basin_forcefield.cpp
@@ -298,6 +298,12 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_2Basin_consistency)
             BOOST_TEST(Z(sys_default.force(j)) == Z(sys_openmp.force(j)),
                        boost::test_tools::tolerance(tol));
         }
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 
@@ -593,6 +599,13 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_3Basin_consistency)
             BOOST_TEST(Z(sys_default.force(j)) == Z(sys_openmp.force(j)),
                        boost::test_tools::tolerance(tol));
         }
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
+
     }
 }
 

--- a/test/omp/test_omp_multiple_basin_forcefield.cpp
+++ b/test/omp/test_omp_multiple_basin_forcefield.cpp
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_2Basin_consistency)
         // check the virials are the same
         for(std::size_t i=0; i<9; ++i)
         {
-            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys_default.virial()[i] == sys_openmp.virial()[i], boost::test_tools::tolerance(tol));
         }
 
     }
@@ -602,7 +602,7 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_3Basin_consistency)
         // check the virials are the same
         for(std::size_t i=0; i<9; ++i)
         {
-            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys_default.virial()[i] == sys_openmp.virial()[i], boost::test_tools::tolerance(tol));
         }
 
 


### PR DESCRIPTION
Under the periodic boundary conditions, the virial cannot be calculated independently from the potentials. To calculate it correctly, forcefield should calculate it while calculating forces.