### PR TITLE
feat: add NPT Langevin

### DIFF
--- a/mjolnir/core/BAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/BAOABLangevinIntegrator.hpp
@@ -22,6 +22,7 @@ class BAOABLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -125,6 +126,7 @@ void BAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;
@@ -161,6 +163,7 @@ BAOABLangevinIntegrator<traitsT>::step(
         // collect largest displacement
         largest_disp2 = std::max(largest_disp2, math::length_sq(dp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/BoundaryCondition.hpp
+++ b/mjolnir/core/BoundaryCondition.hpp
@@ -30,6 +30,12 @@ struct UnlimitedBoundary
         return r;
     }
 
+    // transpose `target` with respect to ref to make it the nearest pair
+    coordinate_type transpose(coordinate_type target, const coordinate_type& /*ref*/) const noexcept
+    {
+        return target;
+    }
+
     void set_boundary(const coordinate_type&, const coordinate_type&) noexcept {assert(false);}
     void set_lower_bound(const coordinate_type&) noexcept {assert(false);}
     void set_upper_bound(const coordinate_type&) noexcept {assert(false);}
@@ -94,6 +100,13 @@ struct CuboidalPeriodicBoundary
         else if(math::Z(pos) >= math::Z(upper_)) {math::Z(pos) -= math::Z(width_);}
         return pos;
     }
+
+    // transpose `target` with respect to ref to make it the nearest pair
+    coordinate_type transpose(coordinate_type target, const coordinate_type& ref) const noexcept
+    {
+        return ref + this->adjust_direction(ref, target);
+    }
+
 
     coordinate_type const& lower_bound() const noexcept {return lower_;}
     coordinate_type const& upper_bound() const noexcept {return upper_;}

--- a/mjolnir/core/CMakeLists.txt
+++ b/mjolnir/core/CMakeLists.txt
@@ -4,6 +4,7 @@ set(mjolnir_core_cpp_files
     "${CMAKE_CURRENT_SOURCE_DIR}/BAOABLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/gBAOABLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/GJFNVTLangevinIntegrator.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/GFWNpTLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/UnderdampedLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/VelocityVerletIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/MolecularDynamicsSimulator.cpp"

--- a/mjolnir/core/EnergyObserver.hpp
+++ b/mjolnir/core/EnergyObserver.hpp
@@ -45,11 +45,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         ff->format_energy_name(names); // write into it
         ofs << names;
 
-        ofs << " kinetic_energy";
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << "             Pxx             Pyy             Pzz";
-        }
+        ofs << " kinetic_energy             Pxx             Pyy             Pzz";
         for(const auto& attr : sys.attributes())
         {
             ofs << " attribute:" << attr.first;
@@ -69,11 +65,7 @@ class EnergyObserver final : public ObserverBase<traitsT>
         ff->format_energy_name(names); // write into it
         ofs << names;
 
-        ofs << " kinetic_energy";
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << "             Pxx             Pyy             Pzz";
-        }
+        ofs << " kinetic_energy             Pxx             Pyy             Pzz";
         for(const auto& attr : sys.attributes())
         {
             ofs << " attribute:" << attr.first;
@@ -103,21 +95,17 @@ class EnergyObserver final : public ObserverBase<traitsT>
         }
 
         real_type Ek(0), Px(0), Py(0), Pz(0);
-        std::tie(Ek, Px, Py, Pz) = this->calc_energy_and_pressure(sys,
-                is_cuboidal_periodic_boundary<boundary_type>{});
+        std::tie(Ek, Px, Py, Pz) = this->calc_energy_and_pressure(sys);
 
         ofs << std::setw(14) << std::right << std::fixed << Ek;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Px;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Py;
+        ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Pz;
         if(!is_finite(Ek))
         {
             MJOLNIR_GET_DEFAULT_LOGGER();
             MJOLNIR_LOG_ERROR("kinetic energy becomes NaN.");
             is_ok = false;
-        }
-        if(is_cuboidal_periodic_boundary<boundary_type>::value)
-        {
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Px;
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Py;
-            ofs << std::setw(16) << std::right << std::setprecision(8) << std::scientific << Pz;
         }
 
         for(const auto& attr : sys.attributes())
@@ -149,49 +137,32 @@ class EnergyObserver final : public ObserverBase<traitsT>
   private:
 
     std::tuple<real_type, real_type, real_type, real_type>
-    calc_energy_and_pressure(const system_type& sys, std::true_type)
+    calc_energy_and_pressure(const system_type& sys)
     {
         const auto cell_width = sys.boundary().width();
         const auto volume = math::X(cell_width) * math::Y(cell_width) * math::Z(cell_width);
         const auto rvolume = real_type(1) / volume;
 
         real_type Ek(0);
-        real_type Px(0);
-        real_type Py(0);
-        real_type Pz(0);
+        real_type Px(sys.virial()(0, 0));
+        real_type Py(sys.virial()(1, 1));
+        real_type Pz(sys.virial()(2, 2));
 
         for(std::size_t i=0; i<sys.size(); ++i)
         {
             const auto  m = sys.mass(i);
-            const auto& r = sys.position(i);
             const auto& v = sys.velocity(i);
-            const auto& f = sys.force(i);
 
             Ek += math::length_sq(v) * m;
-            Px += m * math::X(v) * math::X(v) + math::X(f) * math::X(r);
-            Py += m * math::Y(v) * math::Y(v) + math::Y(f) * math::Y(r);
-            Pz += m * math::Z(v) * math::Z(v) + math::Z(f) * math::Z(r);
+            Px += m * math::X(v) * math::X(v);
+            Py += m * math::Y(v) * math::Y(v);
+            Pz += m * math::Z(v) * math::Z(v);
         }
         Ek *= 0.5;
         Px *= rvolume;
         Py *= rvolume;
         Pz *= rvolume;
-
         return std::make_tuple(Ek, Px, Py, Pz);
-    }
-
-    std::tuple<real_type, real_type, real_type, real_type>
-    calc_energy_and_pressure(const system_type& sys, std::false_type)
-    {
-        real_type Ek(0);
-        for(std::size_t i=0; i<sys.size(); ++i)
-        {
-            const auto  m = sys.mass(i);
-            const auto& v = sys.velocity(i);
-            Ek += math::length_sq(v) * m;
-        }
-        Ek *= 0.5;
-        return std::make_tuple(Ek, real_type(0.0), real_type(0.0), real_type(0.0));
     }
 
     void clear_file(const std::string& fname) const

--- a/mjolnir/core/GFWNpTLangevinIntegrator.cpp
+++ b/mjolnir/core/GFWNpTLangevinIntegrator.cpp
@@ -1,0 +1,13 @@
+#include <mjolnir/core/GFWNpTLangevinIntegrator.hpp>
+
+#ifndef MJOLNIR_SEPARATE_BUILD
+#error "MJOLNIR_SEPARATE_BUILD flag is required"
+#endif
+
+namespace mjolnir
+{
+template class GFWNpTLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>>;
+template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>>;
+template class GFWNpTLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>;
+template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+} // mjolnir

--- a/mjolnir/core/GFWNpTLangevinIntegrator.hpp
+++ b/mjolnir/core/GFWNpTLangevinIntegrator.hpp
@@ -80,10 +80,7 @@ class GFWNpTLangevinIntegrator
         const auto h_cell = sys.boundary().width();
         this->P_ins_ = this->calc_pressure(sys, h_cell);
 
-        sys.attribute("P_instantaneous_x") = X(P_ins_);
-        sys.attribute("P_instantaneous_y") = Y(P_ins_);
-        sys.attribute("P_instantaneous_z") = Z(P_ins_);
-        sys.attribute("volume")            = X(h_cell) * Y(h_cell) * Z(h_cell);
+        sys.attribute("volume") = X(h_cell) * Y(h_cell) * Z(h_cell);
 
         return;
     }
