### PR TITLE
update boost url

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ if(BUILD_UNIT_TEST)
             message(STATUS "Boost library not found. Donwloading...")
             message(STATUS "It can take minutes. hang tight!")
 
-            file(DOWNLOAD https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.bz2
+            file(DOWNLOAD https://boostorg.jfrog.io/artifactory/main/release/1.73.0/source/boost_1_73_0.tar.bz2
                 ${PROJECT_SOURCE_DIR}/extlib/boost_1_73_0.tar.bz2
                 EXPECTED_HASH SHA256=4eb3b8d442b426dc35346235c8733b5ae35ba431690e38c6a8263dce9fcbb402
                 STATUS MJOLNIR_DOWNLOAD_BOOST_STATUS)


### PR DESCRIPTION
Recently, boost has changed its URL.  On their webpage, there is a notice indicating:

...
Instead of: https://dl.bintray.com/boostorg/release/ you should use https://boostorg.jfrog.io/artifactory/main/release/ to retrieve boost releases.
...

(https://www.boost.org/users/news/boost_has_moved_downloads_to_jfr.html)

This commit updates the URL in the CMake file.