### PR TITLE
add gitignore for G-JF Integrator integration test

### DIFF
--- a/test/integration/test_G-JF_Integrator/.gitignore
+++ b/test/integration/test_G-JF_Integrator/.gitignore
@@ -1,0 +1,2 @@
+test_G-JFIntegrator
+data/*


### PR DESCRIPTION
I noticed the other integration tests have a .gitignore file. Thus, I added one for the G-JF Integrator test.