### PR TITLE
Enable to update dt

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: Ubuntu-18.04
+    runs-on: Ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.29.0
+
+### Added
+
+- enable to restrain χ value in the multiple basin forcefield
+
+## 1.28.1
+
+### Fixed
+
+- Fix instability of the G-JF Integrator introduced in v1.28.0
+
 ## 1.28.0
 
 ### Added

--- a/book/content.en/docs/reference/forcefields/MultipleBasinForceField.md
+++ b/book/content.en/docs/reference/forcefields/MultipleBasinForceField.md
@@ -128,7 +128,7 @@ name = "common"
 # ...
 ```
 
-To restrain {{<katex>}} \chi {{<katex>}}, define `k_chi` and `chi_0`.
+To restrain {{<katex>}} \chi {{</katex>}}, define `k_chi` and `chi_0`.
 
 ```toml
 forcefields.type = "MultipleBasin"

--- a/book/content.ja/docs/reference/forcefields/MultipleBasinForceField.md
+++ b/book/content.ja/docs/reference/forcefields/MultipleBasinForceField.md
@@ -126,7 +126,7 @@ name = "common"
 # ...
 ```
 
-{{<katex>}} \chi {{<katex>}} に拘束力をかけるには、`k_chi`と`chi_0`を設定してください。
+{{<katex>}} \chi {{</katex>}} に拘束力をかけるには、`k_chi`と`chi_0`を設定してください。
 
 ```toml
 forcefields.type = "MultipleBasin"

--- a/mjolnir/core/BAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/BAOABLangevinIntegrator.hpp
@@ -56,8 +56,16 @@ class BAOABLangevinIntegrator
         this->reset_parameters(sys);
         return;
     }
+    void update(const system_type& sys, const real_type newdt)
+    {
+        this->dt_     = newdt;
+        this->halfdt_ = 0.5 * newdt;
+        this->update(sys);
+        return;
+    }
 
     real_type delta_t() const noexcept {return dt_;}
+
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}
 
   private:

--- a/mjolnir/core/GFWNPTLangevinIntegrator.hpp
+++ b/mjolnir/core/GFWNPTLangevinIntegrator.hpp
@@ -133,6 +133,17 @@ class GFWNPTLangevinIntegrator
         this->reset_parameters(sys);
         return ;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->update(sys);
+        return ;
+    }
+
 
     real_type step(const real_type t, system_type& sys,
                    forcefield_type& ff, rng_type& rng)

--- a/mjolnir/core/GJFNVTLangevinIntegrator.hpp
+++ b/mjolnir/core/GJFNVTLangevinIntegrator.hpp
@@ -89,6 +89,14 @@ class GJFNVTLangevinIntegrator
         this->reset_parameters(sys);
         return;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->update(sys);
+        return;
+    }
+
 
     real_type delta_t() const noexcept {return dt_;}
     std::vector<real_type> const& parameters() const noexcept {return alphas_;}

--- a/mjolnir/core/UnderdampedLangevinIntegrator.hpp
+++ b/mjolnir/core/UnderdampedLangevinIntegrator.hpp
@@ -50,10 +50,6 @@ class UnderdampedLangevinIntegrator
                    rng_type& rng);
 
     real_type delta_t() const noexcept {return dt_;}
-    void  set_delta_t(const real_type dt) noexcept
-    {
-        dt_ = dt; halfdt_ = dt / 2; halfdt2_ = dt * dt / 2;
-    }
 
     void update(const system_type& sys)
     {
@@ -85,6 +81,15 @@ class UnderdampedLangevinIntegrator
             param.sqrt_gamma_over_mass = std::sqrt(var.gamma() / var.m());
             params_for_dynvar_[key] = param;
         }
+    }
+
+    void update(const system_type& sys, const real_type dt) noexcept
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->halfdt2_ = dt * dt / 2;
+        this->update(sys);
+        return;
     }
 
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}

--- a/mjolnir/core/VelocityVerletIntegrator.hpp
+++ b/mjolnir/core/VelocityVerletIntegrator.hpp
@@ -37,12 +37,14 @@ class VelocityVerletIntegrator
                    rng_type& rng);
 
     real_type delta_t() const noexcept {return dt_;}
-    void  set_delta_t(const real_type dt) noexcept
-    {
-        dt_ = dt; halfdt_ = dt / 2;
-    }
 
-    void update(const system_type&) const noexcept {/* do nothing */}
+    void update(const system_type&) noexcept {/* do nothing */}
+    void update(const system_type&, const real_type newdt) noexcept
+    {
+        this->dt_     = newdt;
+        this->halfdt_ = newdt * 0.5;
+        return ;
+    }
 
   private:
     real_type dt_;      //!< dt

--- a/mjolnir/core/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/gBAOABLangevinIntegrator.hpp
@@ -56,6 +56,21 @@ class gBAOABLangevinIntegrator
         this->reset_parameter(sys);
         return;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+
