### PR TITLE
Fix read uniform global potential

### DIFF
--- a/mjolnir/forcefield/global/ParameterList.hpp
+++ b/mjolnir/forcefield/global/ParameterList.hpp
@@ -531,7 +531,7 @@ class EmptyCombinationRule final
       : participants_should_be_updated_(false), participants_(participants),
         exclusion_list_(exclusions, std::move(ignore_mol), std::move(ignore_grp))
     {
-        assert(partisipants.size() != 0);
+        assert(participants.size() != 0);
     }
     EmptyCombinationRule(
         const std::map<connection_kind_type, std::size_t>& exclusions,

--- a/mjolnir/forcefield/global/ParameterList.hpp
+++ b/mjolnir/forcefield/global/ParameterList.hpp
@@ -217,6 +217,8 @@ class LorentzBerthelotRule final
         ignore_molecule_type ignore_mol, ignore_group_type ignore_grp)
       : exclusion_list_(exclusions, std::move(ignore_mol), std::move(ignore_grp))
     {
+        assert(parameters.size() != 0);
+
         this->parameters_  .reserve(parameters.size());
         this->participants_.reserve(parameters.size());
         for(const auto& idxp : parameters)
@@ -368,6 +370,8 @@ struct CombinationTable final
       : table_(std::move(table)),
         exclusion_list_(exclusions, std::move(ignore_mol), std::move(ignore_grp))
     {
+        assert(parameters.size() != 0);
+
         this->parameters_  .reserve(parameters.size());
         this->participants_.reserve(parameters.size());
         for(const auto& idxp : parameters)
@@ -526,7 +530,9 @@ class EmptyCombinationRule final
         ignore_molecule_type ignore_mol, ignore_group_type ignore_grp)
       : participants_should_be_updated_(false), participants_(participants),
         exclusion_list_(exclusions, std::move(ignore_mol), std::move(ignore_grp))
-    {}
+    {
+        assert(partisipants.size() != 0);
+    }
     EmptyCombinationRule(
         const std::map<connection_kind_type, std::size_t>& exclusions,
         ignore_molecule_type ignore_mol, ignore_group_type ignore_grp)

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -640,7 +640,7 @@ read_uniform_cubic_pan_potential(const toml::value& global)
         MJOLNIR_LOG_WARN("UniformCubicPanPotential does not have any participants.");
         MJOLNIR_LOG_WARN("All the particles are considered to be participants.");
         MJOLNIR_LOG_WARN("To disable this potential, "
-                             "simply remove the part from the input file.");
+                             "simply remove or comment the part out from the input file.");
 
         return std::make_pair(potential_type(eps, v0, range),
             ParameterList<traitsT, potential_type>(

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -508,7 +508,7 @@ read_uniform_lennard_jones_potential(const toml::value& global)
         MJOLNIR_LOG_WARN("UniformLennardJonesPotential does not have any participants.");
         MJOLNIR_LOG_WARN("All the particles are considered to be participants.");
         MJOLNIR_LOG_WARN("To disable this potential, "
-                             "simply remove the part from the input file.");
+                             "simply remove or comment the part out from the input file.");
 
         return std::make_pair(potential_type(cutoff, sigma, epsilon),
             ParameterList<traitsT, potential_type>(

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -512,6 +512,13 @@ read_uniform_lennard_jones_potential(const toml::value& global)
                 )));
     }
     const auto& ps = toml::find<toml::array>(global, "parameters");
+    if(ps.size() == 0)
+    {
+        throw_exception<std::runtime_error>("[error]"
+            "mjolnir::read_uniform_lennard_jones_potential: "
+            "0 size parameters table found. When you set parameters table, "
+            "you need to set at least one parameter.");
+    }
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
     const auto& env = global.contains("env") ? global.at("env") : toml::value{};
@@ -639,6 +646,13 @@ read_uniform_cubic_pan_potential(const toml::value& global)
                 )));
     }
     const auto& ps = toml::find<toml::array>(global, "parameters");
+    if(ps.size() == 0)
+    {
+        throw_exception<std::runtime_error>("[error]"
+            "mjolnir::read_uniform_cubic_pan_potential: "
+            "0 size parameters table found. When you set parameters table, "
+            "you need to set at least one parameter.");
+    }
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
     const auto& env = global.contains("env") ? global.at("env") : toml::value{};

--- a/mjolnir/input/read_global_potential.hpp
+++ b/mjolnir/input/read_global_potential.hpp
@@ -502,22 +502,20 @@ read_uniform_lennard_jones_potential(const toml::value& global)
     //     # ...
     // ]
 
-    if( ! global.contains("parameters"))
+    const auto& ps = toml::find_or<toml::array>(global, "parameters", {});
+    if(ps.size() == 0)
     {
+        MJOLNIR_LOG_WARN("UniformLennardJonesPotential does not have any participants.");
+        MJOLNIR_LOG_WARN("All the particles are considered to be participants.");
+        MJOLNIR_LOG_WARN("To disable this potential, "
+                             "simply remove the part from the input file.");
+
         return std::make_pair(potential_type(cutoff, sigma, epsilon),
             ParameterList<traitsT, potential_type>(
                 make_unique<parameter_list>(
                     read_ignore_particles_within(global),
                     read_ignored_molecule(global), read_ignored_group(global)
                 )));
-    }
-    const auto& ps = toml::find<toml::array>(global, "parameters");
-    if(ps.size() == 0)
-    {
-        throw_exception<std::runtime_error>("[error]"
-            "mjolnir::read_uniform_lennard_jones_potential: "
-            "0 size parameters table found. When you set parameters table, "
-            "you need to set at least one parameter.");
     }
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 
@@ -636,22 +634,20 @@ read_uniform_cubic_pan_potential(const toml::value& global)
     // # ...
     // ]
 