@@ -238,6 +235,7 @@ class GFWNpTLangevinIntegrator
         inv_h   = make_coordinate<coordinate_type>(
                     1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
 
+        sys.attribute("volume") = det_h;
         sys.boundary().set_boundary(cell_origin, cell_origin + h_cell);
 
         // --------------------------------------------------------------------
@@ -273,11 +271,6 @@ class GFWNpTLangevinIntegrator
         // using just updated velocities and virial from `calc_force`
 
         this->P_ins_ = this->calc_pressure(sys, h_cell);
-
-        sys.attribute("P_instantaneous_x") = X(P_ins_);
-        sys.attribute("P_instantaneous_y") = Y(P_ins_);
-        sys.attribute("P_instantaneous_z") = Z(P_ins_);
-        sys.attribute("volume")            = det_h;
 
         P_diff = P_ins_ - P_ref_;
 

--- a/mjolnir/core/GFWNpTLangevinIntegrator.hpp
+++ b/mjolnir/core/GFWNpTLangevinIntegrator.hpp
@@ -1,0 +1,432 @@
+#ifndef MJOLNIR_CORE_GFW_NPT_LANGEVIN_INTEGRATOR_HPP
+#define MJOLNIR_CORE_GFW_NPT_LANGEVIN_INTEGRATOR_HPP
+#include <mjolnir/core/SimulatorTraits.hpp>
+#include <mjolnir/core/RandomNumberGenerator.hpp>
+#include <mjolnir/core/System.hpp>
+#include <mjolnir/core/ForceFieldBase.hpp>
+#include <mjolnir/core/SystemMotionRemover.hpp>
+#include <mjolnir/core/Unit.hpp>
+#include <mjolnir/util/logger.hpp>
+#include <mjolnir/util/throw_exception.hpp>
+
+namespace mjolnir
+{
+
+// isothermal-isobaric Langevin integrator developed by the following paper
+// - Xingyu Gao, Jun Fang, and Han Wang, J. Cmem. Phys. 144, 124113 (2016)
+//
+// It requires Periodic Boundary Condition. If the UnlimitedBoundary is applied,
+// it always throws. PBC implementations are below.
+//
+// The original algorithm allows cell deformation, but here it inhibits shell
+// deformation. The PBC cell will be kept always cuboidal. This condition
+// corredponds to the case where we choose Mab -> inf (a != b). Under that
+// condition, the off-diagonal terms dissappear.
+template<typename traitsT>
+class GFWNpTLangevinIntegrator
+{
+  public:
+    using traits_type     = traitsT;
+    using boundary_type   = typename traits_type::boundary_type;
+    using real_type       = typename traits_type::real_type;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using system_type     = System<traits_type>;
+    using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
+    using rng_type        = RandomNumberGenerator<traits_type>;
+
+  public:
+
+    GFWNpTLangevinIntegrator(const real_type dt, const real_type chi,
+            const coordinate_type& m_cell,     const coordinate_type& gamma_cell,
+            const coordinate_type& v_cell_ini, const std::vector<real_type>& gammas)
+        : dt_(dt), halfdt_(dt / 2), temperature_(/* dummy = */ -1), chi_(chi),
+          P_ins_(math::make_coordinate<coordinate_type>(0, 0, 0)),
+          P_ref_(math::make_coordinate<coordinate_type>(0, 0, 0)),
+          m_cell_(m_cell), v_cell_(v_cell_ini), gamma_cell_(gamma_cell),
+          gammas_(gammas), exp_gamma_dt_(gammas.size()), noise_coeff_(gammas.size())
+    {
+        if(!is_cuboidal_periodic_boundary<boundary_type>::value)
+        {
+            throw_exception<std::runtime_error>("GFWNpTLangevinIntegrator: "
+                    "periodic boundary condition is required");
+        }
+    }
+    ~GFWNpTLangevinIntegrator() = default;
+
+    void initialize(system_type& sys, forcefield_type& ff, rng_type&)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        if(!ff->constraint().empty())
+        {
+            MJOLNIR_LOG_WARN("BAOAB langevin integrator does not support constraint"
+                " forcefield. [[forcefields.constraint]] will be ignored.");
+        }
+
+        // calculate parameters for each particles
+        this->update(sys);
+
+        // calculate force
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
+        }
+        ff->calc_force(sys);
+
+        // calculate the current pressure using the force calculated here
+        const auto h_cell = sys.boundary().width();
+        this->P_ins_ = this->calc_pressure(sys, h_cell);
+
+        sys.attribute("P_instantaneous_x") = X(P_ins_);
+        sys.attribute("P_instantaneous_y") = Y(P_ins_);
+        sys.attribute("P_instantaneous_z") = Z(P_ins_);
+        sys.attribute("volume")            = X(h_cell) * Y(h_cell) * Z(h_cell);
+
+        return;
+    }
+
+    void update(const system_type& sys)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        // update reference temperature and reference pressure
+        this->temperature_    = check_attribute_exists(sys, "temperature");
+        math::X(this->P_ref_) = check_attribute_exists(sys, "pressure_x");
+        math::Y(this->P_ref_) = check_attribute_exists(sys, "pressure_y");
+        math::Z(this->P_ref_) = check_attribute_exists(sys, "pressure_z");
+
+        MJOLNIR_LOG_NOTICE("system temperature is ", this->temperature_);
+        MJOLNIR_LOG_NOTICE("system pressure is ", this->P_ref_);
+
+        this->reset_parameters(sys);
+        return ;
+    }
+
+    real_type step(const real_type t, system_type& sys,
+                   forcefield_type& ff, rng_type& rng)
+    {
+        using math::hadamard_product;
+        using math::make_coordinate;
+        using math::X; using math::Y; using math::Z;
+
+        // --------------------------------------------------------------------
+        // preparation
+
+        const auto cell_origin = sys.boundary().lower_bound();
+
+        auto h_cell = sys.boundary().upper_bound() - cell_origin;
+        auto det_h  = X(h_cell) * Y(h_cell) * Z(h_cell);
+        auto inv_h  = make_coordinate<coordinate_type>(
+                        1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+        auto P_diff = P_ins_ - P_ref_;
+
+        // --------------------------------------------------------------------
+        // update cell velocity
+
+        v_cell_ += hadamard_product(halfdt_ * rm_cell_,
+                   hadamard_product(det_h * inv_h, P_diff) - chi_kBT_ * inv_h);
+
+        // --------------------------------------------------------------------
+        // update particle velocities
+
+        {
+            const auto v_over_h = hadamard_product(-v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                sys.velocity(i) = this->S(sys.velocity(i),
+                                          sys.force(i) * sys.rmass(i),
+                                          v_over_h, coef_S);
+                sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // update cell size, volume and inverse cell matrix
+
+        h_cell  += halfdt_ * v_cell_;
+        det_h    = X(h_cell) * Y(h_cell) * Z(h_cell);
+        inv_h    = make_coordinate<coordinate_type>(
+                    1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+
+        sys.boundary().set_boundary(cell_origin, cell_origin + h_cell);
+
+        // --------------------------------------------------------------------
+        // update particle positions
+
+        real_type max_displacement_sq_1 = 0;
+        {
+            const auto v_over_h = hadamard_product(v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto new_pos = this->S(sys.position(i), sys.velocity(i),
+                                             v_over_h, coef_S);
+
+                max_displacement_sq_1 = std::max(max_displacement_sq_1,
+                        math::length_sq(sys.position(i) - new_pos));
+
+                sys.position(i) = sys.boundary().adjust_position(new_pos);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // update cell velocity (ornstein-Uhlenbeck)
+
+        const auto R_cell = this->gen_R(rng);
+
+        X(v_cell_) *= X(exp_gamma_dt_cell_);
+        Y(v_cell_) *= Y(exp_gamma_dt_cell_);
+        Z(v_cell_) *= Z(exp_gamma_dt_cell_);
+
+        X(v_cell_) += X(noise_coeff_cell_) * X(R_cell);
+        Y(v_cell_) += Y(noise_coeff_cell_) * Y(R_cell);
+        Z(v_cell_) += Z(noise_coeff_cell_) * Z(R_cell);
+
+        // --------------------------------------------------------------------
+        // update particle velocities (Ornstein-Uhlenbeck)
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto R     = this->gen_R(rng);
+            sys.velocity(i) *= this->exp_gamma_dt_[i];
+            sys.velocity(i) += this->noise_coeff_[i] * R;
+        }
+
+        // --------------------------------------------------------------------
+        // update particle positions
+
+
+        real_type max_displacement_sq_2 = 0;
+        {
+            const auto v_over_h = hadamard_product(v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto new_pos = this->S(sys.position(i), sys.velocity(i),
+                                             v_over_h, coef_S);
+
+                max_displacement_sq_2 = std::max(max_displacement_sq_2,
+                        math::length_sq(sys.position(i) - new_pos));
+
+                sys.position(i) = sys.boundary().adjust_position(new_pos);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // update cell size
+
+        h_cell += halfdt_ * v_cell_;
+        det_h   = X(h_cell) * Y(h_cell) * Z(h_cell);
+        inv_h   = make_coordinate<coordinate_type>(
+                    1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+
+        sys.boundary().set_boundary(cell_origin, cell_origin + h_cell);
+
+        // --------------------------------------------------------------------
+        // calc force
+
+        // update neighbor list; reduce margin, reconstruct the list if needed
+        const auto max_displacement = std::sqrt(max_displacement_sq_1) +
+                                      std::sqrt(max_displacement_sq_2);
+        ff->reduce_margin(2 * max_displacement, sys);
+
+        ff->calc_force(sys);
+
+        // --------------------------------------------------------------------
+        // update particle velocities
+
+        {
+            const auto v_over_h = hadamard_product(-v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                sys.velocity(i) = this->S(sys.velocity(i),
+                                          sys.force(i) * sys.rmass(i),
+                                          v_over_h, coef_S);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // calc current pressure
+        this->P_ins_ = this->calc_pressure(sys, h_cell);
+
+        sys.attribute("P_instantaneous_x") = X(P_ins_);
+        sys.attribute("P_instantaneous_y") = Y(P_ins_);
+        sys.attribute("P_instantaneous_z") = Z(P_ins_);
+        sys.attribute("volume")            = det_h;
+
+        P_diff = P_ins_ - P_ref_;
+
+        // --------------------------------------------------------------------
+        // update cell velocities
+
+        v_cell_ += hadamard_product(halfdt_ * rm_cell_,
+                   hadamard_product(det_h * inv_h, P_diff) - chi_kBT_ * inv_h);
+
+        return t + dt_;
+    }
+
+    real_type                     delta_t()    const noexcept {return dt_;}
+    std::vector<real_type> const& parameters() const noexcept {return gammas_;}
+
+  private:
+
+    real_type check_attribute_exists(const system_type& sys, const std::string& attr)
+    {
+        if(!sys.has_attribute(attr))
+        {
+            throw_exception<std::out_of_range>("mjolnir::GFWNpTLangevinIntegrator: "
+                "It requires attribute `", attr, "`, but `", attr,
+                "` is not found in `system.attribute`.");
+        }
+        return sys.attribute(attr);
+    }
+
+    // reset all the cached parameters.
+    void reset_parameters(const system_type& sys) noexcept
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+        using math::X; using math::Y; using math::Z;
+
+        const auto kBT = physics::constants<real_type>::kB() * this->temperature_;
+
+        this->chi_kBT_ = this->chi_ * kBT;
+        MJOLNIR_LOG_INFO("chi = ", this->chi_, ", chi_kBT = ", chi_kBT_);
+
+        X(rm_cell_) = real_type(1) / X(m_cell_);
+        Y(rm_cell_) = real_type(1) / Y(m_cell_);
+        Z(rm_cell_) = real_type(1) / Z(m_cell_);
+
+        // exp(-gamma dt)
+        const real_type exp_gamma_dt_x = std::exp(-dt_ * X(gamma_cell_));
+        const real_type exp_gamma_dt_y = std::exp(-dt_ * Y(gamma_cell_));
+        const real_type exp_gamma_dt_z = std::exp(-dt_ * Z(gamma_cell_));
+
+        // exp(-2gamma dt)
+        const real_type exp_2gamma_dt_x = exp_gamma_dt_x * exp_gamma_dt_x;
+        const real_type exp_2gamma_dt_y = exp_gamma_dt_y * exp_gamma_dt_y;
+        const real_type exp_2gamma_dt_z = exp_gamma_dt_z * exp_gamma_dt_z;
+
+        X(exp_gamma_dt_cell_) = exp_gamma_dt_x;
+        Y(exp_gamma_dt_cell_) = exp_gamma_dt_y;
+        Z(exp_gamma_dt_cell_) = exp_gamma_dt_z;
+
+        // we use velocity in this class, so devide it by M_cell.
+        X(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_x) * kBT * X(rm_cell_));
+        Y(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_y) * kBT * Y(rm_cell_));
+        Z(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_z) * kBT * Z(rm_cell_));
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto gamma    = this->gammas_.at(i);
+            const auto gamma_dt = -1 * gamma * this->dt_;
+            this->exp_gamma_dt_.at(i) = std::exp(gamma_dt);
+            this->noise_coeff_ .at(i) = std::sqrt(
+                    kBT * (1 - std::exp(2 * gamma_dt)) * sys.rmass(i));
+        }
+        return;
+    }
+
+    // It calculates only diagonal terms. off-diagnoal terms are not considered.
+    coordinate_type calc_pressure(const system_type&    sys,
+                                  const coordinate_type h_cell) const noexcept
+    {
+        const auto det_h = math::X(h_cell) * math::Y(h_cell) * math::Z(h_cell);
+
+        // instantaneous pressure
+        auto Pins = math::make_coordinate<coordinate_type>(0, 0, 0);
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto m = sys.mass(i);
+            const auto r = sys.position(i);
+            const auto v = sys.velocity(i);
+            const auto f = sys.force(i);
+
+            // here the original form is a tensor product. but the diagonal term
+            // of the tensor product (cij = ai * bj) becomes hadamard product
+            // (cii = ai * bi).
+
+            Pins += m * math::hadamard_product(v, v) + math::hadamard_product(f, r);
+        }
+        return Pins / det_h;
+    }
+
+    // When the off-diagonal terms vanish, the Su and the Sl functions become
+    // the same with each other and are drastically simplified.
+    // Here it implements diagonal version of Su and Sl.
+    coordinate_type S(coordinate_type x0,      const coordinate_type b,
+                      const coordinate_type A, const coordinate_type coef_S)
+    {
+        using math::X; using math::Y; using math::Z;
+
+        X(x0) *= X(coef_S);
+        Y(x0) *= Y(coef_S);
+        Z(x0) *= Z(coef_S);
+
+        X(x0) -= (real_type(1) - X(coef_S)) * X(b) / X(A);
+        Y(x0) -= (real_type(1) - Y(coef_S)) * Y(b) / Y(A);
+        Z(x0) -= (real_type(1) - Z(coef_S)) * Z(b) / Z(A);
+
+        return x0;
+    }
+
+    coordinate_type gen_R(rng_type& rng) noexcept
+    {
+        const auto x = rng.gaussian();
+        const auto y = rng.gaussian();
+        const auto z = rng.gaussian();
+        return math::make_coordinate<coordinate_type>(x, y, z);
+    }
+
+  private:
+
+    real_type dt_;
+    real_type halfdt_;
+    real_type temperature_;
+    real_type chi_;
+    real_type chi_kBT_;
+
+    // diagonal terms only
+    coordinate_type P_ins_;
+    coordinate_type P_ref_;
+    coordinate_type m_cell_;
+    coordinate_type rm_cell_;
+    coordinate_type v_cell_;
+    coordinate_type gamma_cell_;
+    coordinate_type exp_gamma_dt_cell_;
+    coordinate_type noise_coeff_cell_;
+
+    std::vector<real_type> gammas_;
+    std::vector<real_type> exp_gamma_dt_;
+    std::vector<real_type> noise_coeff_;
+};
+
+#ifdef MJOLNIR_SEPARATE_BUILD
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+#endif
+
+} // mjolnir
+#endif /* MJOLNIR_GFW_NPT_LANGEVIN_INTEGRATOR */

--- a/mjolnir/core/GJFNVTLangevinIntegrator.hpp
+++ b/mjolnir/core/GJFNVTLangevinIntegrator.hpp
@@ -22,6 +22,7 @@ class GJFNVTLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -62,6 +63,7 @@ class GJFNVTLangevinIntegrator
             {
                 sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
             }
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
             ff->calc_force(sys);
         }
         return;
@@ -165,6 +167,7 @@ GJFNVTLangevinIntegrator<traitsT>::step(const real_type time,
         // collect largest displacement
         largest_disp2 = std::max(largest_disp2, math::length_sq(dp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/MsgPackLoader.hpp
+++ b/mjolnir/core/MsgPackLoader.hpp
@@ -223,6 +223,29 @@ class MsgPackLoader
         sys.force_initialized() = true;
 
         // -----------------------------------------------------------------------
+        // load virial
+
+        this->check_msgpack_key(file, filename, "virial");
+        {
+            const auto tag = detail::read_bytes_as<std::uint8_t>(file);
+            if(tag != 0x99)
+            {
+                throw_exception<std::runtime_error>("[error] mjolnir::MsgPackLoader:"
+                        "expected tag 0x99, but got ", std::hex, std::uint32_t(tag));
+            }
+            auto& vir = sys.virial();
+            vir(0, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(0, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(0, 2) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(1, 2) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 0) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 1) = this->from_msgpack<real_type>(file, filename);
+            vir(2, 2) = this->from_msgpack<real_type>(file, filename);
+        }
+
+        // -----------------------------------------------------------------------
         // load attributes
 
         this->check_msgpack_key(file, filename, "attributes");

--- a/mjolnir/core/MsgPackSaver.hpp
+++ b/mjolnir/core/MsgPackSaver.hpp
@@ -28,6 +28,7 @@ namespace mjolnir
 //             "group"   : string,
 //         }, ...
 //     ]
+//     "virial"       : [real; 9]
 //     "attributres"  : map<N>{"temperature": real, ...},
 // }
 //
@@ -41,6 +42,7 @@ class MsgPackSaver
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traits_type>;
     using attribute_type  = typename system_type::attribute_type;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -142,6 +144,12 @@ class MsgPackSaver
         }
 
         // ---------------------------------------------------------------------
+        // write virial of the current state
+
+        to_msgpack("virial");
+        to_msgpack(sys.virial());
+
+        // ---------------------------------------------------------------------
         // write attributes list
 
         to_msgpack("attributes");
@@ -224,7 +232,7 @@ class MsgPackSaver
     void to_msgpack(const coordinate_type& v)
     {
         // [float, float, float]
-        // fixmap (3)
+        // fixarray (3)
         // 0b'1001'0011
         // 0x    9    3
         constexpr std::uint8_t fixarray3_code = 0x93;
@@ -232,6 +240,26 @@ class MsgPackSaver
         to_msgpack(math::X(v));
         to_msgpack(math::Y(v));
         to_msgpack(math::Z(v));
+        return ;
+    }
+
+    void to_msgpack(const matrix33_type& m)
+    {
+        // [float; 9]
+        // fixarray (9)
+        // 0b'1001'1001
+        // 0x    9    3
+        constexpr std::uint8_t fixarray9_code = 0x99;
+        buffer_.push_back(fixarray9_code);
+        to_msgpack(m(0, 0));
+        to_msgpack(m(0, 1));
+        to_msgpack(m(0, 2));
+        to_msgpack(m(1, 0));
+        to_msgpack(m(1, 1));
+        to_msgpack(m(1, 2));
+        to_msgpack(m(2, 0));
+        to_msgpack(m(2, 1));
+        to_msgpack(m(2, 2));
         return ;
     }
 

--- a/mjolnir/core/System.hpp
+++ b/mjolnir/core/System.hpp
@@ -22,6 +22,7 @@ class System
     using string_type     = std::string;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using boundary_type   = typename traits_type::boundary_type;
     using topology_type   = Topology;
     using attribute_type  = std::map<std::string, real_type>;
@@ -39,7 +40,7 @@ class System
 
     System(const std::size_t num_particles, const boundary_type& bound)
         : velocity_initialized_(false), force_initialized_(false),
-          boundary_(bound), attributes_(),
+          boundary_(bound), attributes_(), virial_(0,0,0, 0,0,0, 0,0,0),
           num_particles_(num_particles), masses_   (num_particles),
           rmasses_      (num_particles), positions_(num_particles),
           velocities_   (num_particles), forces_   (num_particles),
@@ -99,6 +100,10 @@ class System
     coordinate_type  adjust_position(coordinate_type dr) const noexcept
     {
         return boundary_.adjust_position(dr);
+    }
+    coordinate_type transpose(coordinate_type tgt, const coordinate_type& ref) const noexcept
+    {
+        return boundary_.transpose(tgt, ref);
     }
 
     std::size_t size() const noexcept {return num_particles_;}
@@ -168,6 +173,9 @@ class System
     string_type const& group(std::size_t i) const noexcept {return groups_[i];}
     string_type&       group(std::size_t i)       noexcept {return groups_[i];}
 
+    matrix33_type&       virial()       noexcept {return virial_;}
+    matrix33_type const& virial() const noexcept {return virial_;}
+
     boundary_type&       boundary()       noexcept {return boundary_;}
     boundary_type const& boundary() const noexcept {return boundary_;}
 
@@ -191,6 +199,7 @@ class System
     bool           velocity_initialized_, force_initialized_;
     boundary_type  boundary_;
     attribute_type attributes_;
+    matrix33_type  virial_;
 
     std::size_t                  num_particles_;
     real_container_type          masses_;

--- a/mjolnir/core/UnderdampedLangevinIntegrator.hpp
+++ b/mjolnir/core/UnderdampedLangevinIntegrator.hpp
@@ -24,6 +24,7 @@ class UnderdampedLangevinIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traits_type>;
@@ -123,6 +124,7 @@ void UnderdampedLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
         // calculate force
         ff->calc_force(system);
@@ -170,6 +172,7 @@ UnderdampedLangevinIntegrator<traitsT>::step(
 
         largest_disp2 = std::max(largest_disp2, math::length_sq(displacement));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/VelocityVerletIntegrator.hpp
+++ b/mjolnir/core/VelocityVerletIntegrator.hpp
@@ -17,6 +17,7 @@ class VelocityVerletIntegrator
     using boundary_type   = typename traits_type::boundary_type;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
     using rng_type        = RandomNumberGenerator<traitsT>;
@@ -73,6 +74,7 @@ void VelocityVerletIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
     return;
@@ -95,6 +97,7 @@ VelocityVerletIntegrator<traitsT>::step(
 
         largest_disp2 = std::max(largest_disp2, math::length_sq(disp));
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     // update neighbor list; reduce margin, reconstruct the list if needed
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);

--- a/mjolnir/core/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/gBAOABLangevinIntegrator.hpp
@@ -20,6 +20,7 @@ class gBAOABLangevinIntegrator
     using traits_type      = traitsT;
     using real_type        = typename traits_type::real_type;
     using coordinate_type  = typename traits_type::coordinate_type;
+    using matrix33_type    = typename traits_type::matrix33_type;
     using indices_type     = std::array<std::size_t, 2>;
     using system_type      = System<traitsT>;
     using forcefield_type = std::unique_ptr<ForceFieldBase<traitsT>>;
@@ -242,6 +243,7 @@ void gBAOABLangevinIntegrator<traitsT>::initialize(
         {
             system.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
         }
+        system.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
         ff->calc_force(system);
     }
 
@@ -324,6 +326,7 @@ gBAOABLangevinIntegrator<traitsT>::step(
         // reset force
         sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
     }
+    sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
 
     ff->reduce_margin(2 * std::sqrt(largest_disp2), sys);
 

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -157,8 +157,12 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    sys.force(Bi) -= dU_rep * Bji_reg;
-                    sys.force(Bj) -= dU_rep * Bij_reg;
+                    const auto F = -dU_rep * Bji_reg;
+                    sys.force(Bi) += F;
+                    sys.force(Bj) -= F;
+
+                    // Bij = Bj - Bi
+                    sys.virial() += math::tensor_product(Bij, -F);
                 }
             }
 
@@ -245,6 +249,11 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
 
                 if(cos_dphi != real_type(-1.0))
                 {
+                    auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                     const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
 
                     // --------------------------------------------------------
@@ -263,10 +272,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                         const auto coef_Bi = dot_SBiBj * rlBij_sq;
                         const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                        sys.force(Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                        sys.force(Sj) += fSj;
+                        f_Si += fSi;
+                        f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                        f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                        f_Sj += fSj;
                     }
 
                     const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -287,9 +296,9 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                                          (cos_theta1 * BSi_reg - Bij_reg);
                         const auto fBj = (coef_rsin * rlBij) *
                                          (cos_theta1 * Bij_reg - BSi_reg);
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) -= (fSi + fBj);
-                        sys.force(Bj) += fBj;
+                        f_Si += fSi;
+                        f_Bi -= (fSi + fBj);
+                        f_Bj += fBj;
                     }
                     // --------------------------------------------------------
                     // calc theta2 term
@@ -307,9 +316,9 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                                          (cos_theta2 * Bji_reg - BSj_reg);
                         const auto fSj = (coef_rsin * rlSBj) *
                                          (cos_theta2 * BSj_reg - Bji_reg);
-                        sys.force(Bi) += fBi;
-                        sys.force(Bj) -= (fBi + fSj);
-                        sys.force(Sj) += fSj;
+                        f_Bi += fBi;
+                        f_Bj -= (fBi + fSj);
+                        f_Sj += fSj;
                     }
                     // --------------------------------------------------------
                     // calc distance
@@ -318,9 +327,19 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     {
                         // remember that F = -dU. Here `coef` = -dU.
                         const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                        sys.force(Bi) += coef * Bji_reg;
-                        sys.force(Bj) += coef * Bij_reg;
+                        f_Bi += coef * Bji_reg;
+                        f_Bj += coef * Bij_reg;
                     }
+
+                    sys.force(Si) += f_Si;
+                    sys.force(Bi) += f_Bi;
+                    sys.force(Bj) += f_Bj;
+                    sys.force(Sj) += f_Sj;
+
+                    sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                     math::tensor_product(                   rBi , f_Bi) +
+                                     math::tensor_product(             rBi + Bij,  f_Bj) +
+                                     math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
                 }
             }
 
@@ -381,6 +400,13 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
             const auto fSi_theta3 = real_type(-1) * fBi_theta3;
             const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+            auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
             // adjacent of Base j exists. its not the edge of the strand.
             if(Bj_next_exists)
             {
@@ -426,10 +452,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -443,17 +469,17 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                         const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                         const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                        sys.force(Si)      += fSi;
-                        sys.force(Bi)      -= (fSi + fBj5);
-                        sys.force(Bj_next) += fBj5;
+                        f_Si      += fSi;
+                        f_Bi      -= (fSi + fBj5);
+                        f_Bj_next += fBj5;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bi)      += coef * Bj5i_reg;
-                        sys.force(Bj_next) -= coef * Bj5i_reg;
+                        f_Bi      += coef * Bj5i_reg;
+                        f_Bj_next -= coef * Bj5i_reg;
                     }
                 }
             }
@@ -500,10 +526,10 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -516,20 +542,34 @@ void ThreeSPN2BaseBaseInteraction<traitsT>::calc_force(
 
                         const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                         const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                        sys.force(Sj)      += fSj;
-                        sys.force(Bj)      -= (fSj + fBi3);
-                        sys.force(Bi_next) += fBi3;
+                        f_Sj      += fSj;
+                        f_Bj      -= (fSj + fBi3);
+                        f_Bi_next += fBi3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bj)      += coef * Bi3j_reg;
-                        sys.force(Bi_next) -= coef * Bi3j_reg;
+                        f_Bj      += coef * Bi3j_reg;
+                        f_Bi_next -= coef * Bi3j_reg;
                     }
                 }
             }
+
+            sys.force(Si)      += f_Si     ;
+            sys.force(Sj)      += f_Sj     ;
+            sys.force(Bi)      += f_Bi     ;
+            sys.force(Bj)      += f_Bj     ;
+            sys.force(Bi_next) += f_Bi_next;
+            sys.force(Bj_next) += f_Bj_next;
+
+            sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                             math::tensor_product(                   rBi , f_Bi) +
+                             math::tensor_product(              rBi + Bij, f_Bj) +
+                             math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                             math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                             math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
         }
     }
     return;
@@ -849,8 +889,11 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    sys.force(Bi) -= dU_rep * Bji_reg;
-                    sys.force(Bj) -= dU_rep * Bij_reg;
+                    const auto F = dU_rep * Bji_reg;
+                    sys.force(Bi) -= F;
+                    sys.force(Bj) += F;
+
+                    sys.virial() += math::tensor_product(Bij, -F); // (Bj - Bi) * Fj
                 }
             }
 
@@ -941,6 +984,11 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
 
                 if(cos_dphi != real_type(-1.0))
                 {
+                    auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                    auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                     // --------------------------------------------------------
                     // calc dihedral term
                     // -sin(dphi)/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
@@ -957,10 +1005,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                         const auto coef_Bi = dot_SBiBj * rlBij_sq;
                         const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                        sys.force(Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                        sys.force(Sj) += fSj;
+                        f_Si += fSi;
+                        f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                        f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                        f_Sj += fSj;
                     }
 
                     const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -981,9 +1029,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                                          (cos_theta1 * BSi_reg - Bij_reg);
                         const auto fBj = (coef_rsin * rlBij) *
                                          (cos_theta1 * Bij_reg - BSi_reg);
-                        sys.force(Si) += fSi;
-                        sys.force(Bi) -= (fSi + fBj);
-                        sys.force(Bj) += fBj;
+                        f_Si += fSi;
+                        f_Bi -= (fSi + fBj);
+                        f_Bj += fBj;
                     }
                     // --------------------------------------------------------
                     // calc theta2 term