+        const auto  tolerance     = constraint_ff.tolerance();
+        this->correction_tolerance_        = tolerance;
+        this->correction_tolerance_dt_     = tolerance / dt_;
+        this->correction_tolerance_dt_itr_ = tolerance * 2. * correction_iter_num_ / dt_;
+        this->dt_in_correction_            = dt_ * 0.5 / correction_iter_num_;
+        this->r_dt_in_correction_          = 1. / dt_in_correction_;
+
+        this->update(sys);
+        return;
+    }
 
     real_type delta_t() const noexcept {return dt_;}
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}

--- a/mjolnir/core/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/core/gBAOABLangevinIntegrator.hpp
@@ -61,7 +61,7 @@ class gBAOABLangevinIntegrator
         this->dt_ = dt;
         this->halfdt_ = dt / 2;
 
-        const auto  tolerance     = constraint_ff.tolerance();
+        const auto tolerance = this->correction_tolerance_;
         this->correction_tolerance_        = tolerance;
         this->correction_tolerance_dt_     = tolerance / dt_;
         this->correction_tolerance_dt_itr_ = tolerance * 2. * correction_iter_num_ / dt_;

--- a/mjolnir/omp/BAOABLangevinIntegrator.hpp
+++ b/mjolnir/omp/BAOABLangevinIntegrator.hpp
@@ -158,6 +158,13 @@ class BAOABLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
         this->reset_parameters(sys);
         return;
     }
+    void update(const system_type& sys, const real_type newdt)
+    {
+        this->dt_     = newdt;
+        this->halfdt_ = 0.5 * newdt;
+        this->update(sys);
+        return;
+    }
 
     real_type delta_t() const noexcept {return dt_;}
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}

--- a/mjolnir/omp/GFWNPTLangevinIntegrator.hpp
+++ b/mjolnir/omp/GFWNPTLangevinIntegrator.hpp
@@ -111,6 +111,16 @@ class GFWNPTLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
         this->reset_parameters(sys);
         return ;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        MJOLNIR_GET_DEFAULT_LOGGER();
+        MJOLNIR_LOG_FUNCTION();
+
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->update(sys);
+        return ;
+    }
 
     real_type step(const real_type t, system_type& sys,
                    forcefield_type& ff, rng_type& rng)

--- a/mjolnir/omp/GJFNVTLangevinIntegrator.hpp
+++ b/mjolnir/omp/GJFNVTLangevinIntegrator.hpp
@@ -160,6 +160,13 @@ class GJFNVTLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
         this->reset_parameters(sys);
         return;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->update(sys);
+        return;
+    }
 
     real_type delta_t() const noexcept {return dt_;}
     std::vector<real_type> const& parameters() const noexcept {return alphas_;}

--- a/mjolnir/omp/UnderdampedLangevinIntegrator.hpp
+++ b/mjolnir/omp/UnderdampedLangevinIntegrator.hpp
@@ -211,6 +211,14 @@ class UnderdampedLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
             params_for_dynvar_[key] = param;
         }
     }
+    void update(const system_type& sys, const real_type dt) noexcept
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+        this->halfdt2_ = dt * dt / 2;
+        this->update(sys);
+        return;
+    }
 
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}
 

--- a/mjolnir/omp/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/omp/gBAOABLangevinIntegrator.hpp
@@ -240,6 +240,20 @@ class gBAOABLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
         this->reset_parameter(sys);
         return;
     }
+    void update(const system_type& sys, const real_type dt)
+    {
+        this->dt_ = dt;
+        this->halfdt_ = dt / 2;
+
+        const auto tolerance = constraint_ff.tolerance();
+        this->correction_tolerance_dt_     = tolerance / dt_;
+        this->correction_tolerance_dt_itr_ = tolerance * 2.0 * correction_iter_num_ / dt_;
+        this->dt_in_correction_            = dt_ * 0.5 / correction_iter_num_;
+        this->r_dt_in_correction_          = 1.0 / dt_in_correction_;
+
+        this->update(sys);
+        return;
+    }
 
     real_type delta_t() const noexcept {return dt_;}
     std::vector<real_type> const& parameters() const noexcept {return gammas_;}

--- a/mjolnir/omp/gBAOABLangevinIntegrator.hpp
+++ b/mjolnir/omp/gBAOABLangevinIntegrator.hpp
@@ -245,7 +245,7 @@ class gBAOABLangevinIntegrator<OpenMPSimulatorTraits<realT, boundaryT>>
         this->dt_ = dt;
         this->halfdt_ = dt / 2;
 
-        const auto tolerance = constraint_ff.tolerance();
+        const auto tolerance = this->correction_tolerance_;
         this->correction_tolerance_dt_     = tolerance / dt_;
         this->correction_tolerance_dt_itr_ = tolerance * 2.0 * correction_iter_num_ / dt_;
         this->dt_in_correction_            = dt_ * 0.5 / correction_iter_num_;


### PR DESCRIPTION
`set_delta_t` does not work when an integrator requries a parameter, like mass of particles. This adds `update(sys, newdt)` to enable integrators to update delta t.