-    if( ! global.contains("parameters"))
+    const auto& ps = toml::find_or<toml::array>(global, "parameters", {});
+    if(ps.size() == 0)
     {
+        MJOLNIR_LOG_WARN("UniformCubicPanPotential does not have any participants.");
+        MJOLNIR_LOG_WARN("All the particles are considered to be participants.");
+        MJOLNIR_LOG_WARN("To disable this potential, "
+                             "simply remove the part from the input file.");
+
         return std::make_pair(potential_type(eps, v0, range),
             ParameterList<traitsT, potential_type>(
                 make_unique<parameter_list>(
                     read_ignore_particles_within(global),
                     read_ignored_molecule(global), read_ignored_group(global)
                 )));
-    }
-    const auto& ps = toml::find<toml::array>(global, "parameters");
-    if(ps.size() == 0)
-    {
-        throw_exception<std::runtime_error>("[error]"
-            "mjolnir::read_uniform_cubic_pan_potential: "
-            "0 size parameters table found. When you set parameters table, "
-            "you need to set at least one parameter.");
     }
     MJOLNIR_LOG_INFO(ps.size(), " parameters are found");
 

--- a/test/core/test_read_forcefield.cpp
+++ b/test/core/test_read_forcefield.cpp
@@ -59,14 +59,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield)
                 interaction = "Pair"
                 potential   = "ExcludedVolume"
                 epsilon     = 3.14
-                parameters  = []
+                parameters  = [{index = 0, radius = 2.0}]
                 ignore.molecule = "Nothing"
                 ignore.particles_within = {bond = 3, contact = 1}
                 spatial_partition.type = "Naive"
             [[forcefields.global]]
                 interaction = "Pair"
                 potential   = "LennardJones"
-                parameters  = []
+                parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
                 ignore.molecule = "Nothing"
                 ignore.particles_within = {bond = 3, contact = 1}
                 spatial_partition.type = "Naive"

--- a/test/core/test_read_global_forcefield.cpp
+++ b/test/core/test_read_global_forcefield.cpp
@@ -56,7 +56,9 @@ BOOST_AUTO_TEST_CASE(read_global_forcefield)
             ignore.molecule                 = "Nothing"
             ignore.particles_within.bond    = 3
             ignore.particles_within.contact = 1
-            parameters = []
+            parameters = [
+                {index = 0, radius = 2.0}
+            ]
         )"_toml;
 
         const auto ffb = mjolnir::read_forcefield<traits_type>(v, toml::table{});
@@ -99,7 +101,9 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield)
             ignore.molecule                 = "Nothing"
             ignore.particles_within.bond    = 3
             ignore.particles_within.contact = 1
-            parameters = []
+            parameters = [
+                {index = 0, radius = 2.0}
+            ]
             [[forcefields.global]]
             interaction                     = "Pair"
             potential                       = "LennardJones"
@@ -107,7 +111,9 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield)
             ignore.molecule                 = "Nothing"
             ignore.particles_within.bond    = 3
             ignore.particles_within.contact = 1
-            parameters = []
+            parameters = [
+                {index = 0, sigma = 2.0, epsilon = 10.0}
+            ]
         )"_toml;
 
         const auto ffb = mjolnir::read_forcefield<traits_type>(v, toml::table{});

--- a/test/core/test_read_hybrid_forcefield.cpp
+++ b/test/core/test_read_hybrid_forcefield.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(read_hybrid_forcefield)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -58,14 +58,14 @@ BOOST_AUTO_TEST_CASE(read_hybrid_forcefield)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"

--- a/test/core/test_read_multiple_basin_forcefield.cpp
+++ b/test/core/test_read_multiple_basin_forcefield.cpp
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_2basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -185,14 +185,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_2basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -218,14 +218,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_2basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -317,7 +317,7 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_3basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -344,14 +344,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_3basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -390,14 +390,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_3basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_3basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
@@ -456,14 +456,14 @@ BOOST_AUTO_TEST_CASE(read_several_forcefield_3basin)
             interaction = "Pair"
             potential   = "ExcludedVolume"
             epsilon     = 3.14
-            parameters  = []
+            parameters  = [{index = 0, radius = 2.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"
           [[forcefields.global]]
             interaction = "Pair"
             potential   = "LennardJones"
-            parameters  = []
+            parameters  = [{index = 0, sigma = 2.0, epsilon = 10.0}]
             ignore.molecule = "Nothing"
             ignore.particles_within = {bond = 3, contact = 1}
             spatial_partition.type = "Naive"


### PR DESCRIPTION
## Problem
When using UniformLennardJonesPotential or UniformCubicPanPotential, if the parameters table is empty, the leading_participants function of EmptyCombinationRule returns the range in which the begin and end positions are the same. This makes segmentation fault errors in runtime.

## Change
In the no parameters case of these potentials, all particles in the system are considered participants. Based on this, I made the empty parameter case also considered all particles as participants, and raise warnings similar to the previous version of Mjolnir.

I don't know the correct behavior of the empty parameters table case, so if this is not appropriate, I'm sorry about that.