@@ -1001,9 +1049,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                                          (cos_theta2 * Bji_reg - BSj_reg);
                         const auto fSj = (coef_rsin * rlSBj) *
                                          (cos_theta2 * BSj_reg - Bji_reg);
-                        sys.force(Bi) += fBi;
-                        sys.force(Bj) -= (fBi + fSj);
-                        sys.force(Sj) += fSj;
+                        f_Bi += fBi;
+                        f_Bj -= (fBi + fSj);
+                        f_Sj += fSj;
                     }
                     // --------------------------------------------------------
                     // calc distance
@@ -1012,9 +1060,19 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     {
                         // remember that F = -dU. Here `coef` = -dU.
                         const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                        sys.force(Bi) += coef * Bji_reg;
-                        sys.force(Bj) += coef * Bij_reg;
+                        f_Bi += coef * Bji_reg;
+                        f_Bj += coef * Bij_reg;
                     }
+
+                    sys.force(Si) += f_Si;
+                    sys.force(Bi) += f_Bi;
+                    sys.force(Bj) += f_Bj;
+                    sys.force(Sj) += f_Sj;
+
+                    sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                     math::tensor_product(                   rBi , f_Bi) +
+                                     math::tensor_product(              rBi + Bij, f_Bj) +
+                                     math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
                 }
             }
 
@@ -1075,6 +1133,13 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
             const auto fSi_theta3 = real_type(-1) * fBi_theta3;
             const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+            auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
             // adjacent of Base j exists. its not the edge of the strand.
             if(Bj_next_exists)
             {
@@ -1122,10 +1187,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1139,17 +1204,17 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                         const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                         const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                        sys.force(Si)      += fSi;
-                        sys.force(Bi)      -= (fSi + fBj5);
-                        sys.force(Bj_next) += fBj5;
+                        f_Si      += fSi;
+                        f_Bi      -= (fSi + fBj5);
+                        f_Bj_next += fBj5;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bi)      += coef * Bj5i_reg;
-                        sys.force(Bj_next) -= coef * Bj5i_reg;
+                        f_Bi      += coef * Bj5i_reg;
+                        f_Bj_next -= coef * Bj5i_reg;
                     }
                 }
             }
@@ -1198,10 +1263,10 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                     if(df3 != real_type(0))
                     {
                         const auto coef = -df3 * fCS * U_dU_attr.first;
-                        sys.force(Si) += coef * fSi_theta3;
-                        sys.force(Sj) += coef * fSj_theta3;
-                        sys.force(Bi) += coef * fBi_theta3;
-                        sys.force(Bj) += coef * fBj_theta3;
+                        f_Si += coef * fSi_theta3;
+                        f_Sj += coef * fSj_theta3;
+                        f_Bi += coef * fBi_theta3;
+                        f_Bj += coef * fBj_theta3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1214,20 +1279,33 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
 
                         const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                         const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                        sys.force(Sj)      += fSj;
-                        sys.force(Bj)      -= (fSj + fBi3);
-                        sys.force(Bi_next) += fBi3;
+                        f_Sj      += fSj;
+                        f_Bj      -= (fSj + fBi3);
+                        f_Bi_next += fBi3;
                     }
                     // --------------------------------------------------------
                     // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                     if(U_dU_attr.second != real_type(0.0))
                     {
                         const auto coef = -f3 * fCS * U_dU_attr.second;
-                        sys.force(Bj)      += coef * Bi3j_reg;
-                        sys.force(Bi_next) -= coef * Bi3j_reg;
+                        f_Bj      += coef * Bi3j_reg;
+                        f_Bi_next -= coef * Bi3j_reg;
                     }
                 }
             }
+            sys.force(Si)      += f_Si     ;
+            sys.force(Sj)      += f_Sj     ;
+            sys.force(Bi)      += f_Bi     ;
+            sys.force(Bj)      += f_Bj     ;
+            sys.force(Bi_next) += f_Bi_next;
+            sys.force(Bj_next) += f_Bj_next;
+
+            sys.virial()  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                             math::tensor_product(                   rBi , f_Bi) +
+                             math::tensor_product(              rBi + Bij, f_Bj) +
+                             math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                             math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                             math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
         }
     }
     return energy;

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseBaseInteraction.hpp
@@ -889,9 +889,9 @@ ThreeSPN2BaseBaseInteraction<traitsT>::calc_force_and_energy(
                 if(dU_rep != real_type(0))
                 {
                     // remember that F = -dU.
-                    const auto F = dU_rep * Bji_reg;
-                    sys.force(Bi) -= F;
-                    sys.force(Bj) += F;
+                    const auto F = -dU_rep * Bji_reg;
+                    sys.force(Bi) += F;
+                    sys.force(Bj) -= F;
 
                     sys.virial() += math::tensor_product(Bij, -F); // (Bj - Bi) * Fj
                 }

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
@@ -249,7 +249,8 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
             // purely repulsive. add the repulsive force to the system and quit.
             sys.force(Bi) += f_Bi;
             sys.force(Bj) += f_Bj;
-            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
+            // Bji = Bj -> Bi = Bi - Bj
+            sys.virial() += math::tensor_product(Bji, f_Bi); // (Bi - Bj) * fBi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);
@@ -449,7 +450,7 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
             // purely repulsive. add the repulsive force to the system and quit.
             sys.force(Bi) += f_Bi;
             sys.force(Bj) += f_Bj;
-            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
+            sys.virial() += math::tensor_product(Bji, f_Bi); // (Bi - Bj) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);

--- a/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/forcefield/3SPN2/ThreeSPN2BaseStackingInteraction.hpp
@@ -205,14 +205,18 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         const auto lBji    = lBji_sq * rlBji;      // |Bji|
         const auto Bji_reg = Bji * rlBji;          // Bji / |Bji|
 
+        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+
         // ====================================================================
         // calc repulsive part, which does not depend on angle term.
 
         const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
         if(dU_rep != real_type(0.0))
         {
-            sys.force(Bi) -= dU_rep * Bji_reg;
-            sys.force(Bj) += dU_rep * Bji_reg;
+            f_Bi -= dU_rep * Bji_reg;
+            f_Bj += dU_rep * Bji_reg;
         }
 
         // --------------------------------------------------------------------
@@ -242,7 +246,10 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         const auto f_theta = potential_.f(theta, theta_0);
         if(f_theta == real_type(0.0))
         {
-            // purely repulsive.
+            // purely repulsive. add the repulsive force to the system and quit.
+            sys.force(Bi) += f_Bi;
+            sys.force(Bj) += f_Bj;
+            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);
@@ -263,9 +270,9 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
             const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
             const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-            sys.force(Si) +=  fSi;
-            sys.force(Bi) -= (fSi + fBj);
-            sys.force(Bj) +=        fBj;
+            f_Si +=  fSi;
+            f_Bi -= (fSi + fBj);
+            f_Bj +=        fBj;
         }
 
         // --------------------------------------------------------------------
@@ -275,9 +282,17 @@ void ThreeSPN2BaseStackingInteraction<traitsT>::calc_force(
         if(U_dU_attr.second != real_type(0.0))
         {
             const auto coef = f_theta * U_dU_attr.second;
-            sys.force(Bi) -= coef * Bji_reg;
-            sys.force(Bj) += coef * Bji_reg;
+            f_Bi -= coef * Bji_reg;
+            f_Bj += coef * Bji_reg;
         }
+
+        sys.force(Bi) += f_Bi;
+        sys.force(Bj) += f_Bj;
+        sys.force(Si) += f_Si;
+
+        sys.virial() += math::tensor_product(rBi,       f_Bi) +
+                        math::tensor_product(rBi - Bji, f_Bj) +
+                        math::tensor_product(rBi - SBi, f_Si);
     }
     return ;
 }
@@ -389,14 +404,18 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         const auto lBji    = lBji_sq * rlBji;      // |Bji|
         const auto Bji_reg = Bji * rlBji;          // Bji / |Bji|
 
+        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+
         // ====================================================================
         // calc repulsive part, which does not depend on angle term.
 
         const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
         if(dU_rep != real_type(0.0))
         {
-            sys.force(Bi) -= dU_rep * Bji_reg;
-            sys.force(Bj) += dU_rep * Bji_reg;
+            f_Bi -= dU_rep * Bji_reg;
+            f_Bj += dU_rep * Bji_reg;
         }
         energy += potential_.U_rep(bs_kind, lBji);
 
@@ -427,7 +446,10 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         const auto f_theta = potential_.f(theta, theta_0);
         if(f_theta == real_type(0.0))
         {
-            // purely repulsive.
+            // purely repulsive. add the repulsive force to the system and quit.
+            sys.force(Bi) += f_Bi;
+            sys.force(Bj) += f_Bj;
+            sys.virial() += math::tensor_product(Bji, f_Bj); // (Bj - Bi) * f_Bi
             continue;
         }
         const auto df_theta  = potential_.df(theta, theta_0);
@@ -450,9 +472,9 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
             const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
             const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-            sys.force(Si) +=  fSi;
-            sys.force(Bi) -= (fSi + fBj);
-            sys.force(Bj) +=        fBj;
+            f_Si +=  fSi;
+            f_Bi -= (fSi + fBj);
+            f_Bj +=        fBj;
         }
 
         // --------------------------------------------------------------------
@@ -462,9 +484,17 @@ ThreeSPN2BaseStackingInteraction<traitsT>::calc_force_and_energy(
         if(U_dU_attr.second != real_type(0.0))
         {
             const auto coef = f_theta * U_dU_attr.second;
-            sys.force(Bi) -= coef * Bji_reg;
-            sys.force(Bj) += coef * Bji_reg;
+            f_Bi -= coef * Bji_reg;
+            f_Bj += coef * Bji_reg;
         }
+
+        sys.force(Bi) += f_Bi;
+        sys.force(Bj) += f_Bj;
+        sys.force(Si) += f_Si;
+
+        sys.virial() += math::tensor_product(rBi,       f_Bi) +
+                        math::tensor_product(rBi - Bji, f_Bj) +
+                        math::tensor_product(rBi - SBi, f_Si);
     }
     return energy;
 }

--- a/mjolnir/forcefield/MultipleBasin/MultipleBasinUnitBase.hpp
+++ b/mjolnir/forcefield/MultipleBasin/MultipleBasinUnitBase.hpp
@@ -33,6 +33,7 @@ class MultipleBasinUnitBase
     using traits_type     = traitsT;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using system_type     = System<traits_type>;
     using topology_type   = Topology;
 

--- a/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
+++ b/mjolnir/forcefield/PWMcos/PWMcosInteraction.hpp
@@ -225,8 +225,13 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
 
             const auto factor = coef * (e_pwm + shift);
 
-            auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
-            auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_Ca  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_S   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B5  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B3  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaN = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaC = math::make_coordinate<coordinate_type>(0, 0, 0);
 
             // ----------------------------------------------------------------
             // calculate direction term
@@ -258,9 +263,9 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlBS ) *
                                 ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
 
-                F_Ca         -= Fi;
-                F_B          += (Fi + Fk);
-                sys.force(S) -= Fk;
+                F_Ca -= Fi;
+                F_B  += (Fi + Fk);
+                F_S  -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -280,10 +285,10 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlB53) *
                                 ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
 
-                F_Ca          -= Fi;
-                F_B           += Fi;
-                sys.force(B5) += Fk;
-                sys.force(B3) -= Fk;
+                F_Ca -= Fi;
+                F_B  += Fi;
+                F_B5 += Fk;
+                F_B3 -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -303,17 +308,30 @@ void PWMcosInteraction<traitsT>::calc_force(system_type& sys) const noexcept
                 const auto Fk = (coef_rsin * rlCCN) *
                                 ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
 
-                F_Ca           -= Fi;
-                F_B            += Fi;
-                sys.force(CaC) += Fk;
-                sys.force(CaN) -= Fk;
+                F_Ca  -= Fi;
+                F_B   += Fi;
+                F_CaC += Fk;
+                F_CaN -= Fk;
             }
 
             // ----------------------------------------------------------------
             // collect force on Ca and B
 
-            sys.force(Ca) += F_Ca;
-            sys.force(B ) += F_B ;
+            sys.force(Ca)  += F_Ca;
+            sys.force(B )  += F_B;
+            sys.force(S)   += F_S;
+            sys.force(B5)  += F_B5;
+            sys.force(B3)  += F_B3;
+            sys.force(CaN) += F_CaN;
+            sys.force(CaC) += F_CaC;
+
+            sys.virial() += math::tensor_product(              rCa,        F_Ca)
+                         +  math::tensor_product(sys.transpose(rB,   rCa), F_B)
+                         +  math::tensor_product(sys.transpose(rS,   rCa), F_S)
+                         +  math::tensor_product(sys.transpose(rB5,  rCa), F_B5)
+                         +  math::tensor_product(sys.transpose(rB3,  rCa), F_B3)
+                         +  math::tensor_product(sys.transpose(rCaN, rCa), F_CaN)
+                         +  math::tensor_product(sys.transpose(rCaC, rCa), F_CaC);
         }
     }
     return ;
@@ -546,8 +564,13 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
             energy += factor * f_df.first *
                       g_dg_1.first * g_dg_2.first * g_dg_3.first;
 
-            auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
-            auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_Ca  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_S   = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B5  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_B3  = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaN = math::make_coordinate<coordinate_type>(0, 0, 0);
+            auto F_CaC = math::make_coordinate<coordinate_type>(0, 0, 0);
 
             // ----------------------------------------------------------------
             // calculate direction term
@@ -579,9 +602,9 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlBS ) *
                                 ((cos1 * rlBS ) * rBS  - rlBCa * rBCa);
 
-                F_Ca         -= Fi;
-                F_B          += (Fi + Fk);
-                sys.force(S) -= Fk;
+                F_Ca -= Fi;
+                F_B  += (Fi + Fk);
+                F_S  -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -601,10 +624,10 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlB53) *
                                 ((cos2 * rlB53) * rB53 - rlBCa * rBCa);
 
-                F_Ca          -= Fi;
-                F_B           += Fi;
-                sys.force(B5) += Fk;
-                sys.force(B3) -= Fk;
+                F_Ca -= Fi;
+                F_B  += Fi;
+                F_B5 += Fk;
+                F_B3 -= Fk;
             }
 
             // ----------------------------------------------------------------
@@ -624,17 +647,30 @@ PWMcosInteraction<traitsT>::calc_force_and_energy(system_type& sys) const noexce
                 const auto Fk = (coef_rsin * rlCCN) *
                                 ((cos3 * rlCCN) * rCCN - rlBCa * rBCa);
 
-                F_Ca           -= Fi;
-                F_B            += Fi;
-                sys.force(CaC) += Fk;
-                sys.force(CaN) -= Fk;
+                F_Ca  -= Fi;
+                F_B   += Fi;
+                F_CaC += Fk;
+                F_CaN -= Fk;
             }
 
             // ----------------------------------------------------------------
             // collect force on Ca and B
 
-            sys.force(Ca) += F_Ca;
-            sys.force(B ) += F_B ;
+            sys.force(Ca)  += F_Ca;
+            sys.force(B )  += F_B ;
+            sys.force(S)   += F_S;
+            sys.force(B5)  += F_B5;
+            sys.force(B3)  += F_B3;
+            sys.force(CaN) += F_CaN;
+            sys.force(CaC) += F_CaC;
+
+            sys.virial() += math::tensor_product(              rCa,        F_Ca)
+                         +  math::tensor_product(sys.transpose(rB,   rCa), F_B)
+                         +  math::tensor_product(sys.transpose(rS,   rCa), F_S)
+                         +  math::tensor_product(sys.transpose(rB5,  rCa), F_B5)
+                         +  math::tensor_product(sys.transpose(rB3,  rCa), F_B3)
+                         +  math::tensor_product(sys.transpose(rCaN, rCa), F_CaN)
+                         +  math::tensor_product(sys.transpose(rCaC, rCa), F_CaC);
         }
     }
     return energy;

--- a/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairExcludedVolumeInteraction.hpp
@@ -109,6 +109,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -194,6 +197,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/global/GlobalPairInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairInteraction.hpp
@@ -124,7 +124,7 @@ void GlobalPairInteraction<traitsT, potT>::calc_force(
             const auto  j     = ptnr.index;
             const auto& param = ptnr.parameter();
 
-            const auto rij =
+            const auto rij = // ri -> rj = rj - ri
                 sys.adjust_direction(sys.position(i), sys.position(j));
             const real_type l2 = math::length_sq(rij); // |rij|^2
             const real_type rl = math::rsqrt(l2);      // 1 / |rij|
@@ -137,6 +137,9 @@ void GlobalPairInteraction<traitsT, potT>::calc_force(
             const coordinate_type f = rij * (f_mag * rl);
             sys.force(i) += f;
             sys.force(j) -= f;
+
+            // (rj - ri) * Fj = (ri - rj) * Fi
+            sys.virial() += math::tensor_product(rij, -f);
         }
     }
     return ;
@@ -195,6 +198,9 @@ GlobalPairInteraction<traitsT, potT>::calc_force_and_energy(
             const coordinate_type f = rij * (f_mag * rl);
             sys.force(i) += f;
             sys.force(j) -= f;
+
+            // (rj - ri) * Fj = (ri - rj) * Fi
+            sys.virial() += math::tensor_product(rij, -f);
         }
     }
     return energy;

--- a/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairLennardJonesInteraction.hpp
@@ -106,6 +106,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -184,6 +187,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/global/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/forcefield/global/GlobalPairUniformLennardJonesInteraction.hpp
@@ -106,6 +106,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -184,6 +187,9 @@ class GlobalPairInteraction<
 
                 sys.force(i) += f;
                 sys.force(j) -= f;
+
+                // rij * Fj = (rj - ri) * Fj = (ri - rj) * Fi
+                sys.virial() += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/forcefield/local/BondAngleInteraction.hpp
+++ b/mjolnir/forcefield/local/BondAngleInteraction.hpp
@@ -90,10 +90,15 @@ class BondAngleInteraction final : public LocalInteractionBase<traitsT>
                             (cos_theta * r_ij_reg - r_kj_reg);
             const auto Fk = (coef_inv_sin * inv_len_r_kj) *
                             (cos_theta * r_kj_reg - r_ij_reg);
+            const auto Fj = -Fi - Fk;
 
             sys.force(idxs[0]) += Fi;
-            sys.force(idxs[1]) -= (Fi + Fk);
+            sys.force(idxs[1]) += Fj;
             sys.force(idxs[2]) += Fk;
+
+            sys.virial() += math::tensor_product(p1 + r_ij, Fi) +
+                            math::tensor_product(p1,        Fj) +
+                            math::tensor_product(p1 + r_kj, Fk);
         }
         return energy;
     }
@@ -164,11 +169,11 @@ void BondAngleInteraction<traitsT, potentialT>::calc_force(
         const auto& p1 = sys.position(idxp.first[1]);
         const auto& p2 = sys.position(idxp.first[2]);
 
-        const auto r_ij         = sys.adjust_direction(p1, p0);
+        const auto r_ij         = sys.adjust_direction(p1, p0); // p1 -> p0
         const auto inv_len_r_ij = math::rlength(r_ij);
         const auto r_ij_reg     = r_ij * inv_len_r_ij;
 
-        const auto r_kj         = sys.adjust_direction(p1, p2);
+        const auto r_kj         = sys.adjust_direction(p1, p2); // p1 -> p2
         const auto inv_len_r_kj = math::rlength(r_kj);
         const auto r_kj_reg     = r_kj * inv_len_r_kj;
 
@@ -187,10 +192,15 @@ void BondAngleInteraction<traitsT, potentialT>::calc_force(
                         (cos_theta * r_ij_reg - r_kj_reg);
         const auto Fk = (coef_inv_sin * inv_len_r_kj) *
                         (cos_theta * r_kj_reg - r_ij_reg);
+        const auto Fj = -Fi - Fk;
 
         sys.force(idxs[0]) += Fi;
-        sys.force(idxs[1]) -= (Fi + Fk);
+        sys.force(idxs[1]) += Fj;
         sys.force(idxs[2]) += Fk;
+
+        sys.virial() += math::tensor_product(p1 + r_ij, Fi) +
+                        math::tensor_product(p1,        Fj) +
+                        math::tensor_product(p1 + r_kj, Fk);
     }
     return;
 }

--- a/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/forcefield/local/BondLengthGoContactInteraction.hpp
@@ -70,6 +70,8 @@ class BondLengthInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -113,6 +115,8 @@ class BondLengthInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }

--- a/mjolnir/forcefield/local/BondLengthInteraction.hpp
+++ b/mjolnir/forcefield/local/BondLengthInteraction.hpp
@@ -115,7 +115,7 @@ void BondLengthInteraction<traitsT, potentialT>::calc_force(
         const std::size_t idx0 = idxp.first[0];
         const std::size_t idx1 = idxp.first[1];
 
-        const auto dpos =
+        const auto dpos = // from r0 -> r1 = r1 - r0
             sys.adjust_direction(sys.position(idx0), sys.position(idx1));
 
         const real_type len2 = math::length_sq(dpos); // l^2
@@ -126,6 +126,8 @@ void BondLengthInteraction<traitsT, potentialT>::calc_force(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return;
 }
@@ -167,6 +169,8 @@ BondLengthInteraction<traitsT, potentialT>::calc_force_and_energy(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return energy;
 }

--- a/mjolnir/forcefield/local/ContactInteraction.hpp
+++ b/mjolnir/forcefield/local/ContactInteraction.hpp
@@ -71,7 +71,7 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
             const std::size_t idx0 = idxp.first[0];
             const std::size_t idx1 = idxp.first[1];
 
-            const auto dpos =
+            const auto dpos = // r0 -> r1 = r1 - r0
                 sys.adjust_direction(sys.position(idx0), sys.position(idx1));
 
             const real_type len2 = math::length_sq(dpos); // l^2
@@ -83,6 +83,8 @@ class ContactInteraction final : public LocalInteractionBase<traitsT>
             const coordinate_type f = dpos * (force * rlen);
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }
@@ -223,6 +225,8 @@ void ContactInteraction<traitsT, potentialT>::calc_force(
         const coordinate_type f = dpos * (force * rlen);
         sys.force(idx0) -= f;
         sys.force(idx1) += f;
+
+        sys.virial() += math::tensor_product(dpos, f);
     }
     return;
 }

--- a/mjolnir/forcefield/local/DihedralAngleInteraction.hpp
+++ b/mjolnir/forcefield/local/DihedralAngleInteraction.hpp
@@ -147,10 +147,18 @@ DihedralAngleInteraction<traitsT, pT>::calc_force(system_type& sys) const noexce
         const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
         const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+        const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+        const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
         sys.force(idx0) += Fi;
-        sys.force(idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-        sys.force(idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+        sys.force(idx1) += Fj;
+        sys.force(idx2) += Fk;
         sys.force(idx3) += Fl;
+
+        sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                        math::tensor_product(r_j,               Fj) +
+                        math::tensor_product(r_j + r_kj,        Fk) +
+                        math::tensor_product(r_j + r_kj + r_lk, Fl);
     }
     return;
 }
@@ -204,9 +212,9 @@ DihedralAngleInteraction<traitsT, pT>::calc_force_and_energy(system_type& sys) c
         const auto& r_k = sys.position(idx2);
         const auto& r_l = sys.position(idx3);
 
-        const coordinate_type r_ij = sys.adjust_direction(r_j, r_i);
-        const coordinate_type r_kj = sys.adjust_direction(r_j, r_k);
-        const coordinate_type r_lk = sys.adjust_direction(r_k, r_l);
+        const coordinate_type r_ij = sys.adjust_direction(r_j, r_i); // j->i
+        const coordinate_type r_kj = sys.adjust_direction(r_j, r_k); // j->k
+        const coordinate_type r_lk = sys.adjust_direction(r_k, r_l); // k->l
         const coordinate_type r_kl = real_type(-1.0) * r_lk;
 
         const real_type r_kj_lensq  = math::length_sq(r_kj);
@@ -235,10 +243,18 @@ DihedralAngleInteraction<traitsT, pT>::calc_force_and_energy(system_type& sys) c
         const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
         const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+        const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+        const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
         sys.force(idx0) += Fi;
-        sys.force(idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-        sys.force(idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+        sys.force(idx1) += Fj;
+        sys.force(idx2) += Fk;
         sys.force(idx3) += Fl;
+
+        sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                        math::tensor_product(r_j,               Fj) +
+                        math::tensor_product(r_j + r_kj,        Fk) +
+                        math::tensor_product(r_j + r_kj + r_lk, Fl);
     }
     return energy;
 }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -325,10 +325,10 @@ void DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       -dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              -dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        -dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, -dU_dir_drCj);// Cj
     }
     return;
 }
@@ -535,10 +535,10 @@ DirectionalContactInteraction<
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
 
-        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
-                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
-                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
-                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
+        sys.virial() += math::tensor_product(rPi + PiCi,       -dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              -dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        -dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, -dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
+++ b/mjolnir/forcefield/local/DirectionalContactInteraction.hpp
@@ -324,6 +324,11 @@ void DirectionalContactInteraction<
         sys.force(Pi) -= dU_dir_drPi;
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
+
+        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
     }
     return;
 }
@@ -529,6 +534,11 @@ DirectionalContactInteraction<
         sys.force(Pi) -= dU_dir_drPi;
         sys.force(Pj) -= dU_dir_drPj;
         sys.force(Cj) -= dU_dir_drCj;
+
+        sys.virial() += math::tensor_product(rPi + PiCi,       dU_dir_drCi) // Ci
+                     +  math::tensor_product(rPi,              dU_dir_drPi) // Pi
+                     +  math::tensor_product(rPi + Pij,        dU_dir_drPj) // Pj
+                     +  math::tensor_product(rPi + Pij + PjCj, dU_dir_drCj);// Cj
 
         energy += U_angle1 * U_angle2 * U_con;
     }

--- a/mjolnir/forcefield/local/GoContactInteraction.hpp
+++ b/mjolnir/forcefield/local/GoContactInteraction.hpp
@@ -74,6 +74,8 @@ class ContactInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -122,6 +124,8 @@ class ContactInteraction<
             const auto f    = coef * dpos;
             sys.force(idx0) -= f;
             sys.force(idx1) += f;
+
+            sys.virial() += math::tensor_product(dpos, f);
         }
         return energy;
     }

--- a/mjolnir/input/read_integrator.cpp
+++ b/mjolnir/input/read_integrator.cpp
@@ -31,4 +31,9 @@ template GJFNVTLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>    
 template GJFNVTLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_GJFNVT_langevin_integrator(const toml::value& simulator);
 template GJFNVTLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_GJFNVT_langevin_integrator(const toml::value& simulator);
 
+template GFWNpTLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>       > read_GFW_NpT_langevin_integrator(const toml::value& simulator);
+template GFWNpTLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>       > read_GFW_NpT_langevin_integrator(const toml::value& simulator);
+template GFWNpTLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>> read_GFW_NpT_langevin_integrator(const toml::value& simulator);
+template GFWNpTLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>> read_GFW_NpT_langevin_integrator(const toml::value& simulator);
+
 } // mjolnir

--- a/mjolnir/input/read_simulator.hpp
+++ b/mjolnir/input/read_simulator.hpp
@@ -523,6 +523,12 @@ read_integrator_type(const toml::value& root, const toml::value& simulator)
         using integratorT = GJFNVTLangevinIntegrator<traitsT>;
         return read_simulator<traitsT, integratorT>(root, simulator);
     }
+    else if(integ == "GFWNpTLangevin")
+    {
+        MJOLNIR_LOG_NOTICE("Integrator is GFWNpTLangevin.");
+        using integratorT = GFWNpTLangevinIntegrator<traitsT>;
+        return read_simulator<traitsT, integratorT>(root, simulator);
+    }
     else
     {
         throw_exception<std::runtime_error>(toml::format_error("[error] "

--- a/mjolnir/math/Vector.hpp
+++ b/mjolnir/math/Vector.hpp
@@ -73,6 +73,15 @@ cross_product(const Vector<realT, 3>& lhs, const Vector<realT, 3>& rhs) noexcept
 }
 
 template<typename realT>
+inline Vector<realT, 3>
+hadamard_product(const Vector<realT, 3>& lhs, const Vector<realT, 3>& rhs) noexcept
+{
+    return Vector<realT, 3>(X(lhs) * X(rhs),
+                            Y(lhs) * Y(rhs),
+                            Z(lhs) * Z(rhs));
+}
+
+template<typename realT>
 inline realT length_sq(const Vector<realT, 3>& lhs) noexcept
 {
     return X(lhs) * X(lhs) + Y(lhs) * Y(lhs) + Z(lhs) * Z(lhs);

--- a/mjolnir/omp/BondLengthGoContactInteraction.hpp
+++ b/mjolnir/omp/BondLengthGoContactInteraction.hpp
@@ -75,6 +75,8 @@ class BondLengthInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -125,6 +127,8 @@ class BondLengthInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/BondLengthInteraction.hpp
+++ b/mjolnir/omp/BondLengthInteraction.hpp
@@ -60,8 +60,11 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // here, L^2 * (1 / L) = L.
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -100,8 +103,11 @@ class BondLengthInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             E += idxp.second.potential(len);
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/CMakeLists.txt
+++ b/mjolnir/omp/CMakeLists.txt
@@ -2,6 +2,7 @@ set(mjolnir_omp_cpp_files
     "${CMAKE_CURRENT_SOURCE_DIR}/System.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/RandomNumberGenerator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/SystemMotionRemover.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/GFWNpTLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/BAOABLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/gBAOABLangevinIntegrator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/GJFNVTLangevinIntegrator.cpp"

--- a/mjolnir/omp/ContactInteraction.hpp
+++ b/mjolnir/omp/ContactInteraction.hpp
@@ -68,8 +68,12 @@ class ContactInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             // here, L^2 * (1 / L) = L.
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) = math::tensor_product(dpos, f);
         }
         return;
     }
@@ -108,8 +112,12 @@ class ContactInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentialT>
             E += idxp.second.potential(len);
 
             const coordinate_type f = dpos * (force * rlen);
-            sys.force_thread(omp_get_thread_num(), idx0) -= f;
-            sys.force_thread(omp_get_thread_num(), idx1) += f;
+
+            const std::size_t thread_id = omp_get_thread_num();
+            sys.force_thread(thread_id, idx0) -= f;
+            sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) = math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/DihedralAngleInteraction.hpp
+++ b/mjolnir/omp/DihedralAngleInteraction.hpp
@@ -89,12 +89,19 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
             const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
-            const auto thread_id = omp_get_thread_num();
+            const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+            const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
 
+            const auto thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) += Fi;
-            sys.force_thread(thread_id, idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-            sys.force_thread(thread_id, idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+            sys.force_thread(thread_id, idx1) += Fj;
+            sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
+
+            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                            math::tensor_product(r_j,               Fj) +
+                            math::tensor_product(r_j + r_kj,        Fk) +
+                            math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return;
     }
@@ -181,12 +188,20 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             const real_type coef_ijk = math::dot_product(r_ij, r_kj) * r_kj_rlensq;
             const real_type coef_jkl = math::dot_product(r_kl, r_kj) * r_kj_rlensq;
 
+            const auto Fj = (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
+            const auto Fk = (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+
             const auto thread_id = omp_get_thread_num();
 
             sys.force_thread(thread_id, idx0) += Fi;
-            sys.force_thread(thread_id, idx1) += (coef_ijk - real_type(1.0)) * Fi - coef_jkl * Fl;
-            sys.force_thread(thread_id, idx2) += (coef_jkl - real_type(1.0)) * Fl - coef_ijk * Fi;
+            sys.force_thread(thread_id, idx1) += Fj;
+            sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
+
+            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
+                            math::tensor_product(r_j,               Fj) +
+                            math::tensor_product(r_j + r_kj,        Fk) +
+                            math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return E;
     }

--- a/mjolnir/omp/DihedralAngleInteraction.hpp
+++ b/mjolnir/omp/DihedralAngleInteraction.hpp
@@ -98,10 +98,11 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
 
-            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
-                            math::tensor_product(r_j,               Fj) +
-                            math::tensor_product(r_j + r_kj,        Fk) +
-                            math::tensor_product(r_j + r_kj + r_lk, Fl);
+            sys.virial_thread(thread_id) +=
+                math::tensor_product(r_j + r_ij,        Fi) +
+                math::tensor_product(r_j,               Fj) +
+                math::tensor_product(r_j + r_kj,        Fk) +
+                math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return;
     }
@@ -198,10 +199,11 @@ class DihedralAngleInteraction<OpenMPSimulatorTraits<realT, boundaryT>, potentia
             sys.force_thread(thread_id, idx2) += Fk;
             sys.force_thread(thread_id, idx3) += Fl;
 
-            sys.virial() += math::tensor_product(r_j + r_ij,        Fi) +
-                            math::tensor_product(r_j,               Fj) +
-                            math::tensor_product(r_j + r_kj,        Fk) +
-                            math::tensor_product(r_j + r_kj + r_lk, Fl);
+            sys.virial_thread(thread_id) +=
+                math::tensor_product(r_j + r_ij,        Fi) +
+                math::tensor_product(r_j,               Fj) +
+                math::tensor_product(r_j + r_kj,        Fk) +
+                math::tensor_product(r_j + r_kj + r_lk, Fl);
         }
         return E;
     }

--- a/mjolnir/omp/GFWNpTLangevinIntegrator.cpp
+++ b/mjolnir/omp/GFWNpTLangevinIntegrator.cpp
@@ -1,0 +1,13 @@
+#include <mjolnir/omp/GFWNpTLangevinIntegrator.hpp>
+
+#ifndef MJOLNIR_SEPARATE_BUILD
+#error "MJOLNIR_SEPARATE_BUILD flag is required"
+#endif
+
+namespace mjolnir
+{
+template class GFWNpTLangevinIntegrator<OpenMPSimulatorTraits<double, UnlimitedBoundary>>;
+template class GFWNpTLangevinIntegrator<OpenMPSimulatorTraits<float,  UnlimitedBoundary>>;
+template class GFWNpTLangevinIntegrator<OpenMPSimulatorTraits<double, CuboidalPeriodicBoundary>>;
+template class GFWNpTLangevinIntegrator<OpenMPSimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+} // mjolnir

--- a/mjolnir/omp/GFWNpTLangevinIntegrator.hpp
+++ b/mjolnir/omp/GFWNpTLangevinIntegrator.hpp
@@ -1,0 +1,441 @@
+#ifndef MJOLNIR_OMP_GFW_NPT_LANGEVIN_INTEGRATOR_HPP
+#define MJOLNIR_OMP_GFW_NPT_LANGEVIN_INTEGRATOR_HPP
+#include <mjolnir/omp/OpenMPSimulatorTraits.hpp>
+#include <mjolnir/omp/System.hpp>
+#include <mjolnir/omp/RandomNumberGenerator.hpp>
+#include <mjolnir/omp/SystemMotionRemover.hpp>
+#include <mjolnir/core/GFWNpTLangevinIntegrator.hpp>
+
+namespace mjolnir
+{
+
+// isothermal-isobaric Langevin integrator developed by the following paper
+// - Xingyu Gao, Jun Fang, and Han Wang, J. Cmem. Phys. 144, 124113 (2016)
+//
+// It requires Periodic Boundary Condition. If the UnlimitedBoundary is applied,
+// it always throws. PBC implementations are below.
+//
+// The original algorithm allows cell deformation, but here it inhibits shell
+// deformation. The PBC cell will be kept always cuboidal. This condition
+// corredponds to the case where we choose Mab -> inf (a != b). Under that
+// condition, the off-diagonal terms dissappear.
+template<typename realT, template<typename, typename> class boundaryT>
+class GFWNpTLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
+{
+  public:
+    using traits_type     = OpenMPSimulatorTraits<realT, boundaryT>;
+    using boundary_type   = typename traits_type::boundary_type;
+    using real_type       = typename traits_type::real_type;
+    using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
+    using system_type     = System<traits_type>;
+    using forcefield_type = std::unique_ptr<ForceFieldBase<traits_type>>;
+    using rng_type        = RandomNumberGenerator<traits_type>;
+
+  public:
+
+    GFWNpTLangevinIntegrator(const real_type dt, const real_type chi,
+            const coordinate_type& m_cell,     const coordinate_type& gamma_cell,
+            const coordinate_type& v_cell_ini, const std::vector<real_type>& gammas)
+        : dt_(dt), halfdt_(dt / 2), temperature_(/* dummy = */ -1), chi_(chi),
+          P_ins_(math::make_coordinate<coordinate_type>(0, 0, 0)),
+          P_ref_(math::make_coordinate<coordinate_type>(0, 0, 0)),
+          m_cell_(m_cell), v_cell_(v_cell_ini), gamma_cell_(gamma_cell),
+          gammas_(gammas), exp_gamma_dt_(gammas.size()), noise_coeff_(gammas.size())
+    {
+        if(!is_cuboidal_periodic_boundary<boundary_type>::value)
+        {
+            throw_exception<std::runtime_error>("GFWNpTLangevinIntegrator: "
+                    "periodic boundary condition is required");
+        }
+    }
+    ~GFWNpTLangevinIntegrator() = default;
+
+    void initialize(system_type& sys, forcefield_type& ff, rng_type&)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        if(!ff->constraint().empty())
+        {
+            MJOLNIR_LOG_WARN("BAOAB langevin integrator does not support constraint"
+                " forcefield. [[forcefields.constraint]] will be ignored.");
+        }
+
+        // calculate parameters for each particles
+        this->update(sys);
+
+        // calculate force
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
+        }
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        ff->calc_force(sys);
+
+        // calculate the current pressure using the force calculated here
+        const auto h_cell = sys.boundary().width();
+        this->P_ins_ = this->calc_pressure(sys, h_cell);
+
+        sys.attribute("volume") = X(h_cell) * Y(h_cell) * Z(h_cell);
+
+        return;
+    }
+
+    void update(const system_type& sys)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        // update reference temperature and reference pressure
+        this->temperature_    = check_attribute_exists(sys, "temperature");
+        math::X(this->P_ref_) = check_attribute_exists(sys, "pressure_x");
+        math::Y(this->P_ref_) = check_attribute_exists(sys, "pressure_y");
+        math::Z(this->P_ref_) = check_attribute_exists(sys, "pressure_z");
+
+        MJOLNIR_LOG_NOTICE("system temperature is ", this->temperature_);
+        MJOLNIR_LOG_NOTICE("system pressure is ", this->P_ref_);
+
+        this->reset_parameters(sys);
+        return ;
+    }
+
+    real_type step(const real_type t, system_type& sys,
+                   forcefield_type& ff, rng_type& rng)
+    {
+        using math::hadamard_product;
+        using math::make_coordinate;
+        using math::X; using math::Y; using math::Z;
+
+        // --------------------------------------------------------------------
+        // preparation
+
+        const auto cell_origin = sys.boundary().lower_bound();
+
+        auto h_cell = sys.boundary().upper_bound() - cell_origin;
+        auto det_h  = X(h_cell) * Y(h_cell) * Z(h_cell);
+        auto inv_h  = make_coordinate<coordinate_type>(
+                        1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+        auto P_diff = P_ins_ - P_ref_;
+
+        // --------------------------------------------------------------------
+        // update cell velocity
+
+        v_cell_ += hadamard_product(halfdt_ * rm_cell_,
+                   hadamard_product(det_h * inv_h, P_diff) - chi_kBT_ * inv_h);
+
+        // --------------------------------------------------------------------
+        // update particle velocities
+
+        {
+            const auto v_over_h = hadamard_product(-v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+#pragma omp parallel for
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                sys.velocity(i) = this->S(sys.velocity(i),
+                                          sys.force(i) * sys.rmass(i),
+                                          v_over_h, coef_S);
+                sys.force(i) = math::make_coordinate<coordinate_type>(0, 0, 0);
+            }
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        }
+
+        // --------------------------------------------------------------------
+        // update cell size, volume and inverse cell matrix
+
+        h_cell  += halfdt_ * v_cell_;
+        det_h    = X(h_cell) * Y(h_cell) * Z(h_cell);
+        inv_h    = make_coordinate<coordinate_type>(
+                    1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+
+        sys.boundary().set_boundary(cell_origin, cell_origin + h_cell);
+
+        // --------------------------------------------------------------------
+        // update particle positions
+
+        real_type max_displacement_sq_1 = 0;
+        {
+            const auto v_over_h = hadamard_product(v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+#pragma omp parallel for reduction(max:max_displacement_sq_1)
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto new_pos = this->S(sys.position(i), sys.velocity(i),
+                                             v_over_h, coef_S);
+
+                max_displacement_sq_1 = std::max(max_displacement_sq_1,
+                        math::length_sq(sys.position(i) - new_pos));
+
+                sys.position(i) = sys.boundary().adjust_position(new_pos);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // update cell velocity (ornstein-Uhlenbeck)
+
+        const auto R_cell = this->gen_R(rng);
+
+        X(v_cell_) *= X(exp_gamma_dt_cell_);
+        Y(v_cell_) *= Y(exp_gamma_dt_cell_);
+        Z(v_cell_) *= Z(exp_gamma_dt_cell_);
+
+        X(v_cell_) += X(noise_coeff_cell_) * X(R_cell);
+        Y(v_cell_) += Y(noise_coeff_cell_) * Y(R_cell);
+        Z(v_cell_) += Z(noise_coeff_cell_) * Z(R_cell);
+
+        // --------------------------------------------------------------------
+        // update particle velocities (Ornstein-Uhlenbeck)
+
+#pragma omp parallel for
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto R     = this->gen_R(rng);
+            sys.velocity(i) *= this->exp_gamma_dt_[i];
+            sys.velocity(i) += this->noise_coeff_[i] * R;
+        }
+
+        // --------------------------------------------------------------------
+        // update particle positions
+
+
+        real_type max_displacement_sq_2 = 0;
+        {
+            const auto v_over_h = hadamard_product(v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+#pragma omp parallel for reduction(max:max_displacement_sq_2)
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                const auto new_pos = this->S(sys.position(i), sys.velocity(i),
+                                             v_over_h, coef_S);
+
+                max_displacement_sq_2 = std::max(max_displacement_sq_2,
+                        math::length_sq(sys.position(i) - new_pos));
+
+                sys.position(i) = sys.boundary().adjust_position(new_pos);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // update cell size
+
+        h_cell += halfdt_ * v_cell_;
+        det_h   = X(h_cell) * Y(h_cell) * Z(h_cell);
+        inv_h   = make_coordinate<coordinate_type>(
+                    1 / X(h_cell), 1 / Y(h_cell), 1 / Z(h_cell));
+
+        sys.boundary().set_boundary(cell_origin, cell_origin + h_cell);
+
+        // --------------------------------------------------------------------
+        // calc force
+
+        // update neighbor list; reduce margin, reconstruct the list if needed
+        const auto max_displacement = std::sqrt(max_displacement_sq_1) +
+                                      std::sqrt(max_displacement_sq_2);
+        ff->reduce_margin(2 * max_displacement, sys);
+
+        ff->calc_force(sys);
+
+        // --------------------------------------------------------------------
+        // update particle velocities
+
+        {
+            const auto v_over_h = hadamard_product(-v_cell_, inv_h);
+            const auto coef_S = make_coordinate<coordinate_type>(
+                    std::exp(halfdt_ * X(v_over_h)),
+                    std::exp(halfdt_ * Y(v_over_h)),
+                    std::exp(halfdt_ * Z(v_over_h)));
+
+#pragma omp parallel for
+            for(std::size_t i=0; i<sys.size(); ++i)
+            {
+                sys.velocity(i) = this->S(sys.velocity(i),
+                                          sys.force(i) * sys.rmass(i),
+                                          v_over_h, coef_S);
+            }
+        }
+
+        // --------------------------------------------------------------------
+        // calc current pressure
+        // using just updated velocities and virial from `calc_force`
+
+        this->P_ins_ = this->calc_pressure(sys, h_cell);
+        sys.attribute("volume") = det_h;
+
+        P_diff = P_ins_ - P_ref_;
+
+        // --------------------------------------------------------------------
+        // update cell velocities
+
+        v_cell_ += hadamard_product(halfdt_ * rm_cell_,
+                   hadamard_product(det_h * inv_h, P_diff) - chi_kBT_ * inv_h);
+
+        return t + dt_;
+    }
+
+    real_type                     delta_t()    const noexcept {return dt_;}
+    std::vector<real_type> const& parameters() const noexcept {return gammas_;}
+
+  private:
+
+    real_type check_attribute_exists(const system_type& sys, const std::string& attr)
+    {
+        if(!sys.has_attribute(attr))
+        {
+            throw_exception<std::out_of_range>("mjolnir::GFWNpTLangevinIntegrator: "
+                "It requires attribute `", attr, "`, but `", attr,
+                "` is not found in `system.attribute`.");
+        }
+        return sys.attribute(attr);
+    }
+
+    // reset all the cached parameters.
+    void reset_parameters(const system_type& sys) noexcept
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+        using math::X; using math::Y; using math::Z;
+
+        const auto kBT = physics::constants<real_type>::kB() * this->temperature_;
+
+        this->chi_kBT_ = this->chi_ * kBT;
+        MJOLNIR_LOG_INFO("chi = ", this->chi_, ", chi_kBT = ", chi_kBT_);
+
+        X(rm_cell_) = real_type(1) / X(m_cell_);
+        Y(rm_cell_) = real_type(1) / Y(m_cell_);
+        Z(rm_cell_) = real_type(1) / Z(m_cell_);
+
+        // exp(-gamma dt)
+        const real_type exp_gamma_dt_x = std::exp(-dt_ * X(gamma_cell_));
+        const real_type exp_gamma_dt_y = std::exp(-dt_ * Y(gamma_cell_));
+        const real_type exp_gamma_dt_z = std::exp(-dt_ * Z(gamma_cell_));
+
+        // exp(-2gamma dt)
+        const real_type exp_2gamma_dt_x = exp_gamma_dt_x * exp_gamma_dt_x;
+        const real_type exp_2gamma_dt_y = exp_gamma_dt_y * exp_gamma_dt_y;
+        const real_type exp_2gamma_dt_z = exp_gamma_dt_z * exp_gamma_dt_z;
+
+        X(exp_gamma_dt_cell_) = exp_gamma_dt_x;
+        Y(exp_gamma_dt_cell_) = exp_gamma_dt_y;
+        Z(exp_gamma_dt_cell_) = exp_gamma_dt_z;
+
+        // we use velocity in this class, so devide it by M_cell.
+        X(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_x) * kBT * X(rm_cell_));
+        Y(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_y) * kBT * Y(rm_cell_));
+        Z(noise_coeff_cell_) = std::sqrt((1 - exp_2gamma_dt_z) * kBT * Z(rm_cell_));
+
+        MJOLNIR_LOG_INFO("1 / M_cell = ", rm_cell_);
+        MJOLNIR_LOG_INFO("beta_cell  = ", noise_coeff_cell_);
+
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto gamma    = this->gammas_.at(i);
+            const auto gamma_dt = -1 * gamma * this->dt_;
+            this->exp_gamma_dt_.at(i) = std::exp(gamma_dt);
+            this->noise_coeff_ .at(i) = std::sqrt(
+                    kBT * (1 - std::exp(2 * gamma_dt)) * sys.rmass(i));
+        }
+        return;
+    }
+
+    // It calculates only diagonal terms. off-diagnoal terms are not considered.
+    coordinate_type calc_pressure(const system_type&    sys,
+                                  const coordinate_type h_cell) const noexcept
+    {
+        const auto det_h = math::X(h_cell) * math::Y(h_cell) * math::Z(h_cell);
+
+        // instantaneous pressure
+        const auto& vir = sys.virial();
+        auto Pins = math::make_coordinate<coordinate_type>(vir(0,0), vir(1,1), vir(2,2));
+        for(std::size_t i=0; i<sys.size(); ++i)
+        {
+            const auto m = sys.mass(i);
+            const auto r = sys.position(i);
+            const auto v = sys.velocity(i);
+            const auto f = sys.force(i);
+
+            // here the original form is a tensor product. but the diagonal term
+            // of the tensor product (cij = ai * bj) becomes hadamard product
+            // (cii = ai * bi).
+
+            Pins += m * math::hadamard_product(v, v);
+        }
+        return Pins / det_h;
+    }
+
+    // When the off-diagonal terms vanish, the Su and the Sl functions become
+    // the same with each other and are drastically simplified.
+    // Here it implements diagonal version of Su and Sl.
+    //
+    // Since S always uses t = dt/2, here it assumes that t = dt/2.
+    coordinate_type S(coordinate_type x0,      const coordinate_type b,
+                      const coordinate_type A, const coordinate_type coef_S)
+    {
+        using math::X; using math::Y; using math::Z;
+
+        X(x0) *= X(coef_S);
+        Y(x0) *= Y(coef_S);
+        Z(x0) *= Z(coef_S);
+
+        // use tailor expansion of F1(0, adt/2), as in the paper
+        const auto tA = halfdt_ * A;
+
+        X(x0) += halfdt_ * X(b) * (real_type(1) + X(tA) / real_type(2) + X(tA) * X(tA) / real_type(6));
+        Y(x0) += halfdt_ * Y(b) * (real_type(1) + Y(tA) / real_type(2) + Y(tA) * Y(tA) / real_type(6));
+        Z(x0) += halfdt_ * Z(b) * (real_type(1) + Z(tA) / real_type(2) + Z(tA) * Z(tA) / real_type(6));
+
+        return x0;
+    }
+
+    coordinate_type gen_R(rng_type& rng) noexcept
+    {
+        const auto x = rng.gaussian();
+        const auto y = rng.gaussian();
+        const auto z = rng.gaussian();
+        return math::make_coordinate<coordinate_type>(x, y, z);
+    }
+
+  private:
+
+    real_type dt_;
+    real_type halfdt_;
+    real_type temperature_;
+    real_type chi_;
+    real_type chi_kBT_;
+
+    // diagonal terms only
+    coordinate_type P_ins_;
+    coordinate_type P_ref_;
+    coordinate_type m_cell_;
+    coordinate_type rm_cell_;
+    coordinate_type v_cell_;
+    coordinate_type gamma_cell_;
+    coordinate_type exp_gamma_dt_cell_;
+    coordinate_type noise_coeff_cell_;
+
+    std::vector<real_type> gammas_;
+    std::vector<real_type> exp_gamma_dt_;
+    std::vector<real_type> noise_coeff_;
+};
+
+#ifdef MJOLNIR_SEPARATE_BUILD
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<double, UnlimitedBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  UnlimitedBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<double, CuboidalPeriodicBoundary>>;
+extern template class GFWNpTLangevinIntegrator<SimulatorTraits<float,  CuboidalPeriodicBoundary>>;
+#endif
+
+} // mjolnir
+#endif /* MJOLNIR_GFW_NPT_LANGEVIN_INTEGRATOR */

--- a/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
+++ b/mjolnir/omp/GlobalPairExcludedVolumeInteraction.hpp
@@ -107,6 +107,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -195,6 +197,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairInteraction.hpp
+++ b/mjolnir/omp/GlobalPairInteraction.hpp
@@ -94,6 +94,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -148,6 +150,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairLennardJonesInteraction.hpp
@@ -104,6 +104,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -183,6 +185,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
+++ b/mjolnir/omp/GlobalPairUniformLennardJonesInteraction.hpp
@@ -104,6 +104,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return ;
@@ -183,6 +185,8 @@ class GlobalPairInteraction<
                 const std::size_t thread_id = omp_get_thread_num();
                 sys.force_thread(thread_id, i) += f;
                 sys.force_thread(thread_id, j) -= f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(rij, -f);
             }
         }
         return energy;

--- a/mjolnir/omp/GoContactInteraction.hpp
+++ b/mjolnir/omp/GoContactInteraction.hpp
@@ -80,6 +80,8 @@ class ContactInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return;
     }
@@ -133,6 +135,8 @@ class ContactInteraction<
             const std::size_t thread_id = omp_get_thread_num();
             sys.force_thread(thread_id, idx0) -= f;
             sys.force_thread(thread_id, idx1) += f;
+
+            sys.virial_thread(thread_id) += math::tensor_product(dpos, f);
         }
         return E;
     }

--- a/mjolnir/omp/PWMcosInteraction.hpp
+++ b/mjolnir/omp/PWMcosInteraction.hpp
@@ -207,6 +207,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
                 auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
 
+                auto vir  = math::tensor_product(F_Ca, F_B); // zero matrix;
+
                 // ----------------------------------------------------------------
                 // calculate direction term
                 // = e(b) df/dr dr/dq g(theta1) g(theta2) g(theta3)
@@ -240,6 +242,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_Ca         -= Fi;
                     F_B          += (Fi + Fk);
                     sys.force_thread(thread_id, S) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rS, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -263,6 +267,9 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B           += Fi;
                     sys.force_thread(thread_id, B5) += Fk;
                     sys.force_thread(thread_id, B3) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rB5, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rB3, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -286,6 +293,9 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B            += Fi;
                     sys.force_thread(thread_id, CaC) += Fk;
                     sys.force_thread(thread_id, CaN) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rCaC, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rCaN, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -293,6 +303,10 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 sys.force_thread(thread_id, Ca) += F_Ca;
                 sys.force_thread(thread_id, B ) += F_B ;
+
+                vir += math::tensor_product(rCa, F_Ca);
+                vir += math::tensor_product(rB , F_B);
+                sys.virial_thread(thread_id) += vir;
             }
         }
         return ;
@@ -526,6 +540,7 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 auto F_Ca = math::make_coordinate<coordinate_type>(0, 0, 0);
                 auto F_B  = math::make_coordinate<coordinate_type>(0, 0, 0);
+                auto vir  = math::tensor_product(F_Ca, F_B); // zero matrix;
 
                 // ----------------------------------------------------------------
                 // calculate direction term
@@ -560,6 +575,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_Ca         -= Fi;
                     F_B          += (Fi + Fk);
                     sys.force_thread(thread_id, S) -= Fk;
+
+                    vir += math::tensor_product(sys.transpose(rS, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -583,6 +600,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B           += Fi;
                     sys.force_thread(thread_id, B5) += Fk;
                     sys.force_thread(thread_id, B3) -= Fk;
+                    vir += math::tensor_product(sys.transpose(rB5, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rB3, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -606,6 +625,8 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     F_B            += Fi;
                     sys.force_thread(thread_id, CaC) += Fk;
                     sys.force_thread(thread_id, CaN) -= Fk;
+                    vir += math::tensor_product(sys.transpose(rCaC, rCa),  Fk);
+                    vir += math::tensor_product(sys.transpose(rCaN, rCa), -Fk);
                 }
 
                 // ----------------------------------------------------------------
@@ -613,6 +634,10 @@ class PWMcosInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
 
                 sys.force_thread(thread_id, Ca) += F_Ca;
                 sys.force_thread(thread_id, B ) += F_B ;
+
+                vir += math::tensor_product(rCa, F_Ca);
+                vir += math::tensor_product(rB , F_B);
+                sys.virial_thread(thread_id) += vir;
             }
         }
         return energy;

--- a/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
+++ b/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
@@ -234,11 +234,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 sys.force_thread(thread_id, para.PN) += f_PN;
                 sys.force_thread(thread_id, para.PC) += f_PC;
 
-                sys.virial() += math::tensor_product(rP,       f_P)
-                             +  math::tensor_product(rP + rPD, f_D)
-                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
-                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
-                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
+                sys.virial_thread(thread_id) +=
+                    math::tensor_product(rP,       f_P) +
+                    math::tensor_product(rP + rPD, f_D) +
+                    math::tensor_product(sys.transpose(rS3, rP), f_S3) +
+                    math::tensor_product(sys.transpose(rPN, rP), f_PN) +
+                    math::tensor_product(sys.transpose(rPC, rP), f_PC) ;
             }
         }
         return;
@@ -488,11 +489,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 sys.force_thread(thread_id, para.PN) += f_PN;
                 sys.force_thread(thread_id, para.PC) += f_PC;
 
-                sys.virial() += math::tensor_product(rP,       f_P)
-                             +  math::tensor_product(rP + rPD, f_D)
-                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
-                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
-                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
+                sys.virial_thread(thread_id) +=
+                    math::tensor_product(rP,       f_P) +
+                    math::tensor_product(rP + rPD, f_D) +
+                    math::tensor_product(sys.transpose(rS3, rP), f_S3) +
+                    math::tensor_product(sys.transpose(rPN, rP), f_PN) +
+                    math::tensor_product(sys.transpose(rPC, rP), f_PC) ;
             }
         }
         return energy;

--- a/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
+++ b/mjolnir/omp/ProteinDNANonSpecificInteraction.hpp
@@ -165,6 +165,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 const auto k = para.k;
                 const auto thread_id = omp_get_thread_num();
 
+                auto f_P  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_D  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_S3 = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PN = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PC = math::make_coordinate<coordinate_type>(0,0,0);
+
                 // df(r) g(theta) g(phi)
                 if(g_dg_theta.first  != 0 && g_dg_phi.first  != 0)
                 {
@@ -174,8 +180,8 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                         f_df.second * g_dg_theta.first * g_dg_phi.first;
                     const auto F = -coef * rPD;
 
-                    sys.force_thread(thread_id, P) -= F;
-                    sys.force_thread(thread_id, D) += F;
+                    f_P -= F;
+                    f_D += F;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -195,10 +201,10 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P  = -coef_sin * rlPD  * (rPNC_reg - cosPNC * rPD_reg );
                     const auto F_PN = -coef_sin * rlPNC * (rPD_reg  - cosPNC * rPNC_reg);
 
-                    sys.force_thread(thread_id, D)       -= F_P;
-                    sys.force_thread(thread_id, P)       += F_P;
-                    sys.force_thread(thread_id, para.PN) += F_PN;
-                    sys.force_thread(thread_id, para.PC) -= F_PN;
+                    f_D  -= F_P;
+                    f_P  += F_P;
+                    f_PN += F_PN;
+                    f_PC -= F_PN;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -218,10 +224,21 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P = -coef_sin * rlPD  * (rS3D_reg - cosS3D * rPD_reg);
                     const auto F_S = -coef_sin * rlS3D * (rPD_reg  - cosS3D * rS3D_reg);
 
-                    sys.force_thread(thread_id, P)  += F_P;
-                    sys.force_thread(thread_id, D)  -= F_P + F_S;
-                    sys.force_thread(thread_id, S3) += F_S;
+                    f_P  += F_P;
+                    f_D  -= F_P + F_S;
+                    f_S3 += F_S;
                 }
+                sys.force_thread(thread_id, P)       += f_P;
+                sys.force_thread(thread_id, D)       += f_D;
+                sys.force_thread(thread_id, S3)      += f_S3;
+                sys.force_thread(thread_id, para.PN) += f_PN;
+                sys.force_thread(thread_id, para.PC) += f_PC;
+
+                sys.virial() += math::tensor_product(rP,       f_P)
+                             +  math::tensor_product(rP + rPD, f_D)
+                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
+                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
+                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
             }
         }
         return;
@@ -400,6 +417,12 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                 const auto k = para.k;
                 const auto thread_id = omp_get_thread_num();
 
+                auto f_P  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_D  = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_S3 = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PN = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_PC = math::make_coordinate<coordinate_type>(0,0,0);
+
                 energy += k * f_df.first * g_dg_theta.first * g_dg_phi.first;
 
                 // df(r) g(theta) g(phi)
@@ -411,8 +434,8 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                         f_df.second * g_dg_theta.first * g_dg_phi.first;
                     const auto F = -coef * rPD;
 
-                    sys.force_thread(thread_id, P) -= F;
-                    sys.force_thread(thread_id, D) += F;
+                    f_P -= F;
+                    f_D += F;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -432,10 +455,10 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P  = -coef_sin * rlPD  * (rPNC_reg - cosPNC * rPD_reg );
                     const auto F_PN = -coef_sin * rlPNC * (rPD_reg  - cosPNC * rPNC_reg);
 
-                    sys.force_thread(thread_id, D)       -= F_P;
-                    sys.force_thread(thread_id, P)       += F_P;
-                    sys.force_thread(thread_id, para.PN) += F_PN;
-                    sys.force_thread(thread_id, para.PC) -= F_PN;
+                    f_D  -= F_P;
+                    f_P  += F_P;
+                    f_PN += F_PN;
+                    f_PC -= F_PN;
                 }
 
                 // f(r) dg(theta) g(phi)
@@ -455,10 +478,21 @@ class ProteinDNANonSpecificInteraction<OpenMPSimulatorTraits<realT, boundaryT>>
                     const auto F_P = -coef_sin * rlPD  * (rS3D_reg - cosS3D * rPD_reg);
                     const auto F_S = -coef_sin * rlS3D * (rPD_reg  - cosS3D * rS3D_reg);
 
-                    sys.force_thread(thread_id, P)  += F_P;
-                    sys.force_thread(thread_id, D)  -= F_P + F_S;
-                    sys.force_thread(thread_id, S3) += F_S;
+                    f_P  += F_P;
+                    f_D  -= F_P + F_S;
+                    f_S3 += F_S;
                 }
+                sys.force_thread(thread_id, P)       += f_P;
+                sys.force_thread(thread_id, D)       += f_D;
+                sys.force_thread(thread_id, S3)      += f_S3;
+                sys.force_thread(thread_id, para.PN) += f_PN;
+                sys.force_thread(thread_id, para.PC) += f_PC;
+
+                sys.virial() += math::tensor_product(rP,       f_P)
+                             +  math::tensor_product(rP + rPD, f_D)
+                             +  math::tensor_product(sys.transpose(rS3, rP), f_S3)
+                             +  math::tensor_product(sys.transpose(rPN, rP), f_PN)
+                             +  math::tensor_product(sys.transpose(rPC, rP), f_PC);
             }
         }
         return energy;

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -187,7 +187,7 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     void postprocess_forces() noexcept
     {
         // sumup virial and zero-clear the thread local virials
-        virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+//         virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0); // allow non-parallelized stuff
         for(std::size_t thread_id=0, max_threads=omp_get_max_threads();
                 thread_id < max_threads; ++thread_id)
         {

--- a/mjolnir/omp/System.hpp
+++ b/mjolnir/omp/System.hpp
@@ -15,6 +15,7 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     using traits_type     = OpenMPSimulatorTraits<realT, boundaryT>;
     using real_type       = typename traits_type::real_type;
     using coordinate_type = typename traits_type::coordinate_type;
+    using matrix33_type   = typename traits_type::matrix33_type;
     using boundary_type   = typename traits_type::boundary_type;
     using topology_type   = Topology;
     using attribute_type  = std::map<std::string, real_type>;
@@ -38,7 +39,11 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
 
     System(const std::size_t num_particles, const boundary_type& bound)
         : velocity_initialized_(false), force_initialized_(false),
-          boundary_(bound), attributes_(), num_particles_(num_particles),
+          boundary_(bound), attributes_(),
+          virial_(0,0,0, 0,0,0, 0,0,0),
+          virial_threads_(omp_get_max_threads(),
+                          matrix33_type(0,0,0, 0,0,0, 0,0,0)),
+          num_particles_(num_particles),
           masses_   (num_particles), rmasses_   (num_particles),
           positions_(num_particles), velocities_(num_particles),
           forces_main_(num_particles),
@@ -88,9 +93,17 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     }
 
     coordinate_type adjust_direction(coordinate_type from, coordinate_type to) const noexcept
-    {return boundary_.adjust_direction(from, to);}
+    {
+        return boundary_.adjust_direction(from, to);
+    }
     coordinate_type  adjust_position(coordinate_type dr) const noexcept
-    {return boundary_.adjust_position(dr);}
+    {
+        return boundary_.adjust_position(dr);
+    }
+    coordinate_type transpose(coordinate_type tgt, const coordinate_type& ref) const noexcept
+    {
+        return boundary_.transpose(tgt, ref);
+    }
 
     std::size_t size() const noexcept {return num_particles_;}
 
@@ -150,13 +163,38 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
         return forces_threads_[thread_num][particle_id];
     }
 
-    // Here, since we already allocate forces_threads_, we don't need anything
-    // in preprocess_forces() function. On the contrary, since all the forces
-    // will be calculated in different cores, we need to merge those
-    // thread-local forces by summing up those for each particle.
-    void preprocess_forces() noexcept { /*do nothing*/ }
+    matrix33_type&       virial()       noexcept {return virial_;}
+    matrix33_type const& virial() const noexcept {return virial_;}
+
+    matrix33_type&       virial_thread(std::size_t thread_num)       noexcept
+    {
+        return virial_threads_[thread_num];
+    }
+    matrix33_type const& virial_thread(std::size_t thread_num) const noexcept
+    {
+        return virial_threads_[thread_num];
+    }
+
+    void preprocess_forces()  noexcept
+    {
+        // Do nothing. We already allocated the thread local forces and virials
+        // with zero values. Also, in the end of each step, postprocess_forces
+        // zero-clears everything.
+    }
+
+    // Since all the forces will be calculated in different cores, we need to
+    // merge those thread-local forces by summing up those for each particle.
     void postprocess_forces() noexcept
     {
+        // sumup virial and zero-clear the thread local virials
+        virial_ = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t thread_id=0, max_threads=omp_get_max_threads();
+                thread_id < max_threads; ++thread_id)
+        {
+            virial_ += virial_threads_[thread_id];
+            virial_threads_[thread_id] = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        }
+
 #pragma omp parallel for
         for(std::size_t i=0; i<this->size(); ++i)
         {
@@ -205,6 +243,9 @@ class System<OpenMPSimulatorTraits<realT, boundaryT>>
     bool           velocity_initialized_, force_initialized_;
     boundary_type  boundary_;
     attribute_type attributes_;
+
+    matrix33_type  virial_;
+    std::vector<matrix33_type, cache_aligned_allocator<matrix33_type>> virial_threads_;
 
     std::size_t                  num_particles_;
     real_container_type          masses_;

--- a/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseBaseInteraction.hpp
@@ -132,8 +132,12 @@ class ThreeSPN2BaseBaseInteraction<
                     if(dU_rep != real_type(0))
                     {
                         // remember that F = -dU.
-                        sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                        sys.force_thread(thread_id, Bj) -= dU_rep * Bij_reg;
+                        const auto F = -dU_rep * Bji_reg;
+                        sys.force_thread(thread_id, Bi) -= F;
+                        sys.force_thread(thread_id, Bj) += F;
+
+                        // Bij = Bi -> Bj = rBj - rBi
+                        sys.virial_thread(thread_id) += math::tensor_product(Bij, F);
                     }
                 }
 
@@ -222,6 +226,11 @@ class ThreeSPN2BaseBaseInteraction<
                     {
                         const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
 
+                        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                         // --------------------------------------------------------
                         // calc dihedral term
                         // -sin(dphi)/2 f(dtheta1) f(dtheta2) U_attr(Bij) dphi/dr
@@ -238,10 +247,10 @@ class ThreeSPN2BaseBaseInteraction<
                             const auto coef_Bi = dot_SBiBj * rlBij_sq;
                             const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                            sys.force_thread(thread_id, Si) += fSi;
-                            sys.force_thread(thread_id, Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                            sys.force_thread(thread_id, Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                            sys.force_thread(thread_id, Sj) += fSj;
+                            f_Si += fSi;
+                            f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                            f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                            f_Sj += fSj;
                         }
 
                         const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -262,9 +271,9 @@ class ThreeSPN2BaseBaseInteraction<
                                              (cos_theta1 * BSi_reg - Bij_reg);
                             const auto fBj = (coef_rsin * rlBij) *
                                              (cos_theta1 * Bij_reg - BSi_reg);
-                            sys.force_thread(thread_id, Si) += fSi;
-                            sys.force_thread(thread_id, Bi) -= (fSi + fBj);
-                            sys.force_thread(thread_id, Bj) += fBj;
+                            f_Si += fSi;
+                            f_Bi -= (fSi + fBj);
+                            f_Bj += fBj;
                         }
                         // --------------------------------------------------------
                         // calc theta2 term
@@ -282,9 +291,9 @@ class ThreeSPN2BaseBaseInteraction<
                                              (cos_theta2 * Bji_reg - BSj_reg);
                             const auto fSj = (coef_rsin * rlSBj) *
                                              (cos_theta2 * BSj_reg - Bji_reg);
-                            sys.force_thread(thread_id, Bi) += fBi;
-                            sys.force_thread(thread_id, Bj) -= (fBi + fSj);
-                            sys.force_thread(thread_id, Sj) += fSj;
+                            f_Bi += fBi;
+                            f_Bj -= (fBi + fSj);
+                            f_Sj += fSj;
                         }
                         // --------------------------------------------------------
                         // calc distance
@@ -293,9 +302,18 @@ class ThreeSPN2BaseBaseInteraction<
                         {
                             // remember that F = -dU. Here `coef` = -dU.
                             const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bi) += coef * Bji_reg;
-                            sys.force_thread(thread_id, Bj) += coef * Bij_reg;
+                            f_Bi += coef * Bji_reg;
+                            f_Bj += coef * Bij_reg;
                         }
+                        sys.force_thread(thread_id, Si) += f_Si;
+                        sys.force_thread(thread_id, Bi) += f_Bi;
+                        sys.force_thread(thread_id, Bj) += f_Bj;
+                        sys.force_thread(thread_id, Sj) += f_Sj;
+
+                        sys.virial_thread(thread_id)  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                         math::tensor_product(                   rBi , f_Bi) +
+                                         math::tensor_product(             rBi + Bij,  f_Bj) +
+                                         math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
                     }
                 }
 
@@ -356,6 +374,13 @@ class ThreeSPN2BaseBaseInteraction<
                 const auto fSi_theta3 = real_type(-1) * fBi_theta3;
                 const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+                auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
                 // adjacent of Base j exists. its not the edge of the strand.
                 if(Bj_next_exists)
                 {
@@ -401,10 +426,10 @@ class ThreeSPN2BaseBaseInteraction<
                         if(df3 != real_type(0))
                         {
                             const auto coef = -df3 * fCS * U_dU_attr.first;
-                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
-                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
-                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
-                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                            f_Si += coef * fSi_theta3;
+                            f_Sj += coef * fSj_theta3;
+                            f_Bi += coef * fBi_theta3;
+                            f_Bj += coef * fBj_theta3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -418,17 +443,17 @@ class ThreeSPN2BaseBaseInteraction<
                             const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                             const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                            sys.force_thread(thread_id, Si)      += fSi;
-                            sys.force_thread(thread_id, Bi)      -= (fSi + fBj5);
-                            sys.force_thread(thread_id, Bj_next) += fBj5;
+                            f_Si      += fSi;
+                            f_Bi      -= (fSi + fBj5);
+                            f_Bj_next += fBj5;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                         if(U_dU_attr.second != real_type(0.0))
                         {
                             const auto coef = -f3 * fCS * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bi)      += coef * Bj5i_reg;
-                            sys.force_thread(thread_id, Bj_next) -= coef * Bj5i_reg;
+                            f_Bi      += coef * Bj5i_reg;
+                            f_Bj_next -= coef * Bj5i_reg;
                         }
                     }
                 }
@@ -475,10 +500,10 @@ class ThreeSPN2BaseBaseInteraction<
                         if(df3 != real_type(0))
                         {
                             const auto coef = -df3 * fCS * U_dU_attr.first;
-                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
-                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
-                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
-                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                            f_Si += coef * fSi_theta3;
+                            f_Sj += coef * fSj_theta3;
+                            f_Bi += coef * fBi_theta3;
+                            f_Bj += coef * fBj_theta3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -491,20 +516,33 @@ class ThreeSPN2BaseBaseInteraction<
 
                             const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                             const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                            sys.force_thread(thread_id, Sj)      += fSj;
-                            sys.force_thread(thread_id, Bj)      -= (fSj + fBi3);
-                            sys.force_thread(thread_id, Bi_next) += fBi3;
+                            f_Sj      += fSj;
+                            f_Bj      -= (fSj + fBi3);
+                            f_Bi_next += fBi3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                         if(U_dU_attr.second != real_type(0.0))
                         {
                             const auto coef = -f3 * fCS * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bj)      += coef * Bi3j_reg;
-                            sys.force_thread(thread_id, Bi_next) -= coef * Bi3j_reg;
+                            f_Bj      += coef * Bi3j_reg;
+                            f_Bi_next -= coef * Bi3j_reg;
                         }
                     }
                 }
+                sys.force_thread(thread_id, Si)      += f_Si     ;
+                sys.force_thread(thread_id, Sj)      += f_Sj     ;
+                sys.force_thread(thread_id, Bi)      += f_Bi     ;
+                sys.force_thread(thread_id, Bj)      += f_Bj     ;
+                sys.force_thread(thread_id, Bi_next) += f_Bi_next;
+                sys.force_thread(thread_id, Bj_next) += f_Bj_next;
+
+                sys.virial_thread(thread_id)  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                 math::tensor_product(                   rBi , f_Bi) +
+                                 math::tensor_product(              rBi + Bij, f_Bj) +
+                                 math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                                 math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                                 math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
             }
         }
         return;
@@ -819,8 +857,11 @@ class ThreeSPN2BaseBaseInteraction<
                     if(dU_rep != real_type(0))
                     {
                         // remember that F = -dU.
-                        sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                        sys.force_thread(thread_id, Bj) -= dU_rep * Bij_reg;
+                        const auto F = dU_rep * Bji_reg;
+                        sys.force_thread(thread_id, Bi) -= F;
+                        sys.force_thread(thread_id, Bj) += F;
+
+                        sys.virial_thread(thread_id) += math::tensor_product(Bij, F); // (Bj - Bi) * Fj
                     }
                 }
 
@@ -907,6 +948,11 @@ class ThreeSPN2BaseBaseInteraction<
 
                     if(cos_dphi != real_type(-1.0))
                     {
+                        auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Sj = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+                        auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
                         const auto U_dU_attr = potential_.U_dU_attr(bp_kind, lBij);
 
                         energy += 0.5 * (1 + cos_dphi) * f1 * f2 * U_dU_attr.first;
@@ -927,10 +973,10 @@ class ThreeSPN2BaseBaseInteraction<
                             const auto coef_Bi = dot_SBiBj * rlBij_sq;
                             const auto coef_Bj = dot_SBjBi * rlBij_sq;
 
-                            sys.force_thread(thread_id, Si) += fSi;
-                            sys.force_thread(thread_id, Bi) += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
-                            sys.force_thread(thread_id, Bj) += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
-                            sys.force_thread(thread_id, Sj) += fSj;
+                            f_Si += fSi;
+                            f_Bi += (coef_Bi - real_type(1.0)) * fSi - coef_Bj * fSj;
+                            f_Bj += (coef_Bj - real_type(1.0)) * fSj - coef_Bi * fSi;
+                            f_Sj += fSj;
                         }
 
                         const auto dihd_term = real_type(0.5) * (real_type(1.0) + cos_dphi);
@@ -951,9 +997,9 @@ class ThreeSPN2BaseBaseInteraction<
                                              (cos_theta1 * BSi_reg - Bij_reg);
                             const auto fBj = (coef_rsin * rlBij) *
                                              (cos_theta1 * Bij_reg - BSi_reg);
-                            sys.force_thread(thread_id, Si) += fSi;
-                            sys.force_thread(thread_id, Bi) -= (fSi + fBj);
-                            sys.force_thread(thread_id, Bj) += fBj;
+                            f_Si += fSi;
+                            f_Bi -= (fSi + fBj);
+                            f_Bj += fBj;
                         }
                         // --------------------------------------------------------
                         // calc theta2 term
@@ -971,9 +1017,9 @@ class ThreeSPN2BaseBaseInteraction<
                                              (cos_theta2 * Bji_reg - BSj_reg);
                             const auto fSj = (coef_rsin * rlSBj) *
                                              (cos_theta2 * BSj_reg - Bji_reg);
-                            sys.force_thread(thread_id, Bi) += fBi;
-                            sys.force_thread(thread_id, Bj) -= (fBi + fSj);
-                            sys.force_thread(thread_id, Sj) += fSj;
+                            f_Bi += fBi;
+                            f_Bj -= (fBi + fSj);
+                            f_Sj += fSj;
                         }
                         // --------------------------------------------------------
                         // calc distance
@@ -982,9 +1028,20 @@ class ThreeSPN2BaseBaseInteraction<
                         {
                             // remember that F = -dU. Here `coef` = -dU.
                             const auto coef = -dihd_term * f1 * f2 * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bi) += coef * Bji_reg;
-                            sys.force_thread(thread_id, Bj) += coef * Bij_reg;
+                            f_Bi += coef * Bji_reg;
+                            f_Bj += coef * Bij_reg;
                         }
+
+                        sys.force_thread(thread_id, Si) += f_Si;
+                        sys.force_thread(thread_id, Bi) += f_Bi;
+                        sys.force_thread(thread_id, Bj) += f_Bj;
+                        sys.force_thread(thread_id, Sj) += f_Sj;
+
+                        sys.virial_thread(thread_id)  += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                                         math::tensor_product(                   rBi , f_Bi) +
+                                         math::tensor_product(              rBi + Bij, f_Bj) +
+                                         math::tensor_product(sys.transpose(rSj, rBi), f_Sj) ;
+
                     }
                 }
 
@@ -1045,6 +1102,13 @@ class ThreeSPN2BaseBaseInteraction<
                 const auto fSi_theta3 = real_type(-1) * fBi_theta3;
                 const auto fSj_theta3 = real_type(-1) * fBj_theta3;
 
+                auto f_Si      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Sj      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bi      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bj      = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bi_next = math::make_coordinate<coordinate_type>(0,0,0);
+                auto f_Bj_next = math::make_coordinate<coordinate_type>(0,0,0);
+
                 // adjacent of Base j exists. its not the edge of the strand.
                 if(Bj_next_exists)
                 {
@@ -1090,10 +1154,10 @@ class ThreeSPN2BaseBaseInteraction<
                         if(df3 != real_type(0))
                         {
                             const auto coef = -df3 * fCS * U_dU_attr.first;
-                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
-                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
-                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
-                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                            f_Si += coef * fSi_theta3;
+                            f_Sj += coef * fSj_theta3;
+                            f_Bi += coef * fBi_theta3;
+                            f_Bj += coef * fBj_theta3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1107,17 +1171,17 @@ class ThreeSPN2BaseBaseInteraction<
                             const auto fSi  =  coef_rsin * rlSBi  * (cos_theta_CS * BSi_reg + Bj5i_reg);
                             const auto fBj5 = -coef_rsin * rlBj5i * (cos_theta_CS * Bj5i_reg + BSi_reg);
 
-                            sys.force_thread(thread_id, Si)      += fSi;
-                            sys.force_thread(thread_id, Bi)      -= (fSi + fBj5);
-                            sys.force_thread(thread_id, Bj_next) += fBj5;
+                            f_Si      += fSi;
+                            f_Bi      -= (fSi + fBj5);
+                            f_Bj_next += fBj5;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                         if(U_dU_attr.second != real_type(0.0))
                         {
                             const auto coef = -f3 * fCS * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bi)      += coef * Bj5i_reg;
-                            sys.force_thread(thread_id, Bj_next) -= coef * Bj5i_reg;
+                            f_Bi      += coef * Bj5i_reg;
+                            f_Bj_next -= coef * Bj5i_reg;
                         }
                     }
                 }
@@ -1164,10 +1228,10 @@ class ThreeSPN2BaseBaseInteraction<
                         if(df3 != real_type(0))
                         {
                             const auto coef = -df3 * fCS * U_dU_attr.first;
-                            sys.force_thread(thread_id, Si) += coef * fSi_theta3;
-                            sys.force_thread(thread_id, Sj) += coef * fSj_theta3;
-                            sys.force_thread(thread_id, Bi) += coef * fBi_theta3;
-                            sys.force_thread(thread_id, Bj) += coef * fBj_theta3;
+                            f_Si += coef * fSi_theta3;
+                            f_Sj += coef * fSj_theta3;
+                            f_Bi += coef * fBi_theta3;
+                            f_Bj += coef * fBj_theta3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) df/dtheta_CS U_attr(eps, alp, rij) dtheta_CS/dr
@@ -1180,20 +1244,34 @@ class ThreeSPN2BaseBaseInteraction<
 
                             const auto fSj  =  coef_rsin * rlSBj  * (cos_theta_CS * BSj_reg + Bi3j_reg);
                             const auto fBi3 = -coef_rsin * rlBi3j * (cos_theta_CS * Bi3j_reg + BSj_reg);
-                            sys.force_thread(thread_id, Sj)      += fSj;
-                            sys.force_thread(thread_id, Bj)      -= (fSj + fBi3);
-                            sys.force_thread(thread_id, Bi_next) += fBi3;
+                            f_Sj      += fSj;
+                            f_Bj      -= (fSj + fBi3);
+                            f_Bi_next += fBi3;
                         }
                         // --------------------------------------------------------
                         // f(theta_3) f(theta_CS)  dU_attr/drij          drij/dr
                         if(U_dU_attr.second != real_type(0.0))
                         {
                             const auto coef = -f3 * fCS * U_dU_attr.second;
-                            sys.force_thread(thread_id, Bj)      += coef * Bi3j_reg;
-                            sys.force_thread(thread_id, Bi_next) -= coef * Bi3j_reg;
+                            f_Bj      += coef * Bi3j_reg;
+                            f_Bi_next -= coef * Bi3j_reg;
                         }
                     }
                 }
+                sys.force_thread(thread_id, Si)      += f_Si     ;
+                sys.force_thread(thread_id, Sj)      += f_Sj     ;
+                sys.force_thread(thread_id, Bi)      += f_Bi     ;
+                sys.force_thread(thread_id, Bj)      += f_Bj     ;
+                sys.force_thread(thread_id, Bi_next) += f_Bi_next;
+                sys.force_thread(thread_id, Bj_next) += f_Bj_next;
+
+                sys.virial_thread(thread_id)
+                    += math::tensor_product(sys.transpose(rSi, rBi), f_Si) +
+                       math::tensor_product(                   rBi , f_Bi) +
+                       math::tensor_product(              rBi + Bij, f_Bj) +
+                       math::tensor_product(sys.transpose(rSj, rBi), f_Sj) +
+                       math::tensor_product(sys.transpose(sys.position(Bi_next), rBi), f_Bi_next) +
+                       math::tensor_product(sys.transpose(sys.position(Bj_next), rBi), f_Bj_next) ;
             }
         }
         return energy;

--- a/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
@@ -125,8 +125,12 @@ class ThreeSPN2BaseStackingInteraction<
             const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
             if(dU_rep != real_type(0.0))
             {
-                sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                sys.force_thread(thread_id, Bj) += dU_rep * Bji_reg;
+                const auto f = dU_rep * Bji_reg;
+                sys.force_thread(thread_id, Bi) -= f;
+                sys.force_thread(thread_id, Bj) += f;
+
+                // Bji = Bj -> Bi = Bi - Bj
+                sys.virial_thread(thread_id) += math::tensor_product(Bji, -f);
             }
 
             // --------------------------------------------------------------------
@@ -166,6 +170,10 @@ class ThreeSPN2BaseStackingInteraction<
             // calc the first term in the attractive part
             // = df(theta) U_attr(rij) dtheta/dr
             //
+            auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
             if(df_theta != real_type(0.0))
             {
                 const auto coef = -df_theta * U_dU_attr.first;
@@ -177,9 +185,9 @@ class ThreeSPN2BaseStackingInteraction<
                 const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
                 const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-                sys.force_thread(thread_id, Si) +=  fSi;
-                sys.force_thread(thread_id, Bi) -= (fSi + fBj);
-                sys.force_thread(thread_id, Bj) +=        fBj;
+                f_Si +=  fSi;
+                f_Bi -= (fSi + fBj);
+                f_Bj +=        fBj;
             }
 
             // --------------------------------------------------------------------
@@ -189,9 +197,16 @@ class ThreeSPN2BaseStackingInteraction<
             if(U_dU_attr.second != real_type(0.0))
             {
                 const auto coef = f_theta * U_dU_attr.second;
-                sys.force_thread(thread_id, Bi) -= coef * Bji_reg;
-                sys.force_thread(thread_id, Bj) += coef * Bji_reg;
+                f_Bi -= coef * Bji_reg;
+                f_Bj += coef * Bji_reg;
             }
+            sys.force_thread(thread_id, Si) += f_Si;
+            sys.force_thread(thread_id, Bi) += f_Bi;
+            sys.force_thread(thread_id, Bj) += f_Bj;
+
+            sys.virial_thread(thread_id) += math::tensor_product(rBi, f_Bi) +
+                                            math::tensor_product(rBi - Bji, f_Bj) +
+                                            math::tensor_product(rBi - SBi, f_Si) ;
         }
         return ;
     }
@@ -309,8 +324,11 @@ class ThreeSPN2BaseStackingInteraction<
             const auto dU_rep = potential_.dU_rep(bs_kind, lBji);
             if(dU_rep != real_type(0.0))
             {
-                sys.force_thread(thread_id, Bi) -= dU_rep * Bji_reg;
-                sys.force_thread(thread_id, Bj) += dU_rep * Bji_reg;
+                const auto f = dU_rep * Bji_reg;
+                sys.force_thread(thread_id, Bi) -= f;
+                sys.force_thread(thread_id, Bj) += f;
+
+                sys.virial_thread(thread_id) += math::tensor_product(Bji, -f);
             }
 
             E += potential_.U_rep(bs_kind, lBji);
@@ -350,6 +368,10 @@ class ThreeSPN2BaseStackingInteraction<
 
             E += U_dU_attr.first * f_theta;
 
+            auto f_Si = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bi = math::make_coordinate<coordinate_type>(0,0,0);
+            auto f_Bj = math::make_coordinate<coordinate_type>(0,0,0);
+
             // --------------------------------------------------------------------
             // calc the first term in the attractive part
             // = df(theta) U_attr(rij) dtheta/dr
@@ -365,9 +387,9 @@ class ThreeSPN2BaseStackingInteraction<
                 const auto fSi = (coef_rsin * rlSBi) * (Bji_reg - cos_theta * SBi_reg);
                 const auto fBj = (coef_rsin * rlBji) * (SBi_reg - cos_theta * Bji_reg);
 
-                sys.force_thread(thread_id, Si) +=  fSi;
-                sys.force_thread(thread_id, Bi) -= (fSi + fBj);
-                sys.force_thread(thread_id, Bj) +=        fBj;
+                f_Si +=  fSi;
+                f_Bi -= (fSi + fBj);
+                f_Bj +=        fBj;
             }
 
             // --------------------------------------------------------------------
@@ -377,9 +399,16 @@ class ThreeSPN2BaseStackingInteraction<
             if(U_dU_attr.second != real_type(0.0))
             {
                 const auto coef = f_theta * U_dU_attr.second;
-                sys.force_thread(thread_id, Bi) -= coef * Bji_reg;
-                sys.force_thread(thread_id, Bj) += coef * Bji_reg;
+                f_Bi -= coef * Bji_reg;
+                f_Bj += coef * Bji_reg;
             }
+            sys.force_thread(thread_id, Si) += f_Si;
+            sys.force_thread(thread_id, Bi) += f_Bi;
+            sys.force_thread(thread_id, Bj) += f_Bj;
+
+            sys.virial_thread(thread_id) += math::tensor_product(rBi, f_Bi) +
+                                            math::tensor_product(rBi - Bji, f_Bj) +
+                                            math::tensor_product(rBi - SBi, f_Si) ;
         }
         return E;
     }

--- a/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
+++ b/mjolnir/omp/ThreeSPN2BaseStackingInteraction.hpp
@@ -129,7 +129,7 @@ class ThreeSPN2BaseStackingInteraction<
                 sys.force_thread(thread_id, Bi) -= f;
                 sys.force_thread(thread_id, Bj) += f;
 
-                // Bji = Bj -> Bi = Bi - Bj
+                // Bji = Bj -> Bi = Bi - Bj ; vir = (Bi - Bj) * f_Bi
                 sys.virial_thread(thread_id) += math::tensor_product(Bji, -f);
             }
 

--- a/mjolnir/omp/omp.hpp
+++ b/mjolnir/omp/omp.hpp
@@ -37,6 +37,7 @@
 #include <mjolnir/omp/UnlimitedGridCellList.hpp>
 #include <mjolnir/omp/PeriodicGridCellList.hpp>
 #include <mjolnir/omp/UnderdampedLangevinIntegrator.hpp>
+#include <mjolnir/omp/GFWNpTLangevinIntegrator.hpp>
 #include <mjolnir/omp/BAOABLangevinIntegrator.hpp>
 #include <mjolnir/omp/gBAOABLangevinIntegrator.hpp>
 #include <mjolnir/omp/GJFNVTLangevinIntegrator.hpp>

--- a/test/core/test_3spn2_base_base_interaction.cpp
+++ b/test/core/test_3spn2_base_base_interaction.cpp
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_numerical_diff,
     using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type         = traits_type::real_type;
     using coord_type        = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type     = traits_type::boundary_type;
     using system_type       = mjolnir::System<traits_type>;
     using topology_type     = mjolnir::Topology;
@@ -306,6 +307,34 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
         } // theta2
         } // theta1
         } // rbp
@@ -322,6 +351,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_numerical_diff,
     using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type         = traits_type::real_type;
     using coord_type        = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type     = traits_type::boundary_type;
     using system_type       = mjolnir::System<traits_type>;
     using topology_type     = mjolnir::Topology;
@@ -788,6 +818,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
         } // thetaCS_j
         } // thetaCS_i
         } // theta3
@@ -1017,6 +1076,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BasePairIntearction_energy_and_force,
                 BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
             }
         } // theta2
         } // theta1
@@ -1420,6 +1483,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force
                 sys.position(idx) += coord_type(0.01 * uni(mt), 0.01 * uni(mt), 0.01 * uni(mt));
                 sys.force(idx)     = coord_type(0.0, 0.0, 0.0);
             }
+            using matrix33_type = typename traits_type::matrix33_type;
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+
             system_type ref_sys = sys;
 
             constexpr real_type tol = 1e-4;
@@ -1434,6 +1500,11 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2CrossStackingIntearction_energy_and_force
                 BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
             }
         } // thetaCS_j
         } // thetaCS_i

--- a/test/core/test_3spn2_base_stacking_interaction.cpp
+++ b/test/core/test_3spn2_base_stacking_interaction.cpp
@@ -29,6 +29,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_numerical_diff,
     using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type        = traits_type::real_type;
     using coord_type       = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type    = traits_type::boundary_type;
     using system_type      = mjolnir::System<traits_type>;
     using interaction_type = mjolnir::ThreeSPN2BaseStackingInteraction<traits_type>;
@@ -308,6 +309,35 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_numerical_diff,
                                boost::test_tools::tolerance(tol));
                 }
             }
+
+            // -----------------------------------------------------------------
+            // check virial
+
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                sys.force(idx) = coord_type(0,0,0);
+            }
+            interaction.calc_force(sys);
+
+            matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+            for(std::size_t idx=0; idx<sys.size(); ++idx)
+            {
+                vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+            }
+
+            BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+            BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+            BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
         } // perturbation
         } // theta
         } // r
@@ -499,6 +529,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_en
             BOOST_TEST(mjolnir::math::Y(sys.force(2)) == 0.0);
             BOOST_TEST(mjolnir::math::Z(sys.force(2)) == 0.0);
 
+            using matrix33_type = typename traits_type::matrix33_type;
+            sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+
             auto ref_sys = sys;
             constexpr real_type tol = 1e-4;
 
@@ -512,6 +545,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(ThreeSPN2BaseStackingInteraction_calc_force_and_en
                 BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                 BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            }
+            for(std::size_t i=0; i<9; ++i)
+            {
+                BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
             }
         } // perturbation
         } // theta

--- a/test/core/test_bond_angle_interaction.cpp
+++ b/test/core/test_bond_angle_interaction.cpp
@@ -279,6 +279,35 @@ BOOST_AUTO_TEST_CASE(BondAngleInteraction_numerical_diff)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 
@@ -342,6 +371,10 @@ BOOST_AUTO_TEST_CASE(BondAngleInteraction_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_bond_length_gocontact_interaction.cpp
+++ b/test/core/test_bond_length_gocontact_interaction.cpp
@@ -196,6 +196,34 @@ BOOST_AUTO_TEST_CASE(BondLengthGoContact_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 
@@ -252,6 +280,10 @@ BOOST_AUTO_TEST_CASE(BondLengthGoContact_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_bond_length_interaction.cpp
+++ b/test/core/test_bond_length_interaction.cpp
@@ -230,6 +230,36 @@ BOOST_AUTO_TEST_CASE(BondLength_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
@@ -286,6 +316,10 @@ BOOST_AUTO_TEST_CASE(BondLength_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_contact_gocontact_interaction.cpp
+++ b/test/core/test_contact_gocontact_interaction.cpp
@@ -205,6 +205,35 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
@@ -263,6 +292,10 @@ BOOST_AUTO_TEST_CASE(ContactGoContact_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_contact_interaction.cpp
+++ b/test/core/test_contact_interaction.cpp
@@ -9,102 +9,226 @@
 #include <mjolnir/core/BoundaryCondition.hpp>
 #include <mjolnir/core/SimulatorTraits.hpp>
 #include <mjolnir/forcefield/local/ContactInteraction.hpp>
-#include <mjolnir/forcefield/local/GoContactPotential.hpp>
+#include <mjolnir/forcefield/local/GaussianPotential.hpp>
 #include <mjolnir/util/make_unique.hpp>
 
-BOOST_AUTO_TEST_CASE(Contact_calc_force)
+BOOST_AUTO_TEST_CASE(Contact_numerical_difference)
 {
-    mjolnir::LoggerManager::set_default_logger("test_contact_calc_force");
+    mjolnir::LoggerManager::set_default_logger("test_contact_interaction.log");
 
     using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type        = traits_type::real_type;
     using coord_type       = traits_type::coordinate_type;
     using boundary_type    = traits_type::boundary_type;
     using system_type      = mjolnir::System<traits_type>;
-    using potential_type   = mjolnir::GoContactPotential<real_type>;
+    using potential_type   = mjolnir::GaussianPotential<real_type>;
     using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
 
-    constexpr real_type tol = 1e-8;
+    const real_type k(1.0);
+    const real_type native(std::sqrt(3.0));
+    const real_type sigma(0.15);
 
-    auto normalize = [](const coord_type& v){return v / mjolnir::math::length(v);};
-
-    const real_type k(100.);
-    const real_type native(2.0);
-
-    potential_type   potential(k, native);
+    potential_type   potential(k, sigma, native);
     interaction_type interaction("none", {{ {{0,1}}, potential}});
 
-    system_type sys(2, boundary_type{});
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
 
-    sys.at(0).mass = 1.0;
-    sys.at(1).mass = 1.0;
-    sys.at(0).rmass = 1.0;
-    sys.at(1).rmass = 1.0;
-
-    sys.at(0).position = coord_type(0,0,0);
-    sys.at(1).position = coord_type(0,0,0);
-    sys.at(0).velocity = coord_type(0,0,0);
-    sys.at(1).velocity = coord_type(0,0,0);
-    sys.at(0).force    = coord_type(0,0,0);
-    sys.at(1).force    = coord_type(0,0,0);
-
-    sys.at(0).name  = "X";
-    sys.at(1).name  = "X";
-    sys.at(0).group = "NONE";
-    sys.at(1).group = "NONE";
-
-    const real_type dr = 1e-3;
-    real_type dist = 1e0;
-    sys[1].position[0] = dist;
-
-    interaction.initialize(sys);
-
-    for(int i = 0; i < 2000; ++i)
+    for(std::size_t i = 0; i < 1000; ++i)
     {
-        sys[0].position = coord_type(0,0,0);
-        sys[1].position = coord_type(0,0,0);
-        sys[0].force    = coord_type(0,0,0);
-        sys[1].force    = coord_type(0,0,0);
-        sys[1].position[0] = dist;
+        system_type sys(2, boundary_type{});
 
-        interaction.reduce_margin(dr, sys);
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
 
-        const real_type deriv = potential.derivative(dist);
-        const real_type coef  = std::abs(deriv);
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
 
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        const auto init = sys;
+
+        constexpr real_type tol = 2e-4;
+        constexpr real_type dr  = 1e-5;
+        for(std::size_t idx=0; idx<2; ++idx)
+        {
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::X(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::X(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Y(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Y(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+            {
+                // ----------------------------------------------------------------
+                // reset positions
+                sys = init;
+                interaction.initialize(sys);
+
+                // calc U(x-dx)
+                const auto E0 = interaction.calc_energy(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc F(x)
+                interaction.calc_force(sys);
+
+                mjolnir::math::Z(sys.position(idx)) += dr;
+
+                // calc U(x+dx)
+                const auto E1 = interaction.calc_energy(sys);
+
+                // central difference
+                const auto dE = (E1 - E0) * 0.5;
+
+                BOOST_TEST(-dE == dr * mjolnir::math::Z(sys.force(idx)),
+                           boost::test_tools::tolerance(tol));
+            }
+        }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
         interaction.calc_force(sys);
 
-        const real_type force_strength1 = mjolnir::math::length(sys.force(0));
-        const real_type force_strength2 = mjolnir::math::length(sys.force(1));
-        BOOST_TEST(coef == force_strength1, boost::test_tools::tolerance(tol));
-        BOOST_TEST(coef == force_strength2, boost::test_tools::tolerance(tol));
-
-        // direction
-        if(dist < native) // repulsive
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
         {
-            const real_type dir1 = mjolnir::math::dot_product(
-                normalize(sys[0].force), normalize(sys[0].position - sys[1].position));
-            const real_type dir2 = mjolnir::math::dot_product(
-                normalize(sys[1].force), normalize(sys[1].position - sys[0].position));
-
-            BOOST_TEST(dir1 == 1.0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1.0, boost::test_tools::tolerance(tol));
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
         }
-        else
-        {
-            const real_type dir1 = mjolnir::math::dot_product(
-                normalize(sys[0].force), normalize(sys[1].position - sys[0].position));
-            const real_type dir2 = mjolnir::math::dot_product(
-                normalize(sys[1].force), normalize(sys[0].position - sys[1].position));
 
-            BOOST_TEST(dir1 == 1e0, boost::test_tools::tolerance(tol));
-            BOOST_TEST(dir2 == 1e0, boost::test_tools::tolerance(tol));
-        }
-        BOOST_TEST(mjolnir::math::length(sys[0].force + sys[1].force) == 0.0,
-                   boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
 
-        dist += dr;
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
+BOOST_AUTO_TEST_CASE(Contact_calc_force_and_energy)
+{
+    mjolnir::LoggerManager::set_default_logger("test_contact_interaction.log");
 
+    using traits_type      = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
+    using real_type        = traits_type::real_type;
+    using coord_type       = traits_type::coordinate_type;
+    using boundary_type    = traits_type::boundary_type;
+    using system_type      = mjolnir::System<traits_type>;
+    using potential_type   = mjolnir::GaussianPotential<real_type>;
+    using interaction_type = mjolnir::ContactInteraction<traits_type, potential_type>;
+
+    const real_type k(1.0);
+    const real_type native(std::sqrt(3.0));
+    const real_type sigma(0.15);
+
+    potential_type   potential(k, sigma, native);
+    interaction_type interaction("none", {{ {{0,1}}, potential}});
+
+    std::mt19937 mt(123456789);
+    std::uniform_real_distribution<real_type> uni(-1.0, 1.0);
+
+    for(std::size_t i = 0; i < 1000; ++i)
+    {
+        system_type sys(2, boundary_type{});
+
+        sys.at(0).mass  = 1.0;
+        sys.at(1).mass  = 1.0;
+        sys.at(0).rmass = 1.0;
+        sys.at(1).rmass = 1.0;
+
+        sys.at(0).position = coord_type( 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt), 0.0 + 0.01 * uni(mt));
+        sys.at(1).position = coord_type( 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt), 1.0 + 0.01 * uni(mt));
+        sys.at(0).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).velocity = coord_type( 0.0, 0.0, 0.0);
+        sys.at(0).force    = coord_type( 0.0, 0.0, 0.0);
+        sys.at(1).force    = coord_type( 0.0, 0.0, 0.0);
+
+        sys.at(0).name  = "X";
+        sys.at(1).name  = "X";
+        sys.at(0).group = "TEST";
+        sys.at(1).group = "TEST";
+
+        constexpr real_type tol = 1e-4;
+        auto ref_sys = sys;
+
+        const auto energy = interaction.calc_force_and_energy(sys);
+        const auto ref_energy = interaction.calc_energy(ref_sys);
+        interaction.calc_force(ref_sys);
+        BOOST_TEST(ref_energy == energy, boost::test_tools::tolerance(tol));
+
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+            BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+    }
+}

--- a/test/core/test_dihedral_angle_interaction.cpp
+++ b/test/core/test_dihedral_angle_interaction.cpp
@@ -279,6 +279,36 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_numerical_diff)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
@@ -350,6 +380,10 @@ BOOST_AUTO_TEST_CASE(DihedralAngleInteraction_calc_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_directional_contact_interaction.cpp
+++ b/test/core/test_directional_contact_interaction.cpp
@@ -224,6 +224,33 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_numerical_diff)
                         }
                     }
                 }
+                // -----------------------------------------------------------------
+                // check virial
+
+                sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    sys.force(idx) = coord_type(0,0,0);
+                }
+                interaction.calc_force(sys);
+
+                matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+                for(std::size_t idx=0; idx<sys.size(); ++idx)
+                {
+                    vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+                }
+
+                BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+                BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+                BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+                BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
             }
         }
     }
@@ -346,6 +373,10 @@ BOOST_AUTO_TEST_CASE(DirectionalContactInteraction_calc_force_and_energy)
                     BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                     BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
                     BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+                }
+                for(std::size_t i=0; i<9; ++i)
+                {
+                    BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
                 }
             }
         }

--- a/test/core/test_global_pair_excluded_volume_interaction.cpp
+++ b/test/core/test_global_pair_excluded_volume_interaction.cpp
@@ -167,6 +167,35 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coordinate_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     }
 }
 
@@ -259,6 +288,10 @@ BOOST_AUTO_TEST_CASE(GlobalPairExcludedVolumeInteraction_numeric_force_and_energ
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_global_pair_interaction.cpp
+++ b/test/core/test_global_pair_interaction.cpp
@@ -282,6 +282,37 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coordinate_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
+
     }
 }
 
@@ -375,6 +406,10 @@ BOOST_AUTO_TEST_CASE(GlobalPairInteraction_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_global_pair_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_lennard_jones_interaction.cpp
@@ -168,6 +168,35 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coordinate_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 
@@ -261,6 +290,10 @@ BOOST_AUTO_TEST_CASE(GlobalPairLennardJonesInteraction_numeric_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
+++ b/test/core/test_global_pair_uniform_lennard_jones_interaction.cpp
@@ -167,6 +167,34 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_limits)
                            boost::test_tools::tolerance(tol));
             }
         }
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coordinate_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
     }
 }
 
@@ -259,6 +287,10 @@ BOOST_AUTO_TEST_CASE(GlobalPairUniformLennardJonesInteraction_numeric_force_and_
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
     }
 }

--- a/test/core/test_multiple_basin_forcefield.cpp
+++ b/test/core/test_multiple_basin_forcefield.cpp
@@ -161,6 +161,37 @@ BOOST_AUTO_TEST_CASE(MultipleBasin_2Basin_numerical_difference)
                            boost::test_tools::tolerance(tol));
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+        using matrix33_type = typename traits_type::matrix33_type;
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        forcefield.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
+
     }
 }
 

--- a/test/core/test_pdns_interaction.cpp
+++ b/test/core/test_pdns_interaction.cpp
@@ -18,6 +18,7 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction)
     using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type         = traits_type::real_type;
     using coord_type        = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type     = traits_type::boundary_type;
     using system_type       = mjolnir::System<traits_type>;
     using topology_type     = mjolnir::Topology;
@@ -255,6 +256,35 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction)
                                    ", -dE/dr = " << -dE/dr);
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     } // theta2
     } // theta1
     } // rbp
@@ -434,7 +464,10 @@ BOOST_AUTO_TEST_CASE(PDNS_Interaction_force_and_energy)
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
         }
-
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     } // theta2
     } // theta1
     } // rbp

--- a/test/core/test_pwmcos_interaction.cpp
+++ b/test/core/test_pwmcos_interaction.cpp
@@ -18,6 +18,7 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction)
     using traits_type       = mjolnir::SimulatorTraits<double, mjolnir::UnlimitedBoundary>;
     using real_type         = traits_type::real_type;
     using coord_type        = traits_type::coordinate_type;
+    using matrix33_type     = traits_type::matrix33_type;
     using boundary_type     = traits_type::boundary_type;
     using system_type       = mjolnir::System<traits_type>;
     using topology_type     = mjolnir::Topology;
@@ -270,6 +271,35 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction)
                                    ", -dE/dr = " << -dE/dr);
             }
         }
+
+        // -----------------------------------------------------------------
+        // check virial
+
+        sys.virial() = matrix33_type(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            sys.force(idx) = coord_type(0,0,0);
+        }
+        interaction.calc_force(sys);
+
+        matrix33_type vir(0,0,0, 0,0,0, 0,0,0);
+        for(std::size_t idx=0; idx<sys.size(); ++idx)
+        {
+            vir += mjolnir::math::tensor_product(sys.position(idx), sys.force(idx));
+        }
+
+        BOOST_TEST(sys.virial()(0,0) == vir(0,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,1) == vir(0,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(0,2) == vir(0,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(1,0) == vir(1,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,1) == vir(1,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(1,2) == vir(1,2), boost::test_tools::tolerance(tol));
+
+        BOOST_TEST(sys.virial()(2,0) == vir(2,0), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,1) == vir(2,1), boost::test_tools::tolerance(tol));
+        BOOST_TEST(sys.virial()(2,2) == vir(2,2), boost::test_tools::tolerance(tol));
+
     } // theta3
     } // theta2
     } // theta1
@@ -464,6 +494,10 @@ BOOST_AUTO_TEST_CASE(PWMcos_Interaction_force_and_energy)
             BOOST_TEST(mjolnir::math::X(sys.force(idx)) == mjolnir::math::X(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Y(sys.force(idx)) == mjolnir::math::Y(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
             BOOST_TEST(mjolnir::math::Z(sys.force(idx)) == mjolnir::math::Z(ref_sys.force(idx)), boost::test_tools::tolerance(tol));
+        }
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == ref_sys.virial()[i], boost::test_tools::tolerance(tol));
         }
 
     } // theta3

--- a/test/omp/test_omp_bond_angle_interaction.cpp
+++ b/test/omp/test_omp_bond_angle_interaction.cpp
@@ -129,6 +129,12 @@ BOOST_AUTO_TEST_CASE(omp_BondAngle)
         // check the energies are the same
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_bond_length_gocontact_interaction.cpp
+++ b/test/omp/test_omp_bond_length_gocontact_interaction.cpp
@@ -122,6 +122,13 @@ BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_bond_length_interaction.cpp
+++ b/test/omp/test_omp_bond_length_interaction.cpp
@@ -119,6 +119,13 @@ BOOST_AUTO_TEST_CASE(omp_BondLength_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_contact_interaction.cpp
+++ b/test/omp/test_omp_contact_interaction.cpp
@@ -121,6 +121,12 @@ BOOST_AUTO_TEST_CASE(omp_Contact_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_dihedral_angle_interaction.cpp
+++ b/test/omp/test_omp_dihedral_angle_interaction.cpp
@@ -127,6 +127,13 @@ BOOST_AUTO_TEST_CASE(omp_DihedralAngle_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_global_debye_huckel_interaction.cpp
+++ b/test/omp/test_omp_global_debye_huckel_interaction.cpp
@@ -140,6 +140,13 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_DebyeHuckel_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_global_excluded_volume_interaction.cpp
+++ b/test/omp/test_omp_global_excluded_volume_interaction.cpp
@@ -136,6 +136,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_lennard_jones_interaction.cpp
@@ -136,6 +136,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_LennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_pdns_interaction.cpp
+++ b/test/omp/test_omp_global_pdns_interaction.cpp
@@ -168,6 +168,12 @@ BOOST_AUTO_TEST_CASE(omp_PDNS_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_pwmcos_interaction.cpp
+++ b/test/omp/test_omp_global_pwmcos_interaction.cpp
@@ -175,6 +175,12 @@ BOOST_AUTO_TEST_CASE(omp_PWMcos_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
+++ b/test/omp/test_omp_global_uniform_lennard_jones_interaction.cpp
@@ -129,6 +129,12 @@ BOOST_AUTO_TEST_CASE(omp_GlobalPair_UniformLennardJones_calc_force)
         }
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 

--- a/test/omp/test_omp_gocontact_interaction.cpp
+++ b/test/omp/test_omp_gocontact_interaction.cpp
@@ -124,6 +124,12 @@ BOOST_AUTO_TEST_CASE(omp_Contact_GoContact_calc_force)
 
         BOOST_TEST(interaction.calc_energy(sys) == seq_interaction.calc_energy(seq_sys),
                    boost::test_tools::tolerance(tol));
+
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys.virial()[i] == seq_sys.virial()[i], boost::test_tools::tolerance(tol));
+        }
     }
 }
 

--- a/test/omp/test_omp_multiple_basin_forcefield.cpp
+++ b/test/omp/test_omp_multiple_basin_forcefield.cpp
@@ -298,6 +298,12 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_2Basin_consistency)
             BOOST_TEST(Z(sys_default.force(j)) == Z(sys_openmp.force(j)),
                        boost::test_tools::tolerance(tol));
         }
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys_default.virial()[i] == sys_openmp.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
     }
 }
 
@@ -593,6 +599,13 @@ BOOST_AUTO_TEST_CASE(omp_MultipleBasin_3Basin_consistency)
             BOOST_TEST(Z(sys_default.force(j)) == Z(sys_openmp.force(j)),
                        boost::test_tools::tolerance(tol));
         }
+        // check the virials are the same
+        for(std::size_t i=0; i<9; ++i)
+        {
+            BOOST_TEST(sys_default.virial()[i] == sys_openmp.virial()[i], boost::test_tools::tolerance(tol));
+        }
+
+
     }
 }
 


### PR DESCRIPTION
Result of [physical_validation.py](https://physical-validation.readthedocs.io/en/latest/userguide.html#)

```
## Reading trajectory files

## Validating ensemble
After equilibration, decorrelation and tail pruning, 5.32% (2659 frames) of original Trajectory 1 remain.
After equilibration, decorrelation and tail pruning, 4.79% (2396 frames) of original Trajectory 2 remain.
Overlap is 84.2% of trajectory 1 and 80.2% of trajectory 2.
Rule of thumb estimates that (dT,dP) = (4.1,57.0) would be optimal (currently, (dT,dP) = (5.0,20.0))
==================================================
Maximum Likelihood Analysis (analytical error)
==================================================
Free energy
    240.18598 +/- 17.48985
Estimated slope                  |  True slope
    0.038548  +/- 0.001842       |  0.040091 
    (0.84 quantiles from true slope)
    -0.943881 +/- 0.174111       |  -0.917443
    (0.15 quantiles from true slope)
Estimated dT                     |  True dT
    4.8    +/- 0.2               |  5.0   
Estimated dP                     |  True dP
    16.0   +/- 2.9               |  15.5  
==================================================
[0.83756495 0.151845  ]